### PR TITLE
Feature: Add advanced filtering capabilities for People and Companies

### DIFF
--- a/docs/api/advanced-filtering.md
+++ b/docs/api/advanced-filtering.md
@@ -1,6 +1,6 @@
 # Advanced Filtering in Attio MCP
 
-The Attio MCP server provides enhanced filtering capabilities that extend beyond the standard Attio API. This document outlines the advanced filtering features available for People, Companies, and Lists objects.
+The Attio MCP server provides enhanced filtering capabilities that extend beyond the standard Attio API. This document outlines the advanced filtering features available for People, Companies, and Lists objects, which are now implemented as part of the advanced filtering suite (Issue #57).
 
 ## Overview
 

--- a/docs/api/advanced-filtering.md
+++ b/docs/api/advanced-filtering.md
@@ -1,0 +1,268 @@
+# Advanced Filtering in Attio MCP
+
+The Attio MCP server provides enhanced filtering capabilities that extend beyond the standard Attio API. This document outlines the advanced filtering features available for People, Companies, and Lists objects.
+
+## Overview
+
+Advanced filtering enables you to:
+
+1. Create complex filter conditions with multiple criteria
+2. Combine conditions using logical operators (AND/OR)
+3. Apply various comparison operators to different attribute types
+4. Filter by any available attribute, including special handling for email and phone
+
+## Supported Resources
+
+- **People**: Enhanced searching with client-side support for email/phone
+- **Companies**: Advanced filtering by name, website, industry, and other attributes
+- **Lists**: Comprehensive filtering for list entries
+
+## Filter Structure
+
+Advanced filters follow a consistent structure across all resources:
+
+```typescript
+interface ListEntryFilters {
+  filters?: ListEntryFilter[];      // Array of individual filter conditions
+  matchAny?: boolean;               // When true, uses OR logic between conditions; when false/omitted, uses AND logic
+  filterGroups?: Array<{            // Optional groups for nested conditions
+    filters: ListEntryFilter[];
+    matchAny?: boolean;
+  }>;
+}
+
+interface ListEntryFilter {
+  attribute: {
+    slug: string;                   // Attribute name to filter on
+  };
+  condition: string;                // Condition operator from FilterConditionType
+  value: any;                       // Value to compare against
+  logicalOperator?: 'and' | 'or';   // Optional operator to combine with next filter
+}
+```
+
+## Filter Conditions
+
+All resources support the same set of filter conditions:
+
+| Condition | Description | Applicable Data Types |
+|-----------|-------------|------------------------|
+| equals | Exact match | All types |
+| not_equals | Not an exact match | All types |
+| contains | Contains the given string | Text, Email, URL |
+| not_contains | Does not contain the given string | Text, Email, URL |
+| starts_with | Starts with the given string | Text, Email, URL |
+| ends_with | Ends with the given string | Text, Email, URL |
+| greater_than | Greater than the given value | Number, Currency, Date |
+| less_than | Less than the given value | Number, Currency, Date |
+| greater_than_or_equals | Greater than or equal to value | Number, Currency, Date |
+| less_than_or_equals | Less than or equal to value | Number, Currency, Date |
+| is_empty | Value is empty | All types |
+| is_not_empty | Value is not empty | All types |
+| is_set | Attribute has a value | All types |
+| is_not_set | Attribute does not have a value | All types |
+
+## People Filtering
+
+### Special Considerations for Email and Phone
+
+The Attio API has limitations with filtering directly by email or phone attributes. The MCP server provides enhanced capabilities to overcome these limitations by implementing client-side filtering when necessary.
+
+When filtering People records by email or phone:
+
+1. If the filter includes only standard attributes (name, job_title, etc.), server-side filtering is used
+2. If the filter includes email or phone attributes, the MCP server:
+   - Removes those filters from the API request
+   - Fetches a larger result set using the remaining filters
+   - Applies email/phone filtering client-side
+   - Returns the filtered results
+
+### Example: Filtering People
+
+```typescript
+// Basic filter by name
+const nameFilter = createNameFilter("John Smith", FilterConditionType.EQUALS);
+const people = await advancedSearchPeople(nameFilter);
+
+// Filter by email domain (handled client-side)
+const emailFilter = createEmailFilter("gmail.com", FilterConditionType.CONTAINS);
+const gmailUsers = await advancedSearchPeople(emailFilter);
+
+// Combined filter with AND logic
+const filter = {
+  filters: [
+    {
+      attribute: { slug: 'name' },
+      condition: FilterConditionType.CONTAINS,
+      value: "Smith"
+    },
+    {
+      attribute: { slug: 'job_title' },
+      condition: FilterConditionType.EQUALS,
+      value: "CEO"
+    }
+  ]
+};
+const results = await advancedSearchPeople(filter);
+```
+
+### Helper Functions for People Filtering
+
+```typescript
+// Create a name filter
+const nameFilter = createNameFilter("John", FilterConditionType.CONTAINS);
+
+// Create an email filter
+const emailFilter = createEmailFilter("john@example.com", FilterConditionType.EQUALS);
+
+// Create a phone filter
+const phoneFilter = createPhoneFilter("+1234", FilterConditionType.STARTS_WITH);
+```
+
+## Companies Filtering
+
+Company filtering supports all standard attributes including name, website, industry, etc.
+
+### Example: Filtering Companies
+
+```typescript
+// Basic filter by company name
+const nameFilter = createNameFilter("Acme", FilterConditionType.CONTAINS);
+const companies = await advancedSearchCompanies(nameFilter);
+
+// Filter by website domain
+const websiteFilter = createWebsiteFilter("acme.com", FilterConditionType.EQUALS);
+const acmeCompanies = await advancedSearchCompanies(websiteFilter);
+
+// Filter by industry with OR logic
+const filter = {
+  filters: [
+    {
+      attribute: { slug: 'industry' },
+      condition: FilterConditionType.EQUALS,
+      value: "Technology"
+    },
+    {
+      attribute: { slug: 'industry' },
+      condition: FilterConditionType.EQUALS,
+      value: "Software"
+    }
+  ],
+  matchAny: true // OR logic
+};
+const techCompanies = await advancedSearchCompanies(filter);
+```
+
+### Helper Functions for Companies Filtering
+
+```typescript
+// Create a name filter
+const nameFilter = createNameFilter("Acme", FilterConditionType.CONTAINS);
+
+// Create a website filter
+const websiteFilter = createWebsiteFilter("acme.com", FilterConditionType.EQUALS);
+
+// Create an industry filter
+const industryFilter = createIndustryFilter("Technology", FilterConditionType.EQUALS);
+```
+
+## Using with MCP Tools
+
+For Claude interactions, advanced filtering is available through the following MCP tools:
+
+### People Filtering
+
+```
+Use the advanced-search-people tool with filters:
+- name contains "Smith"
+- job_title equals "CEO"
+```
+
+### Companies Filtering
+
+```
+Use the advanced-search-companies tool with filters:
+- industry equals "Technology" OR
+- annual_revenue greater_than 10000000
+```
+
+## Performance Considerations
+
+1. **Email/Phone Filtering**:
+   - Client-side filtering for email and phone may impact performance for large result sets
+   - When using email or phone filters, the system fetches up to 100 records by default
+
+2. **Combined Filters**:
+   - Using more specific filters first can improve performance
+   - Combine server-side filters (name, job_title, etc.) with client-side filters (email, phone) when possible
+
+## Advanced Filter Examples
+
+### Complex AND/OR Logic
+
+```typescript
+// Companies in Technology industry with revenue > $10M OR
+// Companies in Healthcare industry with > 100 employees
+const complexFilter = {
+  filterGroups: [
+    {
+      filters: [
+        {
+          attribute: { slug: 'industry' },
+          condition: FilterConditionType.EQUALS,
+          value: "Technology"
+        },
+        {
+          attribute: { slug: 'annual_revenue' },
+          condition: FilterConditionType.GREATER_THAN,
+          value: 10000000
+        }
+      ],
+      matchAny: false // AND logic within this group
+    },
+    {
+      filters: [
+        {
+          attribute: { slug: 'industry' },
+          condition: FilterConditionType.EQUALS,
+          value: "Healthcare"
+        },
+        {
+          attribute: { slug: 'employee_count' },
+          condition: FilterConditionType.GREATER_THAN,
+          value: 100
+        }
+      ],
+      matchAny: false // AND logic within this group
+    }
+  ],
+  matchAny: true // OR logic between groups
+};
+```
+
+### Date Range Filtering
+
+```typescript
+// People created in 2023
+const dateRangeFilter = {
+  filters: [
+    {
+      attribute: { slug: 'created_at' },
+      condition: FilterConditionType.GREATER_THAN_OR_EQUALS,
+      value: "2023-01-01T00:00:00Z"
+    },
+    {
+      attribute: { slug: 'created_at' },
+      condition: FilterConditionType.LESS_THAN,
+      value: "2024-01-01T00:00:00Z"
+    }
+  ]
+};
+```
+
+## Related Documentation
+
+- [People API](./people-api.md) - For managing person records
+- [Companies API](./companies-api.md) - For managing company records
+- [Lists API](./lists-api.md) - For managing lists and list entries
+- [Objects API](./objects-api.md) - For understanding object schemas

--- a/docs/api/companies-api.md
+++ b/docs/api/companies-api.md
@@ -6,6 +6,17 @@ The Companies API allows you to manage company records in Attio. Companies are a
 
 Claude can help you interact with company records in Attio through the MCP server. Here are some common tasks and example prompts:
 
+### Advanced Filtering Capabilities
+
+The MCP server now provides enhanced filtering capabilities for company records through the `advanced-search-companies` tool. This feature supports:
+
+- Complex filtering with multiple conditions
+- Logical operators (AND/OR)
+- All comparison operators (equals, contains, starts_with, etc.)
+- Filtering by any company attribute including name, website, and industry
+
+See the [Advanced Filtering documentation](./advanced-filtering.md) for detailed information about these capabilities.
+
 ### Searching for Companies
 
 You can ask Claude to search for companies using various criteria:

--- a/docs/api/lists-api.md
+++ b/docs/api/lists-api.md
@@ -72,6 +72,8 @@ The advanced-filter-list-entries tool supports:
 - Logical operators to create complex filter expressions
 - matchAny parameter to switch between AND/OR logic between all filters
 
+For comprehensive documentation on advanced filtering capabilities, including examples and best practices, see the [Advanced Filtering documentation](./advanced-filtering.md). This advanced filtering approach is now available for Lists, People, and Companies.
+
 #### Complex Filter Examples
 
 Here are some examples of advanced filter scenarios:

--- a/docs/api/people-api.md
+++ b/docs/api/people-api.md
@@ -8,6 +8,17 @@ The People API allows you to manage person records in Attio. Person records repr
 
 When searching for people by email or phone through the MCP server, Claude handles this differently than direct API calls. While the Attio API doesn't support direct filtering by `email` or `phone` attributes, the MCP server implements a client-side search to overcome this limitation.
 
+### Advanced Filtering Capabilities
+
+The MCP server now provides enhanced filtering capabilities for people records through the `advanced-search-people` tool. This feature supports:
+
+- Complex filtering with multiple conditions
+- Logical operators (AND/OR)
+- All comparison operators (equals, contains, starts_with, etc.)
+- Special handling for email and phone attributes with client-side filtering
+
+See the [Advanced Filtering documentation](./advanced-filtering.md) for detailed information about these capabilities.
+
 ### Example Claude Interactions
 
 #### Searching for People

--- a/src/handlers/tool-configs/companies.ts
+++ b/src/handlers/tool-configs/companies.ts
@@ -6,9 +6,16 @@ import {
   searchCompanies, 
   getCompanyDetails, 
   getCompanyNotes, 
-  createCompanyNote 
+  createCompanyNote,
+  advancedSearchCompanies
 } from "../../objects/companies.js";
-import { SearchToolConfig, DetailsToolConfig, NotesToolConfig, CreateNoteToolConfig } from "../tool-types.js";
+import { 
+  SearchToolConfig, 
+  DetailsToolConfig, 
+  NotesToolConfig, 
+  CreateNoteToolConfig,
+  AdvancedSearchToolConfig
+} from "../tool-types.js";
 
 // Company tool configurations
 export const companyToolConfigs = {
@@ -20,6 +27,14 @@ export const companyToolConfigs = {
         `- ${company.values?.name?.[0]?.value || 'Unnamed'} (ID: ${company.id?.record_id || 'unknown'})`).join('\n')}`;
     }
   } as SearchToolConfig,
+  advancedSearch: {
+    name: "advanced-search-companies",
+    handler: advancedSearchCompanies,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} companies with specified filters:\n${results.map((company: any) => 
+        `- ${company.values?.name?.[0]?.value || 'Unnamed'} (ID: ${company.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as AdvancedSearchToolConfig,
   details: {
     name: "get-company-details",
     handler: getCompanyDetails,
@@ -49,6 +64,63 @@ export const companyToolDefinitions = [
         }
       },
       required: ["query"]
+    }
+  },
+  {
+    name: "advanced-search-companies",
+    description: "Search for companies using advanced filtering capabilities",
+    inputSchema: {
+      type: "object",
+      properties: {
+        filters: {
+          type: "object",
+          description: "Complex filter object for advanced searching",
+          properties: {
+            filters: {
+              type: "array",
+              description: "Array of filter conditions",
+              items: {
+                type: "object",
+                properties: {
+                  attribute: {
+                    type: "object",
+                    properties: {
+                      slug: {
+                        type: "string",
+                        description: "Attribute to filter on (e.g., 'name', 'website', 'industry')"
+                      }
+                    },
+                    required: ["slug"]
+                  },
+                  condition: {
+                    type: "string",
+                    description: "Condition to apply (e.g., 'equals', 'contains', 'starts_with')"
+                  },
+                  value: {
+                    type: ["string", "number", "boolean"],
+                    description: "Value to filter by"
+                  }
+                },
+                required: ["attribute", "condition", "value"]
+              }
+            },
+            matchAny: {
+              type: "boolean",
+              description: "When true, matches any filter (OR logic). When false, matches all filters (AND logic)"
+            }
+          },
+          required: ["filters"]
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["filters"]
     }
   },
   {

--- a/src/handlers/tool-configs/people.ts
+++ b/src/handlers/tool-configs/people.ts
@@ -8,9 +8,16 @@ import {
   searchPeopleByPhone,
   getPersonDetails,
   getPersonNotes,
-  createPersonNote
+  createPersonNote,
+  advancedSearchPeople
 } from "../../objects/people.js";
-import { SearchToolConfig, DetailsToolConfig, NotesToolConfig, CreateNoteToolConfig } from "../tool-types.js";
+import { 
+  SearchToolConfig, 
+  DetailsToolConfig, 
+  NotesToolConfig, 
+  CreateNoteToolConfig,
+  AdvancedSearchToolConfig
+} from "../tool-types.js";
 
 // People tool configurations
 export const peopleToolConfigs = {
@@ -38,6 +45,14 @@ export const peopleToolConfigs = {
         `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
     }
   } as SearchToolConfig,
+  advancedSearch: {
+    name: "advanced-search-people",
+    handler: advancedSearchPeople,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} people with specified filters:\n${results.map((person: any) => 
+        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as AdvancedSearchToolConfig,
   details: {
     name: "get-person-details",
     handler: getPersonDetails,
@@ -95,6 +110,63 @@ export const peopleToolDefinitions = [
         }
       },
       required: ["phone"]
+    }
+  },
+  {
+    name: "advanced-search-people",
+    description: "Search for people using advanced filtering capabilities",
+    inputSchema: {
+      type: "object",
+      properties: {
+        filters: {
+          type: "object",
+          description: "Complex filter object for advanced searching",
+          properties: {
+            filters: {
+              type: "array",
+              description: "Array of filter conditions",
+              items: {
+                type: "object",
+                properties: {
+                  attribute: {
+                    type: "object",
+                    properties: {
+                      slug: {
+                        type: "string",
+                        description: "Attribute to filter on (e.g., 'name', 'email', 'phone')"
+                      }
+                    },
+                    required: ["slug"]
+                  },
+                  condition: {
+                    type: "string",
+                    description: "Condition to apply (e.g., 'equals', 'contains', 'starts_with')"
+                  },
+                  value: {
+                    type: ["string", "number", "boolean"],
+                    description: "Value to filter by"
+                  }
+                },
+                required: ["attribute", "condition", "value"]
+              }
+            },
+            matchAny: {
+              type: "boolean",
+              description: "When true, matches any filter (OR logic). When false, matches all filters (AND logic)"
+            }
+          },
+          required: ["filters"]
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["filters"]
     }
   },
   {

--- a/src/handlers/tool-types.ts
+++ b/src/handlers/tool-types.ts
@@ -3,6 +3,7 @@
  */
 import { Request, Response } from "express";
 import { AttioRecord, AttioNote, AttioList, AttioListEntry } from "../types/attio.js";
+import { ListEntryFilters } from "../api/attio-operations.js";
 
 // Base tool configuration interface
 export interface ToolConfig {
@@ -14,6 +15,12 @@ export interface ToolConfig {
 // Search tool configuration
 export interface SearchToolConfig extends ToolConfig {
   handler: (query: string) => Promise<AttioRecord[]>;
+  formatResult: (results: AttioRecord[]) => string;
+}
+
+// Advanced search tool configuration
+export interface AdvancedSearchToolConfig extends ToolConfig {
+  handler: (filters: ListEntryFilters, limit?: number, offset?: number) => Promise<AttioRecord[]>;
   formatResult: (results: AttioRecord[]) => string;
 }
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -26,6 +26,7 @@ import {
 import { 
   ToolConfig,
   SearchToolConfig,
+  AdvancedSearchToolConfig,
   DetailsToolConfig,
   NotesToolConfig,
   CreateNoteToolConfig,
@@ -916,6 +917,54 @@ export function registerToolHandlers(server: Server): void {
             error instanceof Error ? error : new Error("Unknown error"),
             `objects/${objectSlug}/records/batch`,
             "PATCH",
+            (error as any).response?.data || {}
+          );
+        }
+      }
+      
+      // Handle advanced search tools
+      if (toolType === 'advancedSearch') {
+        const filters = request.params.arguments?.filters as any;
+        
+        // Convert parameters to the correct type
+        let limit: number | undefined;
+        let offset: number | undefined;
+        
+        if (request.params.arguments?.limit !== undefined && request.params.arguments?.limit !== null) {
+          limit = Number(request.params.arguments.limit);
+        }
+        
+        if (request.params.arguments?.offset !== undefined && request.params.arguments?.offset !== null) {
+          offset = Number(request.params.arguments.offset);
+        }
+        
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`[advancedSearch ${resourceType}] Processing request with parameters:`, {
+            filters: JSON.stringify(filters),
+            limit,
+            offset
+          });
+        }
+        
+        try {
+          const advancedSearchToolConfig = toolConfig as AdvancedSearchToolConfig;
+          const results = await advancedSearchToolConfig.handler(filters, limit, offset);
+          const formattedResults = advancedSearchToolConfig.formatResult(results);
+          
+          return {
+            content: [
+              {
+                type: "text",
+                text: formattedResults,
+              },
+            ],
+            isError: false,
+          };
+        } catch (error) {
+          return createErrorResult(
+            error instanceof Error ? error : new Error("Unknown error"),
+            `/objects/${resourceType}/records/query`,
+            "POST",
             (error as any).response?.data || {}
           );
         }

--- a/src/objects/companies.ts
+++ b/src/objects/companies.ts
@@ -3,7 +3,8 @@
  */
 import { getAttioClient } from "../api/attio-client.js";
 import { 
-  searchObject, 
+  searchObject,
+  advancedSearchObject,
   listObjects, 
   getObjectDetails, 
   getObjectNotes, 
@@ -11,12 +12,15 @@ import {
   batchSearchObjects,
   batchGetObjectDetails,
   BatchConfig,
-  BatchResponse
+  BatchResponse,
+  ListEntryFilters,
+  ListEntryFilter
 } from "../api/attio-operations.js";
 import { 
   ResourceType, 
   Company, 
-  AttioNote 
+  AttioNote,
+  FilterConditionType
 } from "../types/attio.js";
 
 /**
@@ -573,4 +577,101 @@ export async function batchGetCompanyDetails(
     
     return results;
   }
+}
+
+/**
+ * Search for companies using advanced filtering capabilities
+ * 
+ * @param filters - Filter conditions to apply
+ * @param limit - Maximum number of results to return (default: 20)
+ * @param offset - Number of results to skip (default: 0)
+ * @returns Array of matching company records
+ */
+export async function advancedSearchCompanies(
+  filters: ListEntryFilters,
+  limit?: number,
+  offset?: number
+): Promise<Company[]> {
+  try {
+    return await advancedSearchObject<Company>(
+      ResourceType.COMPANIES,
+      filters,
+      limit,
+      offset
+    );
+  } catch (error) {
+    // Handle specific API limitations for website/industry filtering if needed
+    if (error instanceof Error) {
+      throw error;
+    }
+    
+    // If we reach here, it's an unexpected error
+    throw new Error(`Failed to search companies with advanced filters: ${String(error)}`);
+  }
+}
+
+/**
+ * Helper function to create filters for searching companies by name
+ * 
+ * @param name - Name to search for
+ * @param condition - Condition type (default: CONTAINS)
+ * @returns ListEntryFilters object configured for name search
+ */
+export function createNameFilter(
+  name: string, 
+  condition: FilterConditionType = FilterConditionType.CONTAINS
+): ListEntryFilters {
+  return {
+    filters: [
+      {
+        attribute: { slug: 'name' },
+        condition: condition,
+        value: name
+      }
+    ]
+  };
+}
+
+/**
+ * Helper function to create filters for searching companies by website
+ * 
+ * @param website - Website to search for
+ * @param condition - Condition type (default: CONTAINS)
+ * @returns ListEntryFilters object configured for website search
+ */
+export function createWebsiteFilter(
+  website: string, 
+  condition: FilterConditionType = FilterConditionType.CONTAINS
+): ListEntryFilters {
+  return {
+    filters: [
+      {
+        attribute: { slug: 'website' },
+        condition: condition,
+        value: website
+      }
+    ]
+  };
+}
+
+/**
+ * Helper function to create filters for searching companies by industry
+ * 
+ * @param industry - Industry to search for
+ * @param condition - Condition type (default: CONTAINS)
+ * @returns ListEntryFilters object configured for industry search
+ */
+export function createIndustryFilter(
+  industry: string, 
+  condition: FilterConditionType = FilterConditionType.CONTAINS
+): ListEntryFilters {
+  return {
+    filters: [
+      {
+        attribute: { slug: 'industry' },
+        condition: condition,
+        value: industry
+      }
+    ]
+  };
 }

--- a/test/api/advanced-search.test.ts
+++ b/test/api/advanced-search.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tests for advanced filtering capabilities
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { FilterConditionType, ResourceType } from '../../src/types/attio.js';
+import { advancedSearchObject } from '../../src/api/attio-operations.js';
+import { 
+  advancedSearchPeople, 
+  createNameFilter,
+  createEmailFilter,
+  createPhoneFilter
+} from '../../src/objects/people.js';
+import { 
+  advancedSearchCompanies,
+  createWebsiteFilter,
+  createIndustryFilter
+} from '../../src/objects/companies.js';
+import * as attioClient from '../../src/api/attio-client.js';
+
+// Mock the Axios client
+jest.mock('../../src/api/attio-client.js', () => {
+  return {
+    getAttioClient: jest.fn(() => ({
+      post: jest.fn()
+    }))
+  };
+});
+
+describe('advancedSearchObject', () => {
+  let mockAxiosPost: jest.Mock;
+  
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+    
+    // Setup mock API response
+    mockAxiosPost = jest.fn().mockResolvedValue({
+      data: {
+        data: [
+          { 
+            id: { record_id: '123' },
+            values: { 
+              name: [{ value: 'Test Name' }]
+            }
+          }
+        ]
+      }
+    });
+    
+    // Apply mock
+    (attioClient.getAttioClient as jest.Mock).mockReturnValue({
+      post: mockAxiosPost
+    });
+  });
+  
+  test('calls API with correct filter format for single condition', async () => {
+    const filters = {
+      filters: [
+        {
+          attribute: { slug: 'name' },
+          condition: FilterConditionType.EQUALS,
+          value: 'Test Name'
+        }
+      ]
+    };
+    
+    await advancedSearchObject(ResourceType.PEOPLE, filters);
+    
+    // Verify API was called with correct parameters
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+    expect(mockAxiosPost.mock.calls[0][0]).toBe('/objects/people/records/query');
+    expect(mockAxiosPost.mock.calls[0][1]).toEqual({
+      limit: 20,
+      offset: 0,
+      filter: {
+        name: {
+          '$equals': 'Test Name'
+        }
+      }
+    });
+  });
+  
+  test('applies limit and offset correctly', async () => {
+    const filters = createNameFilter('Test');
+    const limit = 50;
+    const offset = 10;
+    
+    await advancedSearchObject(ResourceType.PEOPLE, filters, limit, offset);
+    
+    // Verify API was called with correct parameters
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+    expect(mockAxiosPost.mock.calls[0][1]).toMatchObject({
+      limit: 50,
+      offset: 10
+    });
+  });
+  
+  test('handles complex filters with AND logic', async () => {
+    const filters = {
+      filters: [
+        {
+          attribute: { slug: 'name' },
+          condition: FilterConditionType.CONTAINS,
+          value: 'Test'
+        },
+        {
+          attribute: { slug: 'stage' },
+          condition: FilterConditionType.EQUALS,
+          value: 'Lead'
+        }
+      ]
+    };
+    
+    await advancedSearchObject(ResourceType.PEOPLE, filters);
+    
+    // Verify API was called with correct parameters
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+    expect(mockAxiosPost.mock.calls[0][1].filter).toEqual({
+      name: {
+        '$contains': 'Test'
+      },
+      stage: {
+        '$equals': 'Lead'
+      }
+    });
+  });
+  
+  test('handles complex filters with OR logic', async () => {
+    const filters = {
+      filters: [
+        {
+          attribute: { slug: 'name' },
+          condition: FilterConditionType.CONTAINS,
+          value: 'Test'
+        },
+        {
+          attribute: { slug: 'name' },
+          condition: FilterConditionType.CONTAINS,
+          value: 'Company'
+        }
+      ],
+      matchAny: true
+    };
+    
+    await advancedSearchObject(ResourceType.PEOPLE, filters);
+    
+    // Verify API was called with correct parameters
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+    expect(mockAxiosPost.mock.calls[0][1].filter).toEqual({
+      '$or': [
+        { name: { '$contains': 'Test' } },
+        { name: { '$contains': 'Company' } }
+      ]
+    });
+  });
+});
+
+describe('People advanced filtering', () => {
+  let mockAxiosPost: jest.Mock;
+  
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+    
+    // Setup mock API response
+    mockAxiosPost = jest.fn().mockResolvedValue({
+      data: {
+        data: [
+          { 
+            id: { record_id: '123' },
+            values: { 
+              name: [{ value: 'John Smith' }],
+              email: [{ value: 'john@example.com' }],
+              phone: [{ value: '+1234567890' }]
+            }
+          },
+          { 
+            id: { record_id: '456' },
+            values: { 
+              name: [{ value: 'Jane Smith' }],
+              email: [{ value: 'jane@example.com' }],
+              phone: [{ value: '+0987654321' }]
+            }
+          }
+        ]
+      }
+    });
+    
+    // Apply mock
+    (attioClient.getAttioClient as jest.Mock).mockReturnValue({
+      post: mockAxiosPost
+    });
+  });
+  
+  test('filter helper functions create correct filter structures', () => {
+    const nameFilter = createNameFilter('John Smith', FilterConditionType.EQUALS);
+    expect(nameFilter).toEqual({
+      filters: [
+        {
+          attribute: { slug: 'name' },
+          condition: FilterConditionType.EQUALS,
+          value: 'John Smith'
+        }
+      ]
+    });
+    
+    const emailFilter = createEmailFilter('example.com', FilterConditionType.CONTAINS);
+    expect(emailFilter).toEqual({
+      filters: [
+        {
+          attribute: { slug: 'email' },
+          condition: FilterConditionType.CONTAINS,
+          value: 'example.com'
+        }
+      ]
+    });
+    
+    const phoneFilter = createPhoneFilter('+1234', FilterConditionType.STARTS_WITH);
+    expect(phoneFilter).toEqual({
+      filters: [
+        {
+          attribute: { slug: 'phone' },
+          condition: FilterConditionType.STARTS_WITH,
+          value: '+1234'
+        }
+      ]
+    });
+  });
+  
+  test('correctly handles client-side email filtering', async () => {
+    // Setup a mock that will throw "unknown attribute slug: email" error first time
+    const mockError = new Error('unknown attribute slug: email');
+    mockAxiosPost
+      .mockRejectedValueOnce({ message: mockError.message })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { 
+              id: { record_id: '123' },
+              values: { 
+                name: [{ value: 'John Smith' }],
+                email: [{ value: 'john@example.com' }]
+              }
+            },
+            { 
+              id: { record_id: '456' },
+              values: { 
+                name: [{ value: 'Jane Smith' }],
+                email: [{ value: 'jane@gmail.com' }]
+              }
+            }
+          ]
+        }
+      });
+      
+    // Create a filter with email
+    const emailFilter = createEmailFilter('example.com', FilterConditionType.CONTAINS);
+    
+    // This should handle the error by falling back to client-side filtering
+    const results = await advancedSearchPeople(emailFilter);
+    
+    // Should only return the first person with example.com email
+    expect(results.length).toBe(1);
+    expect(results[0].id.record_id).toBe('123');
+  });
+});
+
+describe('Companies advanced filtering', () => {
+  let mockAxiosPost: jest.Mock;
+  
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+    
+    // Setup mock API response
+    mockAxiosPost = jest.fn().mockResolvedValue({
+      data: {
+        data: [
+          { 
+            id: { record_id: '123' },
+            values: { 
+              name: [{ value: 'Tech Corp' }],
+              website: [{ value: 'techcorp.com' }],
+              industry: [{ value: 'Technology' }]
+            }
+          },
+          { 
+            id: { record_id: '456' },
+            values: { 
+              name: [{ value: 'Green Energy Inc' }],
+              website: [{ value: 'greenenergy.com' }],
+              industry: [{ value: 'Energy' }]
+            }
+          }
+        ]
+      }
+    });
+    
+    // Apply mock
+    (attioClient.getAttioClient as jest.Mock).mockReturnValue({
+      post: mockAxiosPost
+    });
+  });
+  
+  test('filter helper functions create correct filter structures', () => {
+    const nameFilter = createNameFilter('Tech Corp', FilterConditionType.EQUALS);
+    expect(nameFilter).toEqual({
+      filters: [
+        {
+          attribute: { slug: 'name' },
+          condition: FilterConditionType.EQUALS,
+          value: 'Tech Corp'
+        }
+      ]
+    });
+    
+    const websiteFilter = createWebsiteFilter('tech', FilterConditionType.CONTAINS);
+    expect(websiteFilter).toEqual({
+      filters: [
+        {
+          attribute: { slug: 'website' },
+          condition: FilterConditionType.CONTAINS,
+          value: 'tech'
+        }
+      ]
+    });
+    
+    const industryFilter = createIndustryFilter('Technology', FilterConditionType.EQUALS);
+    expect(industryFilter).toEqual({
+      filters: [
+        {
+          attribute: { slug: 'industry' },
+          condition: FilterConditionType.EQUALS,
+          value: 'Technology'
+        }
+      ]
+    });
+  });
+  
+  test('correctly handles advanced company filtering', async () => {
+    // Combined filter for technology companies
+    const filter = {
+      filters: [
+        {
+          attribute: { slug: 'industry' },
+          condition: FilterConditionType.EQUALS,
+          value: 'Technology'
+        },
+        {
+          attribute: { slug: 'website' },
+          condition: FilterConditionType.CONTAINS,
+          value: 'tech'
+        }
+      ]
+    };
+    
+    const results = await advancedSearchCompanies(filter);
+    
+    // Verify it called the API with the right parameters
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+    expect(mockAxiosPost.mock.calls[0][1].filter).toEqual({
+      industry: {
+        '$equals': 'Technology'
+      },
+      website: {
+        '$contains': 'tech'
+      }
+    });
+  });
+});

--- a/test/api/advanced-search.test.ts
+++ b/test/api/advanced-search.test.ts
@@ -1,5 +1,8 @@
 /**
  * Tests for advanced filtering capabilities
+ * 
+ * These tests verify the new advanced filtering functionality for People and Companies,
+ * ensuring that the implementation meets the requirements specified in Issue #57.
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import { FilterConditionType, ResourceType } from '../../src/types/attio.js';


### PR DESCRIPTION
## Summary
- Implement `advancedSearchObject` function with support for complex filtering criteria
- Add `advancedSearchPeople` with special handling for email/phone filtering
- Add `advancedSearchCompanies` with support for all comparison operators
- Create helper functions for common filter types (name, email, phone, website, industry)
- Expose advanced filtering via MCP tools for both People and Companies
- Support for logical operators (AND/OR) and all filter condition types

## Implementation Details
This PR implements issue #57 by extending the filtering capabilities previously developed for lists to work with People and Companies objects. The implementation follows the same pattern as the list filtering, using the `transformFiltersToApiFormat` utility to provide a consistent API interface.

For People objects, special handling was added for email and phone attributes which require client-side filtering due to API limitations with these fields.

### Example Usage
```typescript
// Simple filter for people with a specific name
const people = await advancedSearchPeople(
  createNameFilter("John Smith", FilterConditionType.EQUALS)
);

// Complex filter with AND logic (default)
const complexFilter = {
  filters: [
    {
      attribute: { slug: 'name' },
      condition: FilterConditionType.CONTAINS,
      value: "Smith"
    },
    {
      attribute: { slug: 'email' },
      condition: FilterConditionType.CONTAINS,
      value: "gmail.com"
    }
  ]
};
const results = await advancedSearchPeople(complexFilter);

// Using the MCP tool
// advanced-search-people with filters object
```

## Known Limitations
- Email/phone filtering for People is performed client-side, which may impact performance for large result sets
- The maximum number of records fetched is increased to 100 when email/phone filtering is used to ensure adequate results after client-side filtering
- All filter condition types are supported, but some might not be applicable to certain attributes

## Test Plan
- Test advanced filtering for People with name, email, and phone filters
- Test advanced filtering for Companies with name, website, and industry filters
- Test compound filters with AND/OR logic
- Test all comparison operators (equals, contains, starts_with, etc.)
- Test filtering with limit and offset parameters
- Verify client-side filtering for email/phone works correctly
EOF < /dev/null