### PR TITLE
Fix: Resolve search-people display issues

### DIFF
--- a/src/handlers/tool-configs/people.ts
+++ b/src/handlers/tool-configs/people.ts
@@ -9,6 +9,24 @@ import {
   ActivityFilter,
   Person
 } from "../../types/attio.js";
+
+/**
+ * Utility function to safely extract a person's name from Attio record format.
+ * Tries multiple potential paths to find a valid name.
+ * 
+ * @param person - The person record from Attio API
+ * @returns The person's name or 'Unnamed' if not found
+ */
+function getPersonName(person: any): string {
+  // Try multiple potential paths to find a name
+  return person.values?.name?.[0]?.full_name || 
+         person.values?.name?.[0]?.value || 
+         person.values?.name?.[0]?.formatted || 
+         person.values?.full_name?.[0]?.value ||
+         person.attributes?.name?.value ||
+         'Unnamed';
+}
+
 import {
   searchPeople,
   searchPeopleByEmail,
@@ -42,24 +60,24 @@ export const peopleToolConfigs = {
     name: "search-people",
     handler: searchPeople,
     formatResult: (results: AttioRecord[]) => {
-      return `Found ${results.length} people:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+      return results.map((person: any) => 
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'})`).join('\n');
     }
   } as SearchToolConfig,
   searchByEmail: {
     name: "search-people-by-email",
     handler: searchPeopleByEmail,
     formatResult: (results: AttioRecord[]) => {
-      return `Found ${results.length} people with the specified email:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+      return results.map((person: any) => 
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'})`).join('\n');
     }
   } as SearchToolConfig,
   searchByPhone: {
     name: "search-people-by-phone",
     handler: searchPeopleByPhone,
     formatResult: (results: AttioRecord[]) => {
-      return `Found ${results.length} people with the specified phone number:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+      return results.map((person: any) => 
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'})`).join('\n');
     }
   } as SearchToolConfig,
   advancedSearch: {
@@ -67,8 +85,8 @@ export const peopleToolConfigs = {
     handler: advancedSearchPeople,
     formatResult: (response: any) => {
       const results = response.results || response;
-      return `Found ${results.length} people with specified filters:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+      return results.map((person: any) => 
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'})`).join('\n');
     }
   } as any,
   details: {
@@ -105,11 +123,11 @@ export const peopleToolConfigs = {
       // Contact information section
       const contactInfo = [];
       if (person.values.email_addresses?.length) {
-        contactInfo.push(`Email: ${person.values.email_addresses.map((e: AttioValue<string>) => 
+        contactInfo.push(`Email: ${person.values.email_addresses.map((e: any) => 
           e.email_address || e.value || 'N/A').join(', ')}`);
       }
       if (person.values.phone_numbers?.length) {
-        contactInfo.push(`Phone: ${person.values.phone_numbers.map((p: AttioValue<string>) => 
+        contactInfo.push(`Phone: ${person.values.phone_numbers.map((p: any) => 
           p.phone_number || p.value || 'N/A').join(', ')}`);
       }
       if (contactInfo.length) {
@@ -138,7 +156,7 @@ export const peopleToolConfigs = {
         
         if (Array.isArray(values) && values.length > 0) {
           // Format different value types appropriately
-          const formattedValues = values.map((v: AttioValue<unknown>) => {
+          const formattedValues = values.map((v: any) => {
             if (v.value === undefined) return 'N/A';
             if (typeof v.value === 'object') return JSON.stringify(v.value);
             return String(v.value);
@@ -193,7 +211,7 @@ export const peopleToolConfigs = {
     handler: searchPeopleByCreationDate,
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} people created in the specified date range:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'}, Created: ${person.values?.created_at || 'unknown'})`).join('\n')}`;
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'}, Created: ${person.values?.created_at || 'unknown'})`).join('\n')}`;
     }
   } as DateBasedSearchToolConfig,
   
@@ -202,7 +220,7 @@ export const peopleToolConfigs = {
     handler: searchPeopleByModificationDate,
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} people modified in the specified date range:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'}, Modified: ${person.values?.updated_at || 'unknown'})`).join('\n')}`;
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'}, Modified: ${person.values?.updated_at || 'unknown'})`).join('\n')}`;
     }
   } as DateBasedSearchToolConfig,
   
@@ -211,7 +229,7 @@ export const peopleToolConfigs = {
     handler: searchPeopleByLastInteraction,
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} people with interactions in the specified date range:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'}, Last Interaction: ${person.values?.last_interaction?.interacted_at || 'unknown'})`).join('\n')}`;
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'}, Last Interaction: ${person.values?.last_interaction?.interacted_at || 'unknown'})`).join('\n')}`;
     }
   } as DateBasedSearchToolConfig,
   
@@ -220,7 +238,7 @@ export const peopleToolConfigs = {
     handler: searchPeopleByActivity,
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} people with matching activity:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'}, Last Interaction: ${person.values?.last_interaction?.interacted_at || 'unknown'})`).join('\n')}`;
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'}, Last Interaction: ${person.values?.last_interaction?.interacted_at || 'unknown'})`).join('\n')}`;
     }
   } as DateBasedSearchToolConfig,
 
@@ -317,7 +335,7 @@ export const peopleToolConfigs = {
     },
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} people matching the company filter:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.full_name || person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
     }
   } as any,
 
@@ -326,7 +344,7 @@ export const peopleToolConfigs = {
     handler: searchPeopleByCompanyList,
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} people who work at companies in the specified list:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
     }
   } as any,
 
@@ -335,7 +353,7 @@ export const peopleToolConfigs = {
     handler: searchPeopleByNotes,
     formatResult: (results: AttioRecord[]) => {
       return `Found ${results.length} people with matching notes:\n${results.map((person: any) => 
-        `- ${person.values?.name?.[0]?.value || 'Unnamed'} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
+        `- ${getPersonName(person)} (ID: ${person.id?.record_id || 'unknown'})`).join('\n')}`;
     }
   } as SearchToolConfig
 };


### PR DESCRIPTION
This PR fixes two issues with the search-people tool:

1. Duplicate 'Found X people:' headers in search results output
   - Modified dispatcher.ts to check if formatters already include headers
   - Updated people formatters to only return list items, letting dispatcher add headers

2. People names incorrectly showing as 'Unnamed' instead of actual names
   - Added robust getPersonName utility function to extract names from various paths
   - Enhanced name extraction to check multiple potential paths where names could be stored
   - Updated all people-related formatters to use the new utility function

This ensures search results display names correctly and without duplicate headers.

Fixes #146