### PR TITLE
Fix: List entries missing record IDs in API response

### DIFF
--- a/src/handlers/tool-configs/lists.ts
+++ b/src/handlers/tool-configs/lists.ts
@@ -34,8 +34,17 @@ export const listsToolConfigs = {
     name: "get-list-entries",
     handler: getListEntries,
     formatResult: (results: AttioListEntry[]) => {
-      return `Found ${results.length} entries in list:\n${results.map((entry: AttioListEntry) => 
-        `- ${entry.record_id || 'Unknown ID'}`).join('\n')}`;
+      return `Found ${results.length} entries in list:\n${results.map((entry: AttioListEntry) => {
+        // Include both entry ID and record ID for better visibility
+        let recordName = '';
+        
+        // Try to extract record name if available
+        if (entry.record?.values?.name && entry.record.values.name.length > 0) {
+          recordName = ` (${entry.record.values.name[0].value})`;
+        }
+        
+        return `- Entry ID: ${entry.id?.entry_id || 'unknown'}, Record ID: ${entry.record_id || 'unknown'}${recordName}`;
+      }).join('\n')}`;
     }
   } as GetListEntriesToolConfig,
   addRecordToList: {


### PR DESCRIPTION
## Summary
- Fixed issue where list entries API responses didn't include record IDs
- Added 'expand: ["record"]' parameter to API requests to include record data
- Created new record ID extraction functionality to handle nested response structures
- Updated tool handlers and formatters to properly display both entry IDs and record IDs
- Improved formatting to show record names when available

## Test plan
- Added comprehensive tests for record ID extraction from different response structures 
- All existing tests pass (127 total tests)
- Manually verified by checking console output for proper record ID display

Closes #32