### PR TITLE
Add debugging for batch-create-companies issue

### DIFF
--- a/src/handlers/tools/dispatcher.ts
+++ b/src/handlers/tools/dispatcher.ts
@@ -575,6 +575,12 @@ export async function executeToolRequest(request: CallToolRequest) {
                     operation === 'create' ? 'batch-create-companies' : 'batch-update-companies', 
                     request);
       
+      // Enhanced debugging
+      console.log(`[handleCompanyBatchOperation:${operation}] Debug info:`);
+      console.log('- Parameter name:', paramName);
+      console.log('- Request arguments:', JSON.stringify(request.params.arguments, null, 2));
+      console.log('- Arguments has paramName:', request.params.arguments && paramName in request.params.arguments);
+      
       // Extract and validate parameters
       const records = request.params.arguments?.[paramName] || [];
       
@@ -660,6 +666,10 @@ export async function executeToolRequest(request: CallToolRequest) {
           config: request.params.arguments?.config
         };
         
+        // Debug the params object
+        console.log(`[handleCompanyBatchOperation:${operation}] Calling handler with params:`, JSON.stringify(params, null, 2));
+        console.log('- Handler function:', toolConfig.handler.name || 'anonymous');
+        
         const result = await toolConfig.handler(params);
         return formatResponse(formatBatchResults(result, operation), result.summary.failed > 0);
       } catch (error) {
@@ -683,6 +693,14 @@ export async function executeToolRequest(request: CallToolRequest) {
     
     // Handle specific batch operations for companies
     if (toolType === 'batchCreate' && toolName === 'batch-create-companies') {
+      // Add extra debugging
+      console.log('[batch-create-companies] Debug:');
+      console.log('- Request arguments:', JSON.stringify(request.params.arguments, null, 2));
+      console.log('- Tool type:', toolType);
+      console.log('- Tool name:', toolName);
+      console.log('- Tool config exists:', !!toolConfig);
+      console.log('- Handler exists:', toolConfig && typeof toolConfig.handler === 'function');
+      
       return await handleCompanyBatchOperation('create', request, toolConfig);
     }
     

--- a/src/objects/batch-companies.ts
+++ b/src/objects/batch-companies.ts
@@ -120,15 +120,24 @@ async function executeBatchCompanyOperation<T, R>(
 export async function batchCreateCompanies(
   params: { companies: RecordAttributes[], config?: Partial<BatchConfig> }
 ): Promise<BatchResponse<Company>> {
+  // Debug logging for incoming parameters
+  console.log('[batchCreateCompanies] Received params:', JSON.stringify(params, null, 2));
+  console.log('[batchCreateCompanies] Params type:', typeof params);
+  console.log('[batchCreateCompanies] Is array?', Array.isArray(params));
+  
   // Early validation of parameters - fail fast
   if (!params) {
+    console.log('[batchCreateCompanies] Error: params object is required');
     throw new Error("Invalid request: params object is required");
   }
   
   // Extract and validate companies array
   const { companies, config: batchConfig } = params;
   
+  console.log('[batchCreateCompanies] Extracted companies:', companies ? `Array of ${Array.isArray(companies) ? companies.length : 'non-array'}` : 'undefined');
+  
   if (!companies) {
+    console.log('[batchCreateCompanies] Error: companies parameter is required');
     throw new Error("Invalid request: 'companies' parameter is required");
   }
   


### PR DESCRIPTION
## Summary
- Added extensive debugging to identify why batch-create-companies is still failing 
- Logging request parameters and execution flow in key functions
- Includes detailed console logging of parameter structure to identify the root cause
- This PR is temporary for debugging purposes and should be reverted or have debugging removed after the issue is resolved

## Steps to reproduce the issue
1. Try to use the batch-create-companies tool with the following request:
```
{
  "companies": [
    {
      "name": "Test Company Alpha",
      "website": "https://alpha-test.example.com",
      "industry": "Technology",
      "description": "This is a test company for batch creation"
    },
    {
      "name": "Test Company Beta",
      "website": "https://beta-test.example.com",
      "industry": "Healthcare",
      "description": "Another test company for batch operations"
    }
  ]
}
```

2. Observe the error: "Invalid request: 'companies' parameter is required"

The debugging info will help identify why this error is occurring.
