### PR TITLE
Fix: Implement get-company-json tool handler in dispatcher

### DIFF
--- a/test/manual/test-get-company-json.js
+++ b/test/manual/test-get-company-json.js
@@ -1,0 +1,52 @@
+/**
+ * Manual test for the get-company-json tool
+ * 
+ * This file tests the get-company-json tool which previously had an issue with
+ * the tool handler not being implemented for the 'json' tool type.
+ */
+const { executeToolRequest } = require('../../dist/handlers/tools/dispatcher');
+
+// Sample company ID for testing
+const COMPANY_ID = 'test-company-id';
+
+// Create a test request for get-company-json
+const request = {
+  params: {
+    name: 'get-company-json',
+    arguments: {
+      companyId: COMPANY_ID
+    }
+  },
+  method: 'tools/call'
+};
+
+async function runTest() {
+  try {
+    console.log('Testing get-company-json tool...');
+    console.log('Request:', JSON.stringify(request, null, 2));
+    
+    // Execute the tool request
+    const result = await executeToolRequest(request);
+    
+    console.log('Result:', JSON.stringify(result, null, 2));
+    console.log('Test completed successfully');
+    
+    // Check if the result has an error
+    if (result.isError) {
+      console.error('Test failed: Tool returned an error:', result.error);
+      process.exit(1);
+    }
+    
+    console.log('Test passed: get-company-json tool executed successfully');
+  } catch (error) {
+    console.error('Test failed with error:', error);
+    process.exit(1);
+  }
+}
+
+// Only run if executed directly
+if (require.main === module) {
+  runTest();
+}
+
+module.exports = { runTest };

--- a/test/manual/test-get-company-json.js
+++ b/test/manual/test-get-company-json.js
@@ -3,14 +3,18 @@
  * 
  * This file tests the get-company-json tool which previously had an issue with
  * the tool handler not being implemented for the 'json' tool type.
+ * 
+ * The test includes:
+ * 1. A valid request with companyId to verify success case
+ * 2. A request with missing companyId to verify error handling
  */
 const { executeToolRequest } = require('../../dist/handlers/tools/dispatcher');
 
 // Sample company ID for testing
 const COMPANY_ID = 'test-company-id';
 
-// Create a test request for get-company-json
-const request = {
+// Test case 1: Valid request with companyId
+const validRequest = {
   params: {
     name: 'get-company-json',
     arguments: {
@@ -20,26 +24,88 @@ const request = {
   method: 'tools/call'
 };
 
-async function runTest() {
+// Test case 2: Invalid request missing companyId
+const invalidRequest = {
+  params: {
+    name: 'get-company-json',
+    arguments: {}
+  },
+  method: 'tools/call'
+};
+
+async function testValidRequest() {
+  console.log('=== TEST CASE 1: Valid Request ===');
+  console.log('Testing get-company-json tool with valid companyId...');
+  console.log('Request:', JSON.stringify(validRequest, null, 2));
+  
   try {
-    console.log('Testing get-company-json tool...');
-    console.log('Request:', JSON.stringify(request, null, 2));
-    
     // Execute the tool request
-    const result = await executeToolRequest(request);
+    const result = await executeToolRequest(validRequest);
     
     console.log('Result:', JSON.stringify(result, null, 2));
-    console.log('Test completed successfully');
     
     // Check if the result has an error
     if (result.isError) {
-      console.error('Test failed: Tool returned an error:', result.error);
-      process.exit(1);
+      console.error('❌ Test failed: Tool returned an error:', result.error);
+      return false;
     }
     
-    console.log('Test passed: get-company-json tool executed successfully');
+    console.log('✅ Test passed: get-company-json tool executed successfully with valid request');
+    return true;
   } catch (error) {
-    console.error('Test failed with error:', error);
+    console.error('❌ Test failed with error:', error);
+    return false;
+  }
+}
+
+async function testInvalidRequest() {
+  console.log('\n=== TEST CASE 2: Invalid Request (Missing companyId) ===');
+  console.log('Testing get-company-json tool with missing companyId...');
+  console.log('Request:', JSON.stringify(invalidRequest, null, 2));
+  
+  try {
+    // Execute the tool request
+    const result = await executeToolRequest(invalidRequest);
+    
+    console.log('Result:', JSON.stringify(result, null, 2));
+    
+    // For the invalid request, we expect an error
+    if (result.isError) {
+      if (result.error?.message?.includes('companyId parameter is required')) {
+        console.log('✅ Test passed: Tool correctly returned an error for missing companyId');
+        return true;
+      } else {
+        console.error('❌ Test failed: Tool returned an error, but not the expected one:', result.error);
+        return false;
+      }
+    }
+    
+    console.error('❌ Test failed: Tool did not return an error for missing companyId');
+    return false;
+  } catch (error) {
+    console.error('❌ Test failed with unexpected error:', error);
+    return false;
+  }
+}
+
+async function runTest() {
+  try {
+    console.log('Starting tests for get-company-json tool...');
+    
+    // Run all test cases
+    const validResult = await testValidRequest();
+    const invalidResult = await testInvalidRequest();
+    
+    // Summary
+    console.log('\n=== TEST SUMMARY ===');
+    if (validResult && invalidResult) {
+      console.log('✅ All tests passed!');
+    } else {
+      console.log('❌ Some tests failed.');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('Tests failed with error:', error);
     process.exit(1);
   }
 }
@@ -49,4 +115,4 @@ if (require.main === module) {
   runTest();
 }
 
-module.exports = { runTest };
+module.exports = { runTest, testValidRequest, testInvalidRequest };


### PR DESCRIPTION
## Summary
- Fixes the missing implementation for get-company-json tool handler
- Adds explicit handling for the 'json' tool type in the dispatcher
- Creates a manual test to verify the fix works correctly

## Problem
Users were getting 'Tool handler not implemented for tool type: json' error when trying to use get-company-json. This happened because while the tool was properly defined in formatters.ts, it was missing proper handling in the main dispatcher flow.

## Fix Implementation
1. Added explicit handling for the 'json' tool type in the dispatcher.ts file
2. Implemented proper validation of the companyId parameter
3. Added execution of the tool's handler function with formatted results
4. Included debug logging in development mode to aid future troubleshooting
5. Created comprehensive error handling for the tool

## Test Implementation
Added a manual test file at test/manual/test-get-company-json.js that:
- Creates a sample request for the get-company-json tool
- Executes it through the dispatcher
- Verifies that no error is returned
- Reports success/failure appropriately

## Technical Notes
- The issue was that while a 'json' section existed in the dispatcher code, it wasn't being reached in the control flow
- This fix adds an explicit condition to handle the 'json' tool type before the unsupported tool type error is thrown
- The implementation leverages the existing formatResult function from the tool config for consistent output

Resolves #144