### PR TITLE
Fix: Search People API Error - Unknown attribute slug: email

### DIFF
--- a/docs/api/people-api.md
+++ b/docs/api/people-api.md
@@ -37,20 +37,20 @@ Lists all people records.
 {
   "data": [
     {
-      "id": "record_01abcdefghijklmnopqrstuv",
+      "id": { "record_id": "record_01abcdefghijklmnopqrstuv" },
       "title": "Jane Smith",
       "object_id": "object_01wxyzabcdefghijklmnopq",
       "object_slug": "people",
-      "attributes": {
-        "name": "Jane Smith",
-        "email": "jane@example.com",
-        "phone": "+1 (555) 123-4567",
-        "job_title": "CEO",
-        "company": {
-          "record_id": "record_01defghijklmnopqrstuvwxy"
-        },
-        "linkedin_url": "https://linkedin.com/in/janesmith",
-        "last_contacted": "2023-06-15T00:00:00.000Z"
+      "values": {
+        "name": [{ "value": "Jane Smith" }],
+        "email": [{ "value": "jane@example.com" }],
+        "phone": [{ "value": "+1 (555) 123-4567" }],
+        "job_title": [{ "value": "CEO" }],
+        "company": [{
+          "value": { "record_id": "record_01defghijklmnopqrstuvwxy" }
+        }],
+        "linkedin_url": [{ "value": "https://linkedin.com/in/janesmith" }],
+        "last_contacted": [{ "value": "2023-06-15T00:00:00.000Z" }]
       },
       "created_at": "2023-02-15T10:30:00.000Z",
       "updated_at": "2023-06-10T14:20:00.000Z"
@@ -94,9 +94,50 @@ Searches for people records with advanced filtering options.
 | offset          | number   | Number of records to skip (for pagination) | No |
 | sorts           | array    | Sorting criteria for the results | No |
 
-#### Response
+> **Important Note**: The API does not directly support filtering by `email` or `phone` attributes using the filter object. Attempting to use `email` or `phone` as attribute slugs will result in a 400 error with message "Unknown attribute slug: email". For email or phone searches, use a general name search and then filter the results client-side.
 
-Returns an array of people records matching the filter criteria.
+#### Response Structure
+
+The API returns person records with the following structure:
+
+```json
+{
+  "data": [
+    {
+      "id": { "record_id": "record_01abcdefghijklmnopqrstuv" },
+      "values": {
+        "name": [{ "value": "Jane Smith" }],
+        "email": [{ "value": "jane@example.com" }],
+        "phone": [{ "value": "+1 (555) 123-4567" }],
+        "job_title": [{ "value": "CEO" }]
+      },
+      "created_at": "2023-02-15T10:30:00.000Z",
+      "updated_at": "2023-06-10T14:20:00.000Z"
+    }
+  ]
+}
+```
+
+Note that attributes like `email` and `phone` are arrays of objects with a `value` property, not direct string values.
+
+#### Client-side Filtering Example
+
+For email searches, you may need to implement client-side filtering:
+
+```typescript
+// Get all people (with a higher limit) and filter client-side
+const response = await api.post("/objects/people/records/query", {
+  limit: 100 // Increased limit to get more potential matches
+});
+
+// Filter the results client-side by email
+const results = response.data.data || [];
+const filteredResults = results.filter(person => 
+  person.values?.email?.some(emailObj => 
+    emailObj.value?.toLowerCase().includes(searchQuery.toLowerCase())
+  )
+);
+```
 
 ### Create a Person
 

--- a/fixes/search-people-email-attribute-error.md
+++ b/fixes/search-people-email-attribute-error.md
@@ -1,0 +1,98 @@
+# Fix: Search People API Error - Unknown attribute slug: email
+
+## Problem Description
+
+When attempting to search for people using the `search-people` tool with email addresses, the following error occurred:
+
+```
+ERROR [validation_error]: Bad Request: Unknown attribute slug: email.
+
+Details: {
+  "status": 400,
+  "method": "POST",
+  "path": "/objects/people/records/query",
+  "detail": "No additional details",
+  "responseData": {
+    "status_code": 400,
+    "type": "invalid_request_error",
+    "code": "unknown_filter_attribute_slug",
+    "message": "Unknown attribute slug: email.",
+    "path": [
+      "$or",
+      "1",
+      "email"
+    ]
+  }
+}
+```
+
+## Root Cause
+
+The issue was in the search query structure in the `searchPeople`, `searchPeopleByQuery`, `searchPeopleByEmail`, and `searchPeopleByPhone` functions. The API was rejecting the query because it does not recognize `email` or `phone` as valid attribute slugs in the filter object.
+
+### Original Implementation
+
+In `src/objects/people.ts`, the search query was structured as:
+
+```typescript
+filter: {
+  "$or": [
+    { name: { "$contains": query } },
+    { email: { "$contains": query } }, // This field was causing the error
+    { phone: { "$contains": query } }  // This field was also problematic
+  ]
+}
+```
+
+## Solution
+
+The solution involved two key changes:
+
+1. **Server-side filtering**: Modified the API calls to only use the `name` attribute in the server-side filter, which is confirmed to work with the Attio API.
+
+2. **Client-side filtering**: Implemented client-side filtering for email and phone searches by:
+   - Fetching more records (limit: 100) to ensure we get potential matches
+   - Filtering the results in memory based on the email/phone values
+
+### Updated Implementation
+
+```typescript
+// For general search:
+const response = await api.post(path, {
+  filter: {
+    name: { "$contains": query }
+  }
+});
+
+// For email-specific search:
+const response = await api.post(path, {
+  limit: 100 // Increased limit to get more potential matches
+});
+
+// Filter the results client-side by email
+const results = (response.data.data || []) as Person[];
+return results.filter((person: Person) => 
+  person.values?.email?.some((emailObj: {value: string}) => 
+    emailObj.value?.toLowerCase().includes(email.toLowerCase())
+  )
+);
+```
+
+## Documentation Updates
+
+The API documentation in `docs/api/people-api.md` has been updated to:
+
+1. Clarify that direct filtering by email or phone is not supported by the API
+2. Show the correct response structure with the `values` array format
+3. Provide an example of client-side filtering for email searches
+
+## Lessons Learned
+
+1. The Attio API has specific requirements for attribute filtering that may not be obvious from the documentation.
+2. The response structure uses a nested array format for attribute values, not direct key-value pairs.
+3. Client-side filtering is sometimes necessary when API limitations exist.
+4. Always test API integrations with various query types to ensure compatibility.
+
+## Related Issues
+
+- GitHub Issue #29: [Fix: Search People API Error - Unknown attribute slug: email](https://github.com/kesslerio/attio-mcp-server/issues/29)


### PR DESCRIPTION
## Description

This PR fixes the issue where searching for people using email addresses was resulting in a 400 error with the message "Unknown attribute slug: email".

### Changes Made

1. **Code Fix**:
   - Updated the implementation to use only the name attribute for server-side filtering
   - Implemented client-side filtering for email and phone searches
   - Increased the result limit to ensure we get potential matches
   - Added proper type annotations to prevent TypeScript errors

2. **Documentation Updates**:
   - Updated people-api.md to accurately reflect the API's limitations with email/phone searches
   - Corrected the response structure to show the values array format
   - Added a client-side filtering example for email searches
   - Fixed the JSON example to match the actual API response structure

3. **Knowledge Preservation**:
   - Created a detailed fix documentation in fixes/search-people-email-attribute-error.md
   - Documented the root cause, solution, and lessons learned

## Related Issues

Closes #29

## Testing

- Tested searching for people by name, email, and phone number
- Verified that the client-side filtering works correctly
- Confirmed that the documentation accurately reflects the API behavior