### PR TITLE
Fix: Implement searchByEmail and searchByPhone tool handlers

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -133,6 +133,60 @@ export function registerToolHandlers(server: Server): void {
         }
       }
       
+      // Handle searchByEmail tools
+      if (toolType === 'searchByEmail') {
+        const email = request.params.arguments?.email as string;
+        try {
+          const searchToolConfig = toolConfig as SearchToolConfig;
+          const results = await searchToolConfig.handler(email);
+          const formattedResults = searchToolConfig.formatResult(results);
+          
+          return {
+            content: [
+              {
+                type: "text",
+                text: formattedResults,
+              },
+            ],
+            isError: false,
+          };
+        } catch (error) {
+          return createErrorResult(
+            error instanceof Error ? error : new Error("Unknown error"),
+            `/objects/${resourceType}/records/query`,
+            "POST",
+            (error as any).response?.data || {}
+          );
+        }
+      }
+      
+      // Handle searchByPhone tools
+      if (toolType === 'searchByPhone') {
+        const phone = request.params.arguments?.phone as string;
+        try {
+          const searchToolConfig = toolConfig as SearchToolConfig;
+          const results = await searchToolConfig.handler(phone);
+          const formattedResults = searchToolConfig.formatResult(results);
+          
+          return {
+            content: [
+              {
+                type: "text",
+                text: formattedResults,
+              },
+            ],
+            isError: false,
+          };
+        } catch (error) {
+          return createErrorResult(
+            error instanceof Error ? error : new Error("Unknown error"),
+            `/objects/${resourceType}/records/query`,
+            "POST",
+            (error as any).response?.data || {}
+          );
+        }
+      }
+      
       // Handle details tools
       if (toolType === 'details') {
         let id: string;


### PR DESCRIPTION
## Summary
- Fixed issue with search-people-by-email tool returning 'Tool handler not implemented for tool type: searchByEmail'
- Added missing tool handlers for searchByEmail and searchByPhone tool types in tools.ts
- Ensures that searching for people by email and phone number works correctly

## Test Plan
- Tested search-people-by-email with email parameter
- Verified that the tool now returns proper search results instead of error