### PR TITLE
Feature: Relationship-based filtering (Issue #60)

### DIFF
--- a/docs/api/api-overview.md
+++ b/docs/api/api-overview.md
@@ -29,11 +29,28 @@ Claude uses these URIs to reference specific records when performing operations.
 Claude can interact with Attio using various tools provided by the MCP server:
 
 - **Search tools**: Find companies, people, and other records
+- **Advanced search tools**: Use complex filters including date ranges, numeric values, and relationships
 - **Read tools**: View details of specific records
 - **Write tools**: Create notes and update records
 - **List management tools**: Work with Attio lists
 
 See the specific API documentation for details on each tool.
+
+### Advanced Filtering Capabilities
+
+The Attio MCP server provides multiple filtering methods:
+
+- **Basic filtering**: Simple text-based searches for names, emails, etc.
+- **Advanced filtering**: Complex filter conditions with multiple attributes and logic
+- **Date and numeric filtering**: Filter by dates and numeric values with range support
+- **Activity filtering**: Find records based on interaction history and activity
+- **Relationship filtering**: Find records based on their relationships with other records
+
+For details, see:
+- [Advanced Filtering Guide](./advanced-filtering.md)
+- [Date and Numeric Filtering](./date-numeric-filtering.md)
+- [Activity and Historical Filtering](./activity-historical-filtering.md)
+- [Relationship-Based Filtering](./relationship-filtering.md)
 
 ## Authentication
 

--- a/docs/api/relationship-filtering.md
+++ b/docs/api/relationship-filtering.md
@@ -1,0 +1,182 @@
+# Relationship-Based Filtering
+
+The Attio MCP server provides powerful relationship-based filtering capabilities that allow you to find records based on their relationships with other records. This enables more advanced query patterns and helps you discover connections between different types of records in your Attio CRM.
+
+## Overview
+
+Relationship-based filtering makes it possible to:
+
+- Find people based on attributes of their associated companies
+- Find companies based on attributes of their associated people
+- Find records that belong to specific lists
+- Find records that have notes containing specific text
+
+## People-Company Relationship Filtering
+
+### Finding People by Company Attributes
+
+You can search for people who work at companies matching specific criteria:
+
+```json
+{
+  "companyFilter": {
+    "filters": [
+      {
+        "attribute": { "slug": "industry" },
+        "condition": "equals",
+        "value": "Technology"
+      }
+    ]
+  }
+}
+```
+
+This example finds all people who work at companies in the Technology industry.
+
+### Finding Companies by People Attributes
+
+Similarly, you can search for companies that have employees matching specific criteria:
+
+```json
+{
+  "peopleFilter": {
+    "filters": [
+      {
+        "attribute": { "slug": "job_title" },
+        "condition": "contains",
+        "value": "Engineer"
+      }
+    ]
+  }
+}
+```
+
+This example finds all companies that have employees with "Engineer" in their job title.
+
+## List Membership Filtering
+
+### Finding People in Companies from a List
+
+You can find people who work at companies that belong to a specific list:
+
+```json
+{
+  "listId": "list_abc123"
+}
+```
+
+This finds all people who work at companies in the specified list.
+
+### Finding Companies with People from a List
+
+Similarly, you can find companies that have employees in a specific list:
+
+```json
+{
+  "listId": "list_xyz789"
+}
+```
+
+This finds all companies that have employees in the specified list.
+
+## Note Content Filtering
+
+### Finding People by Note Content
+
+You can search for people who have notes containing specific text:
+
+```json
+{
+  "searchText": "follow up next quarter"
+}
+```
+
+This finds all people who have notes containing the phrase "follow up next quarter".
+
+### Finding Companies by Note Content
+
+Similarly, you can search for companies that have notes containing specific text:
+
+```json
+{
+  "searchText": "potential partnership"
+}
+```
+
+This finds all companies that have notes containing the phrase "potential partnership".
+
+## Examples
+
+### Example 1: Find all people at technology companies with more than 100 employees
+
+```json
+{
+  "companyFilter": {
+    "filters": [
+      {
+        "attribute": { "slug": "industry" },
+        "condition": "equals",
+        "value": "Technology"
+      },
+      {
+        "attribute": { "slug": "employee_count" },
+        "condition": "greater_than",
+        "value": 100
+      }
+    ],
+    "matchAny": false
+  }
+}
+```
+
+### Example 2: Find all companies with executives in San Francisco
+
+```json
+{
+  "peopleFilter": {
+    "filters": [
+      {
+        "attribute": { "slug": "job_title" },
+        "condition": "contains",
+        "value": "CEO"
+      },
+      {
+        "attribute": { "slug": "location" },
+        "condition": "contains",
+        "value": "San Francisco"
+      }
+    ],
+    "matchAny": false
+  }
+}
+```
+
+### Example 3: Find all companies with notes mentioning acquisition
+
+```json
+{
+  "searchText": "acquisition"
+}
+```
+
+## Tool Reference
+
+### People Relationship Tools
+
+| Tool Name | Description |
+|-----------|-------------|
+| `search-people-by-company` | Search for people based on attributes of their associated companies |
+| `search-people-by-company-list` | Search for people who work at companies in a specific list |
+| `search-people-by-notes` | Search for people that have notes containing specific text |
+
+### Company Relationship Tools
+
+| Tool Name | Description |
+|-----------|-------------|
+| `search-companies-by-people` | Search for companies based on attributes of their associated people |
+| `search-companies-by-people-list` | Search for companies that have employees in a specific list |
+| `search-companies-by-notes` | Search for companies that have notes containing specific text |
+
+## Combining Filters
+
+You can combine relationship-based filters with other filtering capabilities to create more powerful and targeted queries. For example, you can combine date-based filtering with relationship filtering to find records created within a specific time range that also have specific relationships.

--- a/src/errors/api-errors.ts
+++ b/src/errors/api-errors.ts
@@ -272,3 +272,79 @@ export class FilterValidationError extends Error {
     Object.setPrototypeOf(this, FilterValidationError.prototype);
   }
 }
+
+/**
+ * Error for relationship filter validation issues
+ * 
+ * @example
+ * ```typescript
+ * try {
+ *   if (!isValidRelationshipType(type)) {
+ *     throw new RelationshipFilterError(`Invalid relationship type: ${type}`, 'people', 'companies');
+ *   }
+ * } catch (error) {
+ *   if (error instanceof RelationshipFilterError) {
+ *     // Handle relationship filter error
+ *   }
+ * }
+ * ```
+ */
+export class RelationshipFilterError extends FilterValidationError {
+  /**
+   * Create a RelationshipFilterError
+   * 
+   * @param message - Error message
+   * @param sourceType - The source entity type (e.g., 'people', 'companies')
+   * @param targetType - The target entity type (e.g., 'companies', 'lists')
+   * @param relationshipType - The type of relationship that failed validation
+   */
+  constructor(
+    message: string,
+    public readonly sourceType?: string,
+    public readonly targetType?: string,
+    public readonly relationshipType?: string
+  ) {
+    super(message);
+    this.name = 'RelationshipFilterError';
+    
+    // This line is needed to properly capture the stack trace in derived classes
+    Object.setPrototypeOf(this, RelationshipFilterError.prototype);
+  }
+}
+
+/**
+ * Error specifically for list relationship issues
+ * 
+ * @example
+ * ```typescript
+ * try {
+ *   if (!isValidListId(listId)) {
+ *     throw new ListRelationshipError(`Invalid list ID: ${listId}`, 'people', listId);
+ *   }
+ * } catch (error) {
+ *   if (error instanceof ListRelationshipError) {
+ *     // Handle list relationship error
+ *   }
+ * }
+ * ```
+ */
+export class ListRelationshipError extends RelationshipFilterError {
+  /**
+   * Create a ListRelationshipError
+   * 
+   * @param message - Error message
+   * @param sourceType - The source entity type (e.g., 'people', 'companies')
+   * @param listId - The list ID that caused the error
+   */
+  constructor(
+    message: string,
+    sourceType?: string,
+    public readonly listId?: string
+  ) {
+    super(message, sourceType, 'lists', 'in_list');
+    this.name = 'ListRelationshipError';
+    
+    // This line is needed to properly capture the stack trace
+    Object.setPrototypeOf(this, ListRelationshipError.prototype);
+  }
+}

--- a/src/handlers/tool-configs/companies.ts
+++ b/src/handlers/tool-configs/companies.ts
@@ -7,7 +7,10 @@ import {
   getCompanyDetails, 
   getCompanyNotes, 
   createCompanyNote,
-  advancedSearchCompanies
+  advancedSearchCompanies,
+  searchCompaniesByPeople,
+  searchCompaniesByPeopleList,
+  searchCompaniesByNotes
 } from "../../objects/companies.js";
 import { 
   SearchToolConfig, 
@@ -24,6 +27,34 @@ export const companyToolConfigs = {
     handler: searchCompanies,
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} companies:\n${results.map((company: any) => 
+        `- ${company.values?.name?.[0]?.value || 'Unnamed'} (ID: ${company.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as SearchToolConfig,
+  
+  // Relationship-based search tools
+  searchByPeople: {
+    name: "search-companies-by-people",
+    handler: searchCompaniesByPeople,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} companies matching the people filter:\n${results.map((company: any) => 
+        `- ${company.values?.name?.[0]?.value || 'Unnamed'} (ID: ${company.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as AdvancedSearchToolConfig,
+  
+  searchByPeopleList: {
+    name: "search-companies-by-people-list",
+    handler: searchCompaniesByPeopleList,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} companies that have employees in the specified list:\n${results.map((company: any) => 
+        `- ${company.values?.name?.[0]?.value || 'Unnamed'} (ID: ${company.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as SearchToolConfig,
+  
+  searchByNotes: {
+    name: "search-companies-by-notes",
+    handler: searchCompaniesByNotes,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} companies with matching notes:\n${results.map((company: any) => 
         `- ${company.values?.name?.[0]?.value || 'Unnamed'} (ID: ${company.id?.record_id || 'unknown'})`).join('\n')}`;
     }
   } as SearchToolConfig,
@@ -201,6 +232,109 @@ export const companyToolDefinitions = [
         { required: ["companyId"] },
         { required: ["uri"] }
       ]
+    }
+  },
+  
+  // Relationship-based tools
+  {
+    name: "search-companies-by-people",
+    description: "Search for companies based on attributes of their associated people",
+    inputSchema: {
+      type: "object",
+      properties: {
+        peopleFilter: {
+          type: "object",
+          description: "Filter conditions to apply to people",
+          properties: {
+            filters: {
+              type: "array",
+              description: "Array of filter conditions",
+              items: {
+                type: "object",
+                properties: {
+                  attribute: {
+                    type: "object",
+                    properties: {
+                      slug: {
+                        type: "string",
+                        description: "Person attribute to filter on (e.g., 'name', 'email', 'phone')"
+                      }
+                    },
+                    required: ["slug"]
+                  },
+                  condition: {
+                    type: "string",
+                    description: "Condition to apply (e.g., 'equals', 'contains', 'starts_with')"
+                  },
+                  value: {
+                    type: ["string", "number", "boolean"],
+                    description: "Value to filter by"
+                  }
+                },
+                required: ["attribute", "condition", "value"]
+              }
+            },
+            matchAny: {
+              type: "boolean",
+              description: "When true, matches any filter (OR logic). When false, matches all filters (AND logic)"
+            }
+          },
+          required: ["filters"]
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["peopleFilter"]
+    }
+  },
+  {
+    name: "search-companies-by-people-list",
+    description: "Search for companies that have employees in a specific list",
+    inputSchema: {
+      type: "object",
+      properties: {
+        listId: {
+          type: "string",
+          description: "ID of the list containing people"
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["listId"]
+    }
+  },
+  {
+    name: "search-companies-by-notes",
+    description: "Search for companies that have notes containing specific text",
+    inputSchema: {
+      type: "object",
+      properties: {
+        searchText: {
+          type: "string",
+          description: "Text to search for in notes"
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["searchText"]
     }
   }
 ];

--- a/src/handlers/tool-configs/people.ts
+++ b/src/handlers/tool-configs/people.ts
@@ -19,6 +19,9 @@ import {
   searchPeopleByModificationDate,
   searchPeopleByLastInteraction,
   searchPeopleByActivity,
+  searchPeopleByCompany,
+  searchPeopleByCompanyList,
+  searchPeopleByNotes,
   advancedSearchPeople
 } from "../../objects/people.js";
 import { 
@@ -113,7 +116,35 @@ export const peopleToolConfigs = {
       return `Found ${results.length} people with matching activity:\n${results.map((person: any) => 
         `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'}, Last Interaction: ${person.values?.last_interaction?.interacted_at || 'unknown'})`).join('\n')}`;
     }
-  } as DateBasedSearchToolConfig
+  } as DateBasedSearchToolConfig,
+
+  // Relationship-based filtering tools
+  searchByCompany: {
+    name: "search-people-by-company",
+    handler: searchPeopleByCompany,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} people matching the company filter:\n${results.map((person: any) => 
+        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as AdvancedSearchToolConfig,
+
+  searchByCompanyList: {
+    name: "search-people-by-company-list",
+    handler: searchPeopleByCompanyList,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} people who work at companies in the specified list:\n${results.map((person: any) => 
+        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as SearchToolConfig,
+
+  searchByNotes: {
+    name: "search-people-by-notes",
+    handler: searchPeopleByNotes,
+    formatResult: (results: AttioRecord[]) => {
+      return `Found ${results.length} people with matching notes:\n${results.map((person: any) => 
+        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as SearchToolConfig
 };
 
 // People tool definitions
@@ -425,6 +456,109 @@ export const peopleToolDefinitions = [
         }
       },
       required: ["activityFilter"]
+    }
+  },
+  
+  // Relationship-based filtering tool definitions
+  {
+    name: "search-people-by-company",
+    description: "Search for people based on attributes of their associated companies",
+    inputSchema: {
+      type: "object",
+      properties: {
+        companyFilter: {
+          type: "object",
+          description: "Filter conditions to apply to companies",
+          properties: {
+            filters: {
+              type: "array",
+              description: "Array of filter conditions",
+              items: {
+                type: "object",
+                properties: {
+                  attribute: {
+                    type: "object",
+                    properties: {
+                      slug: {
+                        type: "string",
+                        description: "Company attribute to filter on (e.g., 'name', 'industry', 'website')"
+                      }
+                    },
+                    required: ["slug"]
+                  },
+                  condition: {
+                    type: "string",
+                    description: "Condition to apply (e.g., 'equals', 'contains', 'starts_with')"
+                  },
+                  value: {
+                    type: ["string", "number", "boolean"],
+                    description: "Value to filter by"
+                  }
+                },
+                required: ["attribute", "condition", "value"]
+              }
+            },
+            matchAny: {
+              type: "boolean",
+              description: "When true, matches any filter (OR logic). When false, matches all filters (AND logic)"
+            }
+          },
+          required: ["filters"]
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["companyFilter"]
+    }
+  },
+  {
+    name: "search-people-by-company-list",
+    description: "Search for people who work at companies in a specific list",
+    inputSchema: {
+      type: "object",
+      properties: {
+        listId: {
+          type: "string",
+          description: "ID of the list containing companies"
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["listId"]
+    }
+  },
+  {
+    name: "search-people-by-notes",
+    description: "Search for people that have notes containing specific text",
+    inputSchema: {
+      type: "object",
+      properties: {
+        searchText: {
+          type: "string",
+          description: "Text to search for in notes"
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)"
+        },
+        offset: {
+          type: "number",
+          description: "Number of results to skip (default: 0)"
+        }
+      },
+      required: ["searchText"]
     }
   }
 ];

--- a/src/objects/companies.ts
+++ b/src/objects/companies.ts
@@ -22,6 +22,13 @@ import {
   AttioNote,
   FilterConditionType
 } from "../types/attio.js";
+import {
+  createCompaniesByPeopleFilter,
+  createCompaniesByPeopleListFilter,
+  createRecordsByNotesFilter
+} from "../utils/relationship-utils.js";
+import { validateNumericParam } from "../utils/filter-validation.js";
+import { FilterValidationError } from "../errors/api-errors.js";
 
 /**
  * Searches for companies by name
@@ -674,4 +681,120 @@ export function createIndustryFilter(
       }
     ]
   };
+}
+
+/**
+ * Search for companies based on attributes of their associated people
+ * 
+ * @param peopleFilter - Filter to apply to people
+ * @param limit - Maximum number of results to return (default: 20)
+ * @param offset - Number of results to skip (default: 0)
+ * @returns Array of matching companies
+ */
+export async function searchCompaniesByPeople(
+  peopleFilter: ListEntryFilters | string | any,
+  limit: number | string = 20,
+  offset: number | string = 0
+): Promise<Company[]> {
+  try {
+    // Ensure peopleFilter is a properly structured filter object
+    if (typeof peopleFilter !== 'object' || !peopleFilter || !peopleFilter.filters) {
+      throw new FilterValidationError(
+        'People filter must be a valid ListEntryFilters object with at least one filter'
+      );
+    }
+    
+    // Validate and normalize limit and offset parameters
+    const validatedLimit = validateNumericParam(limit, 'limit', 20);
+    const validatedOffset = validateNumericParam(offset, 'offset', 0);
+    
+    // Create the relationship-based filter and perform the search
+    const filters = createCompaniesByPeopleFilter(peopleFilter);
+    const results = await advancedSearchCompanies(filters, validatedLimit, validatedOffset);
+    return Array.isArray(results) ? results : [];
+  } catch (error) {
+    // Convert all errors to FilterValidationErrors for consistent handling
+    if (error instanceof FilterValidationError) {
+      throw error;
+    }
+    throw new FilterValidationError(
+      `Failed to search companies by people: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Search for companies that have employees in a specific list
+ * 
+ * @param listId - ID of the list containing people
+ * @param limit - Maximum number of results to return (default: 20)
+ * @param offset - Number of results to skip (default: 0)
+ * @returns Array of matching companies
+ */
+export async function searchCompaniesByPeopleList(
+  listId: string,
+  limit: number | string = 20,
+  offset: number | string = 0
+): Promise<Company[]> {
+  try {
+    // Validate listId
+    if (!listId || typeof listId !== 'string' || listId.trim() === '') {
+      throw new FilterValidationError('List ID must be a non-empty string');
+    }
+    
+    // Validate and normalize limit and offset parameters
+    const validatedLimit = validateNumericParam(limit, 'limit', 20);
+    const validatedOffset = validateNumericParam(offset, 'offset', 0);
+    
+    // Create the relationship-based filter and perform the search
+    const filters = createCompaniesByPeopleListFilter(listId);
+    const results = await advancedSearchCompanies(filters, validatedLimit, validatedOffset);
+    return Array.isArray(results) ? results : [];
+  } catch (error) {
+    // Convert all errors to FilterValidationErrors for consistent handling
+    if (error instanceof FilterValidationError) {
+      throw error;
+    }
+    throw new FilterValidationError(
+      `Failed to search companies by people list: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Search for companies that have notes containing specific text
+ * 
+ * @param searchText - Text to search for in notes
+ * @param limit - Maximum number of results to return (default: 20)
+ * @param offset - Number of results to skip (default: 0)
+ * @returns Array of matching companies
+ */
+export async function searchCompaniesByNotes(
+  searchText: string,
+  limit: number | string = 20,
+  offset: number | string = 0
+): Promise<Company[]> {
+  try {
+    // Validate searchText
+    if (!searchText || typeof searchText !== 'string' || searchText.trim() === '') {
+      throw new FilterValidationError('Search text must be a non-empty string');
+    }
+    
+    // Validate and normalize limit and offset parameters
+    const validatedLimit = validateNumericParam(limit, 'limit', 20);
+    const validatedOffset = validateNumericParam(offset, 'offset', 0);
+    
+    // Create the relationship-based filter and perform the search
+    const filters = createRecordsByNotesFilter(ResourceType.COMPANIES, searchText);
+    const results = await advancedSearchCompanies(filters, validatedLimit, validatedOffset);
+    return Array.isArray(results) ? results : [];
+  } catch (error) {
+    // Convert all errors to FilterValidationErrors for consistent handling
+    if (error instanceof FilterValidationError) {
+      throw error;
+    }
+    throw new FilterValidationError(
+      `Failed to search companies by notes: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 }

--- a/src/objects/people.ts
+++ b/src/objects/people.ts
@@ -29,6 +29,11 @@ import {
   createLastInteractionFilter,
   createActivityFilter
 } from "../utils/filter-utils.js";
+import {
+  createPeopleByCompanyFilter,
+  createPeopleByCompanyListFilter,
+  createRecordsByNotesFilter
+} from "../utils/relationship-utils.js";
 import { FilterValidationError } from "../errors/api-errors.js";
 import { 
   validateDateRange,
@@ -679,6 +684,122 @@ export async function searchPeopleByActivity(
     }
     throw new FilterValidationError(
       `Failed to search people by activity: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Search for people based on attributes of their associated companies
+ * 
+ * @param companyFilter - Filter to apply to companies
+ * @param limit - Maximum number of results to return (default: 20)
+ * @param offset - Number of results to skip (default: 0)
+ * @returns Array of matching people
+ */
+export async function searchPeopleByCompany(
+  companyFilter: ListEntryFilters | string | any,
+  limit: number | string = 20,
+  offset: number | string = 0
+): Promise<Person[]> {
+  try {
+    // Ensure companyFilter is a properly structured filter object
+    if (typeof companyFilter !== 'object' || !companyFilter || !companyFilter.filters) {
+      throw new FilterValidationError(
+        'Company filter must be a valid ListEntryFilters object with at least one filter'
+      );
+    }
+    
+    // Validate and normalize limit and offset parameters
+    const validatedLimit = validateNumericParam(limit, 'limit', 20);
+    const validatedOffset = validateNumericParam(offset, 'offset', 0);
+    
+    // Create the relationship-based filter and perform the search
+    const filters = createPeopleByCompanyFilter(companyFilter);
+    const results = await advancedSearchPeople(filters, validatedLimit, validatedOffset);
+    return Array.isArray(results) ? results : [];
+  } catch (error) {
+    // Convert all errors to FilterValidationErrors for consistent handling
+    if (error instanceof FilterValidationError) {
+      throw error;
+    }
+    throw new FilterValidationError(
+      `Failed to search people by company: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Search for people who work at companies in a specific list
+ * 
+ * @param listId - ID of the list containing companies
+ * @param limit - Maximum number of results to return (default: 20)
+ * @param offset - Number of results to skip (default: 0)
+ * @returns Array of matching people
+ */
+export async function searchPeopleByCompanyList(
+  listId: string,
+  limit: number | string = 20,
+  offset: number | string = 0
+): Promise<Person[]> {
+  try {
+    // Validate listId
+    if (!listId || typeof listId !== 'string' || listId.trim() === '') {
+      throw new FilterValidationError('List ID must be a non-empty string');
+    }
+    
+    // Validate and normalize limit and offset parameters
+    const validatedLimit = validateNumericParam(limit, 'limit', 20);
+    const validatedOffset = validateNumericParam(offset, 'offset', 0);
+    
+    // Create the relationship-based filter and perform the search
+    const filters = createPeopleByCompanyListFilter(listId);
+    const results = await advancedSearchPeople(filters, validatedLimit, validatedOffset);
+    return Array.isArray(results) ? results : [];
+  } catch (error) {
+    // Convert all errors to FilterValidationErrors for consistent handling
+    if (error instanceof FilterValidationError) {
+      throw error;
+    }
+    throw new FilterValidationError(
+      `Failed to search people by company list: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Search for people that have notes containing specific text
+ * 
+ * @param searchText - Text to search for in notes
+ * @param limit - Maximum number of results to return (default: 20)
+ * @param offset - Number of results to skip (default: 0)
+ * @returns Array of matching people
+ */
+export async function searchPeopleByNotes(
+  searchText: string,
+  limit: number | string = 20,
+  offset: number | string = 0
+): Promise<Person[]> {
+  try {
+    // Validate searchText
+    if (!searchText || typeof searchText !== 'string' || searchText.trim() === '') {
+      throw new FilterValidationError('Search text must be a non-empty string');
+    }
+    
+    // Validate and normalize limit and offset parameters
+    const validatedLimit = validateNumericParam(limit, 'limit', 20);
+    const validatedOffset = validateNumericParam(offset, 'offset', 0);
+    
+    // Create the relationship-based filter and perform the search
+    const filters = createRecordsByNotesFilter(ResourceType.PEOPLE, searchText);
+    const results = await advancedSearchPeople(filters, validatedLimit, validatedOffset);
+    return Array.isArray(results) ? results : [];
+  } catch (error) {
+    // Convert all errors to FilterValidationErrors for consistent handling
+    if (error instanceof FilterValidationError) {
+      throw error;
+    }
+    throw new FilterValidationError(
+      `Failed to search people by notes: ${error instanceof Error ? error.message : String(error)}`
     );
   }
 }

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -268,6 +268,17 @@ export enum ResourceType {
 }
 
 /**
+ * Relationship types in Attio
+ * Defines the types of relationships between different record types
+ */
+export enum RelationshipType {
+  WORKS_AT = 'works_at',       // Person to Company relationship
+  EMPLOYS = 'employs',         // Company to Person relationship
+  BELONGS_TO_LIST = 'in_list',  // Any record to List relationship
+  HAS_NOTE = 'has_note'        // Any record to Note relationship
+}
+
+/**
  * API error response shape
  */
 export interface AttioErrorResponse {

--- a/src/utils/relationship-utils.ts
+++ b/src/utils/relationship-utils.ts
@@ -1,0 +1,280 @@
+/**
+ * Relationship utility functions for working with related records in Attio
+ * Provides functions for creating filters based on relationships between records.
+ */
+import { 
+  ListEntryFilter, 
+  ListEntryFilters 
+} from "../api/attio-operations.js";
+import { 
+  ResourceType,
+  FilterConditionType
+} from "../types/attio.js";
+import { FilterValidationError } from "../errors/api-errors.js";
+import { combineFiltersWithAnd, createEqualsFilter } from "./filter-utils.js";
+
+/**
+ * Relationship types in Attio
+ */
+export enum RelationshipType {
+  WORKS_AT = 'works_at',       // Person to Company
+  EMPLOYS = 'employs',         // Company to Person
+  BELONGS_TO_LIST = 'in_list',  // Any record to List
+  HAS_NOTE = 'has_note'        // Any record to Note
+}
+
+/**
+ * Configuration for a relationship-based filter
+ */
+export interface RelationshipFilterConfig {
+  // The source record type
+  sourceType: ResourceType;
+  
+  // The target record type
+  targetType: ResourceType;
+  
+  // The relationship type connecting the records
+  relationshipType: RelationshipType;
+  
+  // Filters to apply to the target records
+  targetFilters: ListEntryFilters;
+}
+
+/**
+ * Creates a filter for people based on their associated company attributes
+ * 
+ * @param companyFilter - Filters to apply to the related companies
+ * @returns Filter for finding people based on company attributes
+ */
+export function createPeopleByCompanyFilter(companyFilter: ListEntryFilters): ListEntryFilters {
+  try {
+    // Validate company filters
+    if (!companyFilter || !companyFilter.filters || companyFilter.filters.length === 0) {
+      throw new Error('Company filter must contain at least one valid filter condition');
+    }
+    
+    // Create a relationship filter configuration
+    const relationshipConfig: RelationshipFilterConfig = {
+      sourceType: ResourceType.PEOPLE,
+      targetType: ResourceType.COMPANIES,
+      relationshipType: RelationshipType.WORKS_AT,
+      targetFilters: companyFilter
+    };
+    
+    // Convert to an Attio API compatible filter
+    return createRelationshipFilter(relationshipConfig);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new FilterValidationError(`Failed to create people-by-company filter: ${errorMessage}`);
+  }
+}
+
+/**
+ * Creates a filter for companies based on their associated people attributes
+ * 
+ * @param peopleFilter - Filters to apply to the related people
+ * @returns Filter for finding companies based on people attributes
+ */
+export function createCompaniesByPeopleFilter(peopleFilter: ListEntryFilters): ListEntryFilters {
+  try {
+    // Validate people filters
+    if (!peopleFilter || !peopleFilter.filters || peopleFilter.filters.length === 0) {
+      throw new Error('People filter must contain at least one valid filter condition');
+    }
+    
+    // Create a relationship filter configuration
+    const relationshipConfig: RelationshipFilterConfig = {
+      sourceType: ResourceType.COMPANIES,
+      targetType: ResourceType.PEOPLE,
+      relationshipType: RelationshipType.EMPLOYS,
+      targetFilters: peopleFilter
+    };
+    
+    // Convert to an Attio API compatible filter
+    return createRelationshipFilter(relationshipConfig);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new FilterValidationError(`Failed to create companies-by-people filter: ${errorMessage}`);
+  }
+}
+
+/**
+ * Creates a filter for records that belong to a specific list
+ * 
+ * @param resourceType - The type of records to filter (people or companies)
+ * @param listId - The ID of the list to filter by
+ * @returns Filter for finding records that belong to the list
+ */
+export function createRecordsByListFilter(
+  resourceType: ResourceType,
+  listId: string
+): ListEntryFilters {
+  try {
+    if (!listId || listId.trim() === '') {
+      throw new Error('List ID must be provided');
+    }
+    
+    // Create a relationship filter configuration
+    const relationshipConfig: RelationshipFilterConfig = {
+      sourceType: resourceType,
+      targetType: ResourceType.LISTS,
+      relationshipType: RelationshipType.BELONGS_TO_LIST,
+      targetFilters: createEqualsFilter('list_id', listId)
+    };
+    
+    // Convert to an Attio API compatible filter
+    return createRelationshipFilter(relationshipConfig);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new FilterValidationError(`Failed to create records-by-list filter: ${errorMessage}`);
+  }
+}
+
+/**
+ * Creates a filter for finding people who work at companies in a specific list
+ * 
+ * @param listId - The ID of the list that contains companies
+ * @returns Filter for finding people who work at companies in the specified list
+ */
+export function createPeopleByCompanyListFilter(listId: string): ListEntryFilters {
+  try {
+    if (!listId || listId.trim() === '') {
+      throw new Error('List ID must be provided');
+    }
+    
+    // First, create a filter for companies in the list
+    const companiesInListFilter = createRecordsByListFilter(
+      ResourceType.COMPANIES,
+      listId
+    );
+    
+    // Then, create a filter for people who work at those companies
+    return createPeopleByCompanyFilter(companiesInListFilter);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new FilterValidationError(`Failed to create people-by-company-list filter: ${errorMessage}`);
+  }
+}
+
+/**
+ * Creates a filter for finding companies that have people in a specific list
+ * 
+ * @param listId - The ID of the list that contains people
+ * @returns Filter for finding companies that have people in the specified list
+ */
+export function createCompaniesByPeopleListFilter(listId: string): ListEntryFilters {
+  try {
+    if (!listId || listId.trim() === '') {
+      throw new Error('List ID must be provided');
+    }
+    
+    // First, create a filter for people in the list
+    const peopleInListFilter = createRecordsByListFilter(
+      ResourceType.PEOPLE,
+      listId
+    );
+    
+    // Then, create a filter for companies that have those people
+    return createCompaniesByPeopleFilter(peopleInListFilter);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new FilterValidationError(`Failed to create companies-by-people-list filter: ${errorMessage}`);
+  }
+}
+
+/**
+ * Creates a filter for records that have associated notes matching criteria
+ * 
+ * @param resourceType - The type of records to filter (people or companies)
+ * @param textSearch - Text to search for in the notes
+ * @returns Filter for finding records with matching notes
+ */
+export function createRecordsByNotesFilter(
+  resourceType: ResourceType,
+  textSearch: string
+): ListEntryFilters {
+  try {
+    if (!textSearch || textSearch.trim() === '') {
+      throw new Error('Text search query must be provided');
+    }
+    
+    // Create a relationship filter configuration
+    const relationshipConfig: RelationshipFilterConfig = {
+      sourceType: resourceType,
+      targetType: ResourceType.LISTS, // Notes don't have a ResourceType, using LISTS as a placeholder
+      relationshipType: RelationshipType.HAS_NOTE,
+      targetFilters: {
+        filters: [
+          {
+            attribute: { slug: 'note_content' },
+            condition: FilterConditionType.CONTAINS,
+            value: textSearch
+          }
+        ],
+        matchAny: false
+      }
+    };
+    
+    // Convert to an Attio API compatible filter
+    return createRelationshipFilter(relationshipConfig);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new FilterValidationError(`Failed to create records-by-notes filter: ${errorMessage}`);
+  }
+}
+
+/**
+ * Core function to create relationship-based filters
+ * This translates our internal representation to the format expected by the Attio API
+ * 
+ * @param config - Relationship filter configuration
+ * @returns Filter in the format expected by Attio API
+ */
+function createRelationshipFilter(config: RelationshipFilterConfig): ListEntryFilters {
+  // The structure we're aiming for in the Attio API format:
+  // {
+  //   "$relationship": {
+  //     "type": "works_at",
+  //     "target": {
+  //       "object": "companies",
+  //       "filter": { /* target filters */ }
+  //     }
+  //   }
+  // }
+  
+  // Map our ResourceType to Attio API object names
+  const getObjectName = (type: ResourceType): string => {
+    switch (type) {
+      case ResourceType.PEOPLE:
+        return 'people';
+      case ResourceType.COMPANIES:
+        return 'companies';
+      case ResourceType.LISTS:
+        return 'lists';
+      case ResourceType.RECORDS:
+        return 'records';
+      default:
+        throw new Error(`Unsupported resource type: ${type}`);
+    }
+  };
+  
+  // The relationship field should be a custom attribute in the filter
+  return {
+    filters: [
+      {
+        attribute: {
+          slug: '$relationship'
+        },
+        condition: FilterConditionType.EQUALS,
+        value: {
+          type: config.relationshipType,
+          target: {
+            object: getObjectName(config.targetType),
+            filter: config.targetFilters
+          }
+        }
+      }
+    ],
+    matchAny: false
+  };
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -246,3 +246,56 @@ export function validateRequest(
   
   return null;
 }
+
+/**
+ * Validates that an ID string is valid and secure to use
+ * 
+ * @param id - The ID to validate
+ * @returns True if the ID is valid, false otherwise
+ */
+export function isValidId(id: string): boolean {
+  // Basic check for non-empty string
+  if (!id || typeof id !== 'string' || id.trim() === '') {
+    return false;
+  }
+  
+  // Check that the ID has a reasonable length
+  if (id.length < 3 || id.length > 100) {
+    return false;
+  }
+  
+  // Check that the ID only contains valid characters
+  // Allowing alphanumeric, hyphens, and underscores
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    return false;
+  }
+  
+  return true;
+}
+
+/**
+ * Validates that a list ID is valid and safe to use
+ * Contains additional validation specific to Attio list IDs
+ * 
+ * @param listId - The list ID to validate
+ * @returns True if the list ID is valid, false otherwise
+ */
+export function isValidListId(listId: string): boolean {
+  // First apply general ID validation
+  if (!isValidId(listId)) {
+    return false;
+  }
+  
+  // Additional validation specific to list IDs
+  // Attio list IDs typically start with "list_" followed by alphanumeric characters
+  if (!/^list_[a-zA-Z0-9]+$/.test(listId)) {
+    return false;
+  }
+  
+  // Ensure the ID isn't suspiciously long
+  if (listId.length > 50) {
+    return false;
+  }
+  
+  return true;
+}

--- a/test/utils/relationship-utils.test.ts
+++ b/test/utils/relationship-utils.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for relationship utility functions
+ */
+import { 
+  RelationshipType,
+  createPeopleByCompanyFilter,
+  createCompaniesByPeopleFilter,
+  createRecordsByListFilter,
+  createPeopleByCompanyListFilter,
+  createCompaniesByPeopleListFilter,
+  createRecordsByNotesFilter
+} from '../../src/utils/relationship-utils';
+import { ResourceType, FilterConditionType } from '../../src/types/attio';
+import { ListEntryFilters } from '../../src/api/attio-operations';
+import { FilterValidationError } from '../../src/errors/api-errors';
+
+describe('Relationship Utilities', () => {
+  describe('createPeopleByCompanyFilter', () => {
+    it('should create a valid relationship filter for people by company', () => {
+      // Create a sample company filter
+      const companyFilter: ListEntryFilters = {
+        filters: [
+          {
+            attribute: { slug: 'industry' },
+            condition: FilterConditionType.EQUALS,
+            value: 'Technology'
+          }
+        ],
+        matchAny: false
+      };
+      
+      // Generate the relationship filter
+      const result = createPeopleByCompanyFilter(companyFilter);
+      
+      // Verify the structure
+      expect(result).toBeDefined();
+      expect(result.filters).toHaveLength(1);
+      
+      const relationshipFilter = result.filters[0];
+      expect(relationshipFilter.attribute.slug).toBe('$relationship');
+      expect(relationshipFilter.condition).toBe(FilterConditionType.EQUALS);
+      
+      // Check the relationship configuration
+      const relationshipValue = relationshipFilter.value as any;
+      expect(relationshipValue.type).toBe(RelationshipType.WORKS_AT);
+      expect(relationshipValue.target.object).toBe('companies');
+      expect(relationshipValue.target.filter).toEqual(companyFilter);
+    });
+    
+    it('should throw an error if company filter is invalid', () => {
+      // Test with an empty filter
+      const emptyFilter = { filters: [] };
+      
+      // Expect it to throw a FilterValidationError
+      expect(() => createPeopleByCompanyFilter(emptyFilter)).toThrow(FilterValidationError);
+    });
+  });
+  
+  describe('createCompaniesByPeopleFilter', () => {
+    it('should create a valid relationship filter for companies by people', () => {
+      // Create a sample people filter
+      const peopleFilter: ListEntryFilters = {
+        filters: [
+          {
+            attribute: { slug: 'job_title' },
+            condition: FilterConditionType.CONTAINS,
+            value: 'Engineer'
+          }
+        ],
+        matchAny: false
+      };
+      
+      // Generate the relationship filter
+      const result = createCompaniesByPeopleFilter(peopleFilter);
+      
+      // Verify the structure
+      expect(result).toBeDefined();
+      expect(result.filters).toHaveLength(1);
+      
+      const relationshipFilter = result.filters[0];
+      expect(relationshipFilter.attribute.slug).toBe('$relationship');
+      expect(relationshipFilter.condition).toBe(FilterConditionType.EQUALS);
+      
+      // Check the relationship configuration
+      const relationshipValue = relationshipFilter.value as any;
+      expect(relationshipValue.type).toBe(RelationshipType.EMPLOYS);
+      expect(relationshipValue.target.object).toBe('people');
+      expect(relationshipValue.target.filter).toEqual(peopleFilter);
+    });
+    
+    it('should throw an error if people filter is invalid', () => {
+      // Test with an empty filter
+      const emptyFilter = { filters: [] };
+      
+      // Expect it to throw a FilterValidationError
+      expect(() => createCompaniesByPeopleFilter(emptyFilter)).toThrow(FilterValidationError);
+    });
+  });
+  
+  describe('createRecordsByListFilter', () => {
+    it('should create a valid filter for records by list ID', () => {
+      const listId = 'list_abc123';
+      const resourceType = ResourceType.PEOPLE;
+      
+      // Generate the relationship filter
+      const result = createRecordsByListFilter(resourceType, listId);
+      
+      // Verify the structure
+      expect(result).toBeDefined();
+      expect(result.filters).toHaveLength(1);
+      
+      const relationshipFilter = result.filters[0];
+      expect(relationshipFilter.attribute.slug).toBe('$relationship');
+      expect(relationshipFilter.condition).toBe(FilterConditionType.EQUALS);
+      
+      // Check the relationship configuration
+      const relationshipValue = relationshipFilter.value as any;
+      expect(relationshipValue.type).toBe(RelationshipType.BELONGS_TO_LIST);
+      expect(relationshipValue.target.object).toBe('lists');
+      
+      // Check the target filter (should be an equals filter on list_id)
+      const targetFilter = relationshipValue.target.filter;
+      expect(targetFilter.filters).toHaveLength(1);
+      expect(targetFilter.filters[0].attribute.slug).toBe('list_id');
+      expect(targetFilter.filters[0].condition).toBe(FilterConditionType.EQUALS);
+      expect(targetFilter.filters[0].value).toBe(listId);
+    });
+    
+    it('should throw an error if list ID is empty', () => {
+      // Test with an empty list ID
+      const emptyListId = '';
+      const resourceType = ResourceType.PEOPLE;
+      
+      // Expect it to throw a FilterValidationError
+      expect(() => createRecordsByListFilter(resourceType, emptyListId)).toThrow(FilterValidationError);
+    });
+  });
+  
+  describe('createPeopleByCompanyListFilter', () => {
+    it('should create a valid filter for people by company list', () => {
+      const listId = 'list_abc123';
+      
+      // Generate the relationship filter
+      const result = createPeopleByCompanyListFilter(listId);
+      
+      // Verify the structure is a nested relationship filter
+      expect(result).toBeDefined();
+      expect(result.filters).toHaveLength(1);
+      
+      const relationshipFilter = result.filters[0];
+      expect(relationshipFilter.attribute.slug).toBe('$relationship');
+      expect(relationshipFilter.condition).toBe(FilterConditionType.EQUALS);
+      
+      // Check the relationship configuration (people who work at companies)
+      const relationshipValue = relationshipFilter.value as any;
+      expect(relationshipValue.type).toBe(RelationshipType.WORKS_AT);
+      expect(relationshipValue.target.object).toBe('companies');
+      
+      // Check that the target filter is another relationship filter (companies in list)
+      const targetFilter = relationshipValue.target.filter;
+      expect(targetFilter.filters).toHaveLength(1);
+      expect(targetFilter.filters[0].attribute.slug).toBe('$relationship');
+      
+      // Check the nested relationship (company belongs to list)
+      const nestedRelationship = targetFilter.filters[0].value as any;
+      expect(nestedRelationship.type).toBe(RelationshipType.BELONGS_TO_LIST);
+      expect(nestedRelationship.target.object).toBe('lists');
+      
+      // Check the list ID filter
+      const listFilter = nestedRelationship.target.filter;
+      expect(listFilter.filters[0].attribute.slug).toBe('list_id');
+      expect(listFilter.filters[0].value).toBe(listId);
+    });
+    
+    it('should throw an error if list ID is empty', () => {
+      // Test with an empty list ID
+      const emptyListId = '';
+      
+      // Expect it to throw a FilterValidationError
+      expect(() => createPeopleByCompanyListFilter(emptyListId)).toThrow(FilterValidationError);
+    });
+  });
+  
+  describe('createCompaniesByPeopleListFilter', () => {
+    it('should create a valid filter for companies by people list', () => {
+      const listId = 'list_xyz789';
+      
+      // Generate the relationship filter
+      const result = createCompaniesByPeopleListFilter(listId);
+      
+      // Verify the structure is a nested relationship filter
+      expect(result).toBeDefined();
+      expect(result.filters).toHaveLength(1);
+      
+      const relationshipFilter = result.filters[0];
+      expect(relationshipFilter.attribute.slug).toBe('$relationship');
+      expect(relationshipFilter.condition).toBe(FilterConditionType.EQUALS);
+      
+      // Check the relationship configuration (companies that employ people)
+      const relationshipValue = relationshipFilter.value as any;
+      expect(relationshipValue.type).toBe(RelationshipType.EMPLOYS);
+      expect(relationshipValue.target.object).toBe('people');
+      
+      // Check that the target filter is another relationship filter (people in list)
+      const targetFilter = relationshipValue.target.filter;
+      expect(targetFilter.filters).toHaveLength(1);
+      expect(targetFilter.filters[0].attribute.slug).toBe('$relationship');
+      
+      // Check the nested relationship (person belongs to list)
+      const nestedRelationship = targetFilter.filters[0].value as any;
+      expect(nestedRelationship.type).toBe(RelationshipType.BELONGS_TO_LIST);
+      expect(nestedRelationship.target.object).toBe('lists');
+      
+      // Check the list ID filter
+      const listFilter = nestedRelationship.target.filter;
+      expect(listFilter.filters[0].attribute.slug).toBe('list_id');
+      expect(listFilter.filters[0].value).toBe(listId);
+    });
+    
+    it('should throw an error if list ID is empty', () => {
+      // Test with an empty list ID
+      const emptyListId = '';
+      
+      // Expect it to throw a FilterValidationError
+      expect(() => createCompaniesByPeopleListFilter(emptyListId)).toThrow(FilterValidationError);
+    });
+  });
+  
+  describe('createRecordsByNotesFilter', () => {
+    it('should create a valid filter for records by note content', () => {
+      const searchText = 'follow up next quarter';
+      const resourceType = ResourceType.PEOPLE;
+      
+      // Generate the relationship filter
+      const result = createRecordsByNotesFilter(resourceType, searchText);
+      
+      // Verify the structure
+      expect(result).toBeDefined();
+      expect(result.filters).toHaveLength(1);
+      
+      const relationshipFilter = result.filters[0];
+      expect(relationshipFilter.attribute.slug).toBe('$relationship');
+      expect(relationshipFilter.condition).toBe(FilterConditionType.EQUALS);
+      
+      // Check the relationship configuration
+      const relationshipValue = relationshipFilter.value as any;
+      expect(relationshipValue.type).toBe(RelationshipType.HAS_NOTE);
+      
+      // Check the note content filter
+      const noteFilter = relationshipValue.target.filter;
+      expect(noteFilter.filters).toHaveLength(1);
+      expect(noteFilter.filters[0].attribute.slug).toBe('note_content');
+      expect(noteFilter.filters[0].condition).toBe(FilterConditionType.CONTAINS);
+      expect(noteFilter.filters[0].value).toBe(searchText);
+    });
+    
+    it('should throw an error if search text is empty', () => {
+      // Test with an empty search text
+      const emptySearchText = '';
+      const resourceType = ResourceType.PEOPLE;
+      
+      // Expect it to throw a FilterValidationError
+      expect(() => createRecordsByNotesFilter(resourceType, emptySearchText)).toThrow(FilterValidationError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements comprehensive relationship-based filtering capabilities for the Attio MCP server
- Allows searching for records based on their relationships with other records
- Enables finding people by company attributes, companies by people attributes, and records by list membership and note content

## Implementation Details
- Created a new `relationship-utils.ts` module with filtering utility functions
- Added support for filtering people by company attributes and companies by people attributes
- Implemented filtering based on list membership, enabling queries for people working at companies in a list
- Added note content filtering to find records with notes containing specific text
- Exposed all relationship filtering capabilities as MCP tools for Claude integration
- Added comprehensive documentation with examples and use cases
- Added unit tests for all relationship filtering functions

## Features
- Filter people by company attributes (industry, size, etc.)
- Filter companies by people attributes (job title, location, etc.)
- Find people working at companies in a specific list
- Find companies with employees in a specific list
- Search for records with notes containing specific text
- Combine relationship filters with other filtering capabilities for powerful queries

## Test Plan
- Run unit tests for relationship utilities: `npm test test/utils/relationship-utils.test.ts`
- Test the MCP tools for relationship filtering using Claude Desktop