### PR TITLE
Fix: People search doesn't work with email addresses

### DIFF
--- a/src/api/attio-client.ts
+++ b/src/api/attio-client.ts
@@ -1,0 +1,26 @@
+/**
+ * Client for the Attio API
+ */
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+/**
+ * Creates and returns an authenticated Axios instance for Attio API
+ * @returns Axios instance configured for Attio API
+ */
+export function getAttioClient(): AxiosInstance {
+  const apiKey = process.env.ATTIO_API_KEY;
+  
+  if (!apiKey) {
+    throw new Error('ATTIO_API_KEY environment variable is required');
+  }
+  
+  const config: AxiosRequestConfig = {
+    baseURL: 'https://api.attio.com/v2',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  };
+  
+  return axios.create(config);
+}

--- a/src/api/attio-operations.ts
+++ b/src/api/attio-operations.ts
@@ -1,0 +1,329 @@
+import { getAttioClient } from "./attio-client.js";
+import { 
+  AttioRecord, 
+  AttioNote, 
+  ResourceType, 
+  AttioListResponse,
+  AttioSingleResponse,
+  Person,
+  Company,
+  AttioList,
+  AttioListEntry
+} from "../types/attio.js";
+
+/**
+ * Generic function to search any object type by name and other fields
+ * 
+ * @param objectType - The type of object to search (people or companies)
+ * @param query - Search query string
+ * @returns Array of matching records
+ */
+export async function searchObject<T extends AttioRecord>(
+  objectType: ResourceType, 
+  query: string
+): Promise<T[]> {
+  const api = getAttioClient();
+  const path = `/objects/${objectType}/records/query`;
+  
+  try {
+    // Create a search filter that looks in multiple fields
+    const searchFilter = objectType === ResourceType.PEOPLE 
+      ? {
+          "$or": [
+            { name: { "$contains": query } },
+            { email: { "$contains": query } },
+            { phone: { "$contains": query } }
+          ]
+        }
+      : {
+          // For companies or other object types, default to name search
+          name: { "$contains": query }
+        };
+    
+    const response = await api.post<AttioListResponse<T>>(path, {
+      filter: searchFilter
+    });
+    return response.data.data || [];
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      throw new Error(`No ${objectType} found matching '${query}'`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Generic function to list any object type with pagination and sorting
+ * 
+ * @param objectType - The type of object to list (people or companies)
+ * @param limit - Maximum number of results to return
+ * @returns Array of records
+ */
+export async function listObjects<T extends AttioRecord>(
+  objectType: ResourceType, 
+  limit: number = 20
+): Promise<T[]> {
+  const api = getAttioClient();
+  const path = `/objects/${objectType}/records/query`;
+  
+  try {
+    const response = await api.post<AttioListResponse<T>>(path, {
+      limit,
+      sorts: [{ attribute: 'last_interaction', field: 'interacted_at', direction: 'desc' }]
+    });
+    return response.data.data || [];
+  } catch (error: any) {
+    if (error.response?.status === 400) {
+      throw new Error(`Invalid parameters when listing ${objectType}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Generic function to get details for a specific record
+ * 
+ * @param objectType - The type of object to get (people or companies)
+ * @param recordId - ID of the record
+ * @returns Record details
+ */
+export async function getObjectDetails<T extends AttioRecord>(
+  objectType: ResourceType, 
+  recordId: string
+): Promise<T> {
+  const api = getAttioClient();
+  const path = `/objects/${objectType}/records/${recordId}`;
+  
+  try {
+    const response = await api.get<AttioSingleResponse<T>>(path);
+    return response.data.data || response.data;
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      throw new Error(`${objectType.charAt(0).toUpperCase() + objectType.slice(1, -1)} with ID ${recordId} not found`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Generic function to get notes for a specific record
+ * 
+ * @param objectType - The type of parent object (people or companies)
+ * @param recordId - ID of the parent record
+ * @param limit - Maximum number of notes to return
+ * @param offset - Number of notes to skip
+ * @returns Array of notes
+ */
+export async function getObjectNotes(
+  objectType: ResourceType, 
+  recordId: string, 
+  limit: number = 10, 
+  offset: number = 0
+): Promise<AttioNote[]> {
+  const api = getAttioClient();
+  const path = `/notes?limit=${limit}&offset=${offset}&parent_object=${objectType}&parent_record_id=${recordId}`;
+  
+  try {
+    const response = await api.get<AttioListResponse<AttioNote>>(path);
+    return response.data.data || [];
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      throw new Error(`Notes for ${objectType.slice(0, -1)} ${recordId} not found`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Generic function to create a note for any object type
+ * 
+ * @param objectType - The type of parent object (people or companies)
+ * @param recordId - ID of the parent record
+ * @param noteTitle - Title of the note
+ * @param noteText - Content of the note
+ * @returns Created note
+ */
+export async function createObjectNote(
+  objectType: ResourceType, 
+  recordId: string, 
+  noteTitle: string, 
+  noteText: string
+): Promise<AttioNote> {
+  const api = getAttioClient();
+  const path = "/notes";
+  
+  try {
+    const response = await api.post<AttioSingleResponse<AttioNote>>(path, {
+      data: {
+        format: "plaintext",
+        parent_object: objectType,
+        parent_record_id: recordId,
+        title: `[AI] ${noteTitle}`,
+        content: noteText
+      },
+    });
+    return response.data.data || response.data;
+  } catch (error: any) {
+    if (error.response?.status === 400) {
+      throw new Error(`Failed to create note: ${error.response.data.message || 'Invalid parameters'}`);
+    } else if (error.response?.status === 404) {
+      throw new Error(`${objectType.charAt(0).toUpperCase() + objectType.slice(1, -1)} with ID ${recordId} not found`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Gets all lists in the workspace
+ * 
+ * @param objectSlug - Optional object type to filter lists by (e.g., 'companies', 'people')
+ * @param limit - Maximum number of lists to fetch (default: 20)
+ * @returns Array of list objects
+ */
+export async function getAllLists(
+  objectSlug?: string, 
+  limit: number = 20
+): Promise<AttioList[]> {
+  const api = getAttioClient();
+  let path = `/lists?limit=${limit}`;
+  
+  if (objectSlug) {
+    path += `&objectSlug=${objectSlug}`;
+  }
+  
+  try {
+    const response = await api.get<AttioListResponse<AttioList>>(path);
+    return response.data.data || [];
+  } catch (error: any) {
+    if (error.response?.status === 400) {
+      throw new Error('Invalid parameters when fetching lists');
+    }
+    throw error;
+  }
+}
+
+/**
+ * Gets details for a specific list
+ * 
+ * @param listId - The ID of the list
+ * @returns List details
+ */
+export async function getListDetails(
+  listId: string
+): Promise<AttioList> {
+  const api = getAttioClient();
+  const path = `/lists/${listId}`;
+  
+  try {
+    const response = await api.get<AttioSingleResponse<AttioList>>(path);
+    return response.data.data || response.data;
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      throw new Error(`List with ID ${listId} not found`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Gets entries for a specific list
+ * 
+ * @param listId - The ID of the list
+ * @param limit - Maximum number of entries to fetch (default: 20)
+ * @param offset - Number of entries to skip (default: 0)
+ * @returns Array of list entries
+ */
+export async function getListEntries(
+  listId: string, 
+  limit: number = 20, 
+  offset: number = 0
+): Promise<AttioListEntry[]> {
+  const api = getAttioClient();
+  
+  // Try the primary endpoint first
+  try {
+    const path = `/lists/${listId}/entries/query`;
+    const response = await api.post<AttioListResponse<AttioListEntry>>(path, {
+      limit,
+      offset
+    });
+    return response.data.data || [];
+  } catch (primaryError) {
+    // Try fallback endpoints
+    try {
+      const fallbackPath = `/lists-entries/query`;
+      const fallbackResponse = await api.post<AttioListResponse<AttioListEntry>>(fallbackPath, {
+        list_id: listId,
+        limit,
+        offset
+      });
+      return fallbackResponse.data.data || [];
+    } catch (fallbackError) {
+      // Last resort fallback
+      try {
+        const lastPath = `/lists-entries?list_id=${listId}&limit=${limit}&offset=${offset}`;
+        const lastResponse = await api.get<AttioListResponse<AttioListEntry>>(lastPath);
+        return lastResponse.data.data || [];
+      } catch (lastError: any) {
+        if (lastError.response?.status === 404) {
+          throw new Error(`List entries for list ${listId} not found`);
+        }
+        throw lastError;
+      }
+    }
+  }
+}
+
+/**
+ * Adds a record to a list
+ * 
+ * @param listId - The ID of the list
+ * @param recordId - The ID of the record to add
+ * @returns The created list entry
+ */
+export async function addRecordToList(
+  listId: string, 
+  recordId: string
+): Promise<AttioListEntry> {
+  const api = getAttioClient();
+  const path = `/lists/${listId}/entries`;
+  
+  try {
+    const response = await api.post<AttioSingleResponse<AttioListEntry>>(path, {
+      record_id: recordId
+    });
+    return response.data.data || response.data;
+  } catch (error: any) {
+    if (error.response?.status === 400) {
+      throw new Error(`Failed to add record: ${error.response.data.message || 'Invalid parameters'}`);
+    } else if (error.response?.status === 404) {
+      throw new Error(`List with ID ${listId} not found`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Removes a record from a list
+ * 
+ * @param listId - The ID of the list
+ * @param entryId - The ID of the list entry to remove
+ * @returns True if successful
+ */
+export async function removeRecordFromList(
+  listId: string, 
+  entryId: string
+): Promise<boolean> {
+  const api = getAttioClient();
+  const path = `/lists/${listId}/entries/${entryId}`;
+  
+  try {
+    await api.delete(path);
+    return true;
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      throw new Error(`List entry ${entryId} in list ${listId} not found`);
+    }
+    throw error;
+  }
+}

--- a/src/objects/people.ts
+++ b/src/objects/people.ts
@@ -1,0 +1,139 @@
+/**
+ * People-related functionality
+ */
+import { getAttioClient } from "../api/attio-client.js";
+import { 
+  searchObject, 
+  listObjects, 
+  getObjectDetails, 
+  getObjectNotes, 
+  createObjectNote 
+} from "../api/attio-operations.js";
+import { 
+  ResourceType, 
+  Person, 
+  AttioNote 
+} from "../types/attio.js";
+
+/**
+ * Searches for people by name, email, or phone number
+ * 
+ * @param query - Search query string
+ * @returns Array of person results
+ */
+export async function searchPeople(query: string): Promise<Person[]> {
+  // Use the unified operation if available, with fallback to direct implementation
+  try {
+    return await searchObject<Person>(ResourceType.PEOPLE, query);
+  } catch (error) {
+    // Fallback implementation
+    const api = getAttioClient();
+    const path = "/objects/people/records/query";
+    
+    const response = await api.post(path, {
+      filter: {
+        "$or": [
+          { name: { "$contains": query } },
+          { email: { "$contains": query } },
+          { phone: { "$contains": query } }
+        ]
+      }
+    });
+    return response.data.data || [];
+  }
+}
+
+/**
+ * Lists people sorted by most recent interaction
+ * 
+ * @param limit - Maximum number of people to return (default: 20)
+ * @returns Array of person results
+ */
+export async function listPeople(limit: number = 20): Promise<Person[]> {
+  // Use the unified operation if available, with fallback to direct implementation
+  try {
+    return await listObjects<Person>(ResourceType.PEOPLE, limit);
+  } catch (error) {
+    // Fallback implementation
+    const api = getAttioClient();
+    const path = "/objects/people/records/query";
+    
+    const response = await api.post(path, {
+      limit,
+      sorts: [{ attribute: 'last_interaction', field: 'interacted_at', direction: 'desc' }]
+    });
+    return response.data.data || [];
+  }
+}
+
+/**
+ * Gets details for a specific person
+ * 
+ * @param personId - The ID of the person
+ * @returns Person details
+ */
+export async function getPersonDetails(personId: string): Promise<Person> {
+  // Use the unified operation if available, with fallback to direct implementation
+  try {
+    return await getObjectDetails<Person>(ResourceType.PEOPLE, personId);
+  } catch (error) {
+    // Fallback implementation
+    const api = getAttioClient();
+    const path = `/objects/people/records/${personId}`;
+    
+    const response = await api.get(path);
+    return response.data;
+  }
+}
+
+/**
+ * Gets notes for a specific person
+ * 
+ * @param personId - The ID of the person
+ * @param limit - Maximum number of notes to fetch (default: 10)
+ * @param offset - Number of notes to skip (default: 0)
+ * @returns Array of notes
+ */
+export async function getPersonNotes(personId: string, limit: number = 10, offset: number = 0): Promise<AttioNote[]> {
+  // Use the unified operation if available, with fallback to direct implementation
+  try {
+    return await getObjectNotes(ResourceType.PEOPLE, personId, limit, offset);
+  } catch (error) {
+    // Fallback implementation
+    const api = getAttioClient();
+    const path = `/notes?limit=${limit}&offset=${offset}&parent_object=people&parent_record_id=${personId}`;
+    
+    const response = await api.get(path);
+    return response.data.data || [];
+  }
+}
+
+/**
+ * Creates a note for a specific person
+ * 
+ * @param personId - The ID of the person
+ * @param title - The title of the note
+ * @param content - The content of the note
+ * @returns The created note
+ */
+export async function createPersonNote(personId: string, title: string, content: string): Promise<AttioNote> {
+  // Use the unified operation if available, with fallback to direct implementation
+  try {
+    return await createObjectNote(ResourceType.PEOPLE, personId, title, content);
+  } catch (error) {
+    // Fallback implementation
+    const api = getAttioClient();
+    const path = 'notes';
+    
+    const response = await api.post(path, {
+      data: {
+        format: "plaintext",
+        parent_object: "people",
+        parent_record_id: personId,
+        title: `[AI] ${title}`,
+        content
+      },
+    });
+    return response.data;
+  }
+}

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -1,0 +1,80 @@
+/**
+ * Type definitions for Attio API responses and data models
+ */
+
+export enum ResourceType {
+  PEOPLE = 'people',
+  COMPANIES = 'companies',
+  LISTS = 'lists'
+}
+
+// Base interfaces
+export interface AttioRecord {
+  id: {
+    record_id: string;
+  };
+  values: Record<string, any>;
+}
+
+export interface AttioNote {
+  id: {
+    note_id: string;
+  };
+  title: string;
+  content: string;
+  format: 'plaintext' | 'markdown';
+  parent_object: string;
+  parent_record_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AttioList {
+  id: {
+    list_id: string;
+  };
+  name: string;
+  description?: string;
+  object: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AttioListEntry {
+  id: {
+    entry_id: string;
+  };
+  list_id: string;
+  record_id: string;
+  created_at: string;
+}
+
+// Response interfaces
+export interface AttioListResponse<T> {
+  data?: T[];
+  has_more?: boolean;
+  next_cursor?: string;
+}
+
+export interface AttioSingleResponse<T> {
+  data?: T;
+}
+
+// Specific record types
+export interface Person extends AttioRecord {
+  values: {
+    name?: Array<{value: string}>;
+    email?: Array<{value: string}>;
+    phone?: Array<{value: string}>;
+    [key: string]: any;
+  };
+}
+
+export interface Company extends AttioRecord {
+  values: {
+    name?: Array<{value: string}>;
+    website?: Array<{value: string}>;
+    industry?: Array<{value: string}>;
+    [key: string]: any;
+  };
+}

--- a/test/api/attio-operations.test.ts
+++ b/test/api/attio-operations.test.ts
@@ -1,0 +1,144 @@
+import { 
+  searchObject, 
+  listObjects, 
+  getObjectDetails,
+  getObjectNotes,
+  createObjectNote
+} from '../../src/api/attio-operations.js';
+import * as attioClient from '../../src/api/attio-client.js';
+import { ResourceType } from '../../src/types/attio.js';
+
+// Mock dependencies
+jest.mock('../../src/api/attio-client.js');
+
+describe('attio-operations', () => {
+  // Mock data
+  const mockPeopleData = [
+    {
+      id: { record_id: 'person1' },
+      values: { 
+        name: [{ value: 'John Doe' }],
+        email: [{ value: 'john@example.com' }],
+        phone: [{ value: '+1234567890' }]
+      }
+    },
+    {
+      id: { record_id: 'person2' },
+      values: { 
+        name: [{ value: 'Jane Smith' }],
+        email: [{ value: 'jane@example.com' }],
+        phone: [{ value: '+0987654321' }]
+      }
+    }
+  ];
+
+  const mockCompaniesData = [
+    {
+      id: { record_id: 'company1' },
+      values: { name: [{ value: 'Acme Corp' }] }
+    },
+    {
+      id: { record_id: 'company2' },
+      values: { name: [{ value: 'Globex Inc' }] }
+    }
+  ];
+
+  let mockAxiosInstance: any;
+  const mockedAttioClient = attioClient as jest.Mocked<typeof attioClient>;
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.resetAllMocks();
+    
+    // Setup mock API client
+    mockAxiosInstance = {
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+    };
+    mockedAttioClient.getAttioClient.mockReturnValue(mockAxiosInstance);
+  });
+
+  describe('searchObject', () => {
+    it('should search people across multiple fields when object type is people', async () => {
+      // Arrange
+      const query = 'john';
+      const mockResponse = {
+        data: {
+          data: [mockPeopleData[0]]
+        }
+      };
+      mockAxiosInstance.post.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await searchObject(ResourceType.PEOPLE, query);
+
+      // Assert
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/objects/people/records/query',
+        expect.objectContaining({
+          filter: {
+            "$or": [
+              { name: { "$contains": query } },
+              { email: { "$contains": query } },
+              { phone: { "$contains": query } }
+            ]
+          }
+        })
+      );
+      expect(result).toEqual([mockPeopleData[0]]);
+    });
+
+    it('should search companies by name only when object type is companies', async () => {
+      // Arrange
+      const query = 'acme';
+      const mockResponse = {
+        data: {
+          data: [mockCompaniesData[0]]
+        }
+      };
+      mockAxiosInstance.post.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await searchObject(ResourceType.COMPANIES, query);
+
+      // Assert
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/objects/companies/records/query',
+        expect.objectContaining({
+          filter: {
+            name: { "$contains": query }
+          }
+        })
+      );
+      expect(result).toEqual([mockCompaniesData[0]]);
+    });
+
+    it('should handle 404 errors correctly', async () => {
+      // Arrange
+      const query = 'nonexistent';
+      mockAxiosInstance.post.mockRejectedValueOnce({
+        response: {
+          status: 404
+        }
+      });
+
+      // Act & Assert
+      await expect(searchObject(ResourceType.PEOPLE, query))
+        .rejects.toThrow(`No people found matching '${query}'`);
+    });
+
+    it('should pass through other errors', async () => {
+      // Arrange
+      const query = 'test';
+      mockAxiosInstance.post.mockRejectedValueOnce(new Error('Network error'));
+
+      // Act & Assert
+      await expect(searchObject(ResourceType.PEOPLE, query))
+        .rejects.toThrow('Network error');
+    });
+  });
+
+  // Tests for other operations could be added here...
+});

--- a/test/objects/people.test.ts
+++ b/test/objects/people.test.ts
@@ -1,0 +1,337 @@
+import { searchPeople, listPeople, getPersonDetails, getPersonNotes, createPersonNote } from '../../src/objects/people.js';
+import * as attioClient from '../../src/api/attio-client.js';
+import * as attioOperations from '../../src/api/attio-operations.js';
+import { ResourceType } from '../../src/types/attio.js';
+
+// Mock dependencies
+jest.mock('../../src/api/attio-client.js');
+jest.mock('../../src/api/attio-operations.js');
+
+describe('people', () => {
+  // Mock data
+  const mockPeopleData = [
+    {
+      id: { record_id: 'person1' },
+      values: { name: [{ value: 'John Doe' }] }
+    },
+    {
+      id: { record_id: 'person2' },
+      values: { name: [{ value: 'Jane Smith' }] }
+    }
+  ];
+
+  const mockPersonDetails = {
+    id: { record_id: 'person1' },
+    values: {
+      name: [{ value: 'John Doe' }],
+      email: [{ value: 'john@example.com' }],
+      phone: [{ value: '+1234567890' }]
+    }
+  };
+
+  const mockNotes = [
+    { 
+      id: { note_id: 'note1' }, 
+      title: 'First meeting', 
+      content: 'Met with John',
+      format: 'plaintext',
+      parent_object: 'people',
+      parent_record_id: 'person1',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z'
+    },
+    { 
+      id: { note_id: 'note2' }, 
+      title: 'Follow-up', 
+      content: 'Discussed next steps',
+      format: 'plaintext',
+      parent_object: 'people',
+      parent_record_id: 'person1',
+      created_at: '2025-01-02T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z'
+    }
+  ];
+
+  const mockCreatedNote = {
+    id: { note_id: 'note3' },
+    title: '[AI] Meeting summary',
+    content: 'Discussed project details',
+    format: 'plaintext',
+    parent_object: 'people',
+    parent_record_id: 'person1',
+    created_at: '2025-01-03T00:00:00Z',
+    updated_at: '2025-01-03T00:00:00Z'
+  };
+
+  let mockAxiosInstance: any;
+  const mockedAttioClient = attioClient as jest.Mocked<typeof attioClient>;
+  const mockedAttioOperations = attioOperations as jest.Mocked<typeof attioOperations>;
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.resetAllMocks();
+    
+    // Setup mock API client
+    mockAxiosInstance = {
+      get: jest.fn(),
+      post: jest.fn(),
+    };
+    mockedAttioClient.getAttioClient.mockReturnValue(mockAxiosInstance);
+  });
+
+  describe('searchPeople', () => {
+    it('should search people by name using operations module if available', async () => {
+      // Arrange
+      const query = 'John';
+      mockedAttioOperations.searchObject.mockResolvedValueOnce(mockPeopleData);
+
+      // Act
+      const result = await searchPeople(query);
+
+      // Assert
+      expect(mockedAttioOperations.searchObject).toHaveBeenCalledWith(ResourceType.PEOPLE, query);
+      expect(result).toEqual(mockPeopleData);
+    });
+
+    it('should search people by name using direct API if operations fail', async () => {
+      // Arrange
+      const query = 'John';
+      mockedAttioOperations.searchObject.mockRejectedValueOnce(new Error('Not available'));
+      
+      const mockResponse = {
+        data: {
+          data: mockPeopleData
+        }
+      };
+      mockAxiosInstance.post.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await searchPeople(query);
+
+      // Assert
+      expect(mockedAttioOperations.searchObject).toHaveBeenCalledWith(ResourceType.PEOPLE, query);
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/objects/people/records/query',
+        expect.objectContaining({
+          filter: {
+            "$or": [
+              { name: { "$contains": query } },
+              { email: { "$contains": query } },
+              { phone: { "$contains": query } }
+            ]
+          }
+        })
+      );
+      expect(result).toEqual(mockPeopleData);
+    });
+    
+    it('should search people by email using direct API if operations fail', async () => {
+      // Arrange
+      const query = 'example.com';
+      mockedAttioOperations.searchObject.mockRejectedValueOnce(new Error('Not available'));
+      
+      const mockResponse = {
+        data: {
+          data: mockPeopleData
+        }
+      };
+      mockAxiosInstance.post.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await searchPeople(query);
+
+      // Assert
+      expect(mockedAttioOperations.searchObject).toHaveBeenCalledWith(ResourceType.PEOPLE, query);
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/objects/people/records/query',
+        expect.objectContaining({
+          filter: {
+            "$or": [
+              { name: { "$contains": query } },
+              { email: { "$contains": query } },
+              { phone: { "$contains": query } }
+            ]
+          }
+        })
+      );
+      expect(result).toEqual(mockPeopleData);
+    });
+
+    it('should throw error when both approaches fail', async () => {
+      // Arrange
+      const query = 'John';
+      mockedAttioOperations.searchObject.mockRejectedValueOnce(new Error('Not available'));
+      mockAxiosInstance.post.mockRejectedValueOnce(new Error('API Error'));
+
+      // Act & Assert
+      await expect(searchPeople(query)).rejects.toThrow('API Error');
+    });
+  });
+
+  describe('listPeople', () => {
+    it('should list people using operations module if available', async () => {
+      // Arrange
+      const limit = 10;
+      mockedAttioOperations.listObjects.mockResolvedValueOnce(mockPeopleData);
+
+      // Act
+      const result = await listPeople(limit);
+
+      // Assert
+      expect(mockedAttioOperations.listObjects).toHaveBeenCalledWith(ResourceType.PEOPLE, limit);
+      expect(result).toEqual(mockPeopleData);
+    });
+
+    it('should list people using direct API if operations fail', async () => {
+      // Arrange
+      const limit = 10;
+      mockedAttioOperations.listObjects.mockRejectedValueOnce(new Error('Not available'));
+      
+      const mockResponse = {
+        data: {
+          data: mockPeopleData
+        }
+      };
+      mockAxiosInstance.post.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await listPeople(limit);
+
+      // Assert
+      expect(mockedAttioOperations.listObjects).toHaveBeenCalledWith(ResourceType.PEOPLE, limit);
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/objects/people/records/query',
+        expect.objectContaining({
+          limit,
+          sorts: [{ attribute: 'last_interaction', field: 'interacted_at', direction: 'desc' }]
+        })
+      );
+      expect(result).toEqual(mockPeopleData);
+    });
+  });
+
+  describe('getPersonDetails', () => {
+    it('should get person details using operations module if available', async () => {
+      // Arrange
+      const personId = 'person1';
+      mockedAttioOperations.getObjectDetails.mockResolvedValueOnce(mockPersonDetails);
+
+      // Act
+      const result = await getPersonDetails(personId);
+
+      // Assert
+      expect(mockedAttioOperations.getObjectDetails).toHaveBeenCalledWith(ResourceType.PEOPLE, personId);
+      expect(result).toEqual(mockPersonDetails);
+    });
+
+    it('should get person details using direct API if operations fail', async () => {
+      // Arrange
+      const personId = 'person1';
+      mockedAttioOperations.getObjectDetails.mockRejectedValueOnce(new Error('Not available'));
+      
+      const mockResponse = {
+        data: mockPersonDetails
+      };
+      mockAxiosInstance.get.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await getPersonDetails(personId);
+
+      // Assert
+      expect(mockedAttioOperations.getObjectDetails).toHaveBeenCalledWith(ResourceType.PEOPLE, personId);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/objects/people/records/${personId}`);
+      expect(result).toEqual(mockPersonDetails);
+    });
+  });
+
+  describe('getPersonNotes', () => {
+    it('should get notes for a person using operations module if available', async () => {
+      // Arrange
+      const personId = 'person1';
+      const limit = 10;
+      const offset = 0;
+      mockedAttioOperations.getObjectNotes.mockResolvedValueOnce(mockNotes);
+
+      // Act
+      const result = await getPersonNotes(personId, limit, offset);
+
+      // Assert
+      expect(mockedAttioOperations.getObjectNotes).toHaveBeenCalledWith(ResourceType.PEOPLE, personId, limit, offset);
+      expect(result).toEqual(mockNotes);
+    });
+
+    it('should get notes for a person using direct API if operations fail', async () => {
+      // Arrange
+      const personId = 'person1';
+      const limit = 10;
+      const offset = 0;
+      mockedAttioOperations.getObjectNotes.mockRejectedValueOnce(new Error('Not available'));
+      
+      const mockResponse = {
+        data: {
+          data: mockNotes
+        }
+      };
+      mockAxiosInstance.get.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await getPersonNotes(personId, limit, offset);
+
+      // Assert
+      expect(mockedAttioOperations.getObjectNotes).toHaveBeenCalledWith(ResourceType.PEOPLE, personId, limit, offset);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        `/notes?limit=${limit}&offset=${offset}&parent_object=people&parent_record_id=${personId}`
+      );
+      expect(result).toEqual(mockNotes);
+    });
+  });
+
+  describe('createPersonNote', () => {
+    it('should create a note for a person using operations module if available', async () => {
+      // Arrange
+      const personId = 'person1';
+      const title = 'Meeting summary';
+      const content = 'Discussed project details';
+      mockedAttioOperations.createObjectNote.mockResolvedValueOnce(mockCreatedNote);
+
+      // Act
+      const result = await createPersonNote(personId, title, content);
+
+      // Assert
+      expect(mockedAttioOperations.createObjectNote).toHaveBeenCalledWith(ResourceType.PEOPLE, personId, title, content);
+      expect(result).toEqual(mockCreatedNote);
+    });
+
+    it('should create a note for a person using direct API if operations fail', async () => {
+      // Arrange
+      const personId = 'person1';
+      const title = 'Meeting summary';
+      const content = 'Discussed project details';
+      mockedAttioOperations.createObjectNote.mockRejectedValueOnce(new Error('Not available'));
+      
+      const mockResponse = {
+        data: mockCreatedNote
+      };
+      mockAxiosInstance.post.mockResolvedValueOnce(mockResponse);
+
+      // Act
+      const result = await createPersonNote(personId, title, content);
+
+      // Assert
+      expect(mockedAttioOperations.createObjectNote).toHaveBeenCalledWith(ResourceType.PEOPLE, personId, title, content);
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        'notes',
+        {
+          data: {
+            format: "plaintext",
+            parent_object: "people",
+            parent_record_id: personId,
+            title: `[AI] ${title}`,
+            content
+          }
+        }
+      );
+      expect(result).toEqual(mockCreatedNote);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Enhanced search functionality to include email addresses and phone numbers
- Previously search only worked with name fields, causing users to be unable to find contacts by email
- Modified both the main implementation and fallback code paths to ensure consistent behavior
- Added comprehensive tests for both components

## Test plan
- Run unit tests with `npm test`
- Run type checking with `npm run check`
- Verify search with name, email, and phone number

Fixes #2