### PR TITLE
[HOTFIX] Fix B2B segment attribute mapping import path

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1060,7 +1060,7 @@ export function registerToolHandlers(server: Server): void {
         }
         
         // Import the attribute mapping utility
-        const { translateAttributeNamesInFilters } = await import("../utils/attribute-mapping.js");
+        const { translateAttributeNamesInFilters } = await import("../utils/attribute-mapping/index.js");
         
         // Translate any human-readable attribute names to their slug equivalents
         // Pass resourceType for object-specific mappings


### PR DESCRIPTION
## Summary
- Fixed critical attribute mapping import path issue
- Resolves 'Unknown attribute slug: b2b_segment' error

## Problem
The attribute mapping system was failing to translate user-defined attributes (like b2b_segment → type_persona) because of an incorrect import path in tools.ts.

## Solution
Changed the import path from:
```javascript
const { translateAttributeNamesInFilters } = await import("../utils/attribute-mapping.js");
```

To:
```javascript
const { translateAttributeNamesInFilters } = await import("../utils/attribute-mapping/index.js");
```

## Impact
- Minimal change with focused impact
- Enables proper attribute translation for all user-defined mappings
- Fixes the immediate issue reported by the user

## Testing
Confirmed that the b2b_segment attribute now correctly translates to type_persona and queries execute successfully.

## Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)
- 🔥 Hot fix (critical production issue)