### PR TITLE
Fix: Add proper handler for get-list-details MCP tool

### DIFF
--- a/docs/development/FIX-GET-LIST-DETAILS-TOOL-179.md
+++ b/docs/development/FIX-GET-LIST-DETAILS-TOOL-179.md
@@ -1,0 +1,36 @@
+# Fix for get-list-details Tool (Issue #179)
+
+## Issue Summary
+
+The `get-list-details` tool was failing when used through the MCP server. It returned an API error instead of the expected list details due to a missing tool type handler in the dispatcher.
+
+## Root Cause Analysis
+
+1. The MCP tool named `get-list-details` has its handler and definition properly set up in `src/handlers/tool-configs/lists.ts`.
+2. The function `getListDetails` in `src/objects/lists.ts` that actually retrieves the list details works correctly.
+3. However, the dispatcher code in `src/handlers/tools/dispatcher.ts` was missing specific handling for the `getListDetails` tool type.
+4. Additionally, the tool configuration did not include a `formatResult` function to format the Attio API response into a readable format.
+
+## Fix Implementation
+
+1. Added a dedicated tool type handler in `src/handlers/tools/dispatcher.ts` for the `getListDetails` tool type:
+   - Implemented proper argument validation for the required `listId` parameter
+   - Added proper error handling and formatted error responses
+   - Invoked the handler with the correct parameters
+   - Used the `formatResult` function from the tool config if present
+
+2. Added a `formatResult` function to the `getListDetails` tool configuration in `src/handlers/tool-configs/lists.ts`:
+   - Properly extracts the list ID, name, and other details
+   - Formats the response into a readable format with list details
+   - Handles potential missing fields gracefully
+
+## Testing
+
+1. Created a test script to verify the fix:
+   - `scripts/test-get-list-details.js` to test the MCP tool invocation directly
+   - Confirmed that the tool now returns formatted list details instead of an error
+   - Verified that missing or invalid `listId` parameters are handled appropriately
+
+## Conclusion
+
+The fix ensures the `get-list-details` tool works correctly through the MCP server. It now returns properly formatted list details when provided with a valid list ID, and returns appropriate error messages for invalid inputs.

--- a/scripts/test-get-list-details.js
+++ b/scripts/test-get-list-details.js
@@ -1,0 +1,67 @@
+/**
+ * Quick test for the get-list-details tool to verify our fix
+ */
+
+const dispatcher = require('../build/handlers/tools/dispatcher.js');
+const registry = require('../build/handlers/tools/registry.js');
+const attioClient = require('../build/api/attio-client.js');
+const dotenv = require('dotenv');
+
+// Load environment variables
+dotenv.config();
+
+// Initialize the Attio client with the API key from environment variables
+const apiKey = process.env.ATTIO_API_KEY;
+
+if (!apiKey) {
+  console.error('ERROR: You must set ATTIO_API_KEY environment variable to run this test');
+  process.exit(1);
+}
+
+// Initialize the API client
+attioClient.initializeAttioClient(apiKey);
+
+// Create a test function to run the test
+async function testGetListDetails() {
+  try {
+    // Test with a sample list ID - replace with a valid list ID if you have one
+    // You can create a list in Attio or use an existing one
+    const listId = process.argv[2]; // Take list ID from command line argument
+    
+    if (!listId) {
+      console.error('Please provide a list ID as a command line argument');
+      console.error('Usage: node test-get-list-details.js <list-id>');
+      process.exit(1);
+    }
+    
+    console.log(`Getting details for list with ID: ${listId}`);
+    
+    // Create a mock request to test the tool
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: listId
+        }
+      }
+    };
+    
+    // Execute the request through the dispatcher
+    const response = await dispatcher.executeToolRequest(mockRequest);
+    
+    console.log("Response:", JSON.stringify(response, null, 2));
+    
+    // Check if we got an error
+    if (response.isError) {
+      console.error("ERROR:", response.error);
+      if (response.error.details) {
+        console.error("Details:", response.error.details);
+      }
+    }
+  } catch (error) {
+    console.error('Unexpected error:', error);
+  }
+}
+
+// Run the test
+testGetListDetails().catch(console.error);

--- a/src/handlers/tool-configs/lists.ts
+++ b/src/handlers/tool-configs/lists.ts
@@ -39,8 +39,9 @@ export const listsToolConfigs = {
       const listName = result.name || result.title || 'Unnamed List';
       const objectType = result.object_slug || 'unknown';
       const entryCount = result.entry_count !== undefined ? `${result.entry_count} entries` : 'Unknown entry count';
-      const createdAt = result.created_at ? new Date(result.created_at).toLocaleDateString() : 'Unknown date';
-      const updatedAt = result.updated_at ? new Date(result.updated_at).toLocaleDateString() : 'Unknown date';
+      // Format dates in ISO format for consistency across environments
+      const createdAt = result.created_at ? new Date(result.created_at).toISOString().split('T')[0] : 'Unknown date';
+      const updatedAt = result.updated_at ? new Date(result.updated_at).toISOString().split('T')[0] : 'Unknown date';
       
       return `List Details:
 ID: ${listId}

--- a/src/handlers/tool-configs/lists.ts
+++ b/src/handlers/tool-configs/lists.ts
@@ -33,6 +33,24 @@ export const listsToolConfigs = {
   getListDetails: {
     name: "get-list-details",
     handler: getListDetails,
+    formatResult: (result: AttioList) => {
+      // Extract list_id properly from id object
+      const listId = result.id?.list_id || result.id || 'unknown';
+      const listName = result.name || result.title || 'Unnamed List';
+      const objectType = result.object_slug || 'unknown';
+      const entryCount = result.entry_count !== undefined ? `${result.entry_count} entries` : 'Unknown entry count';
+      const createdAt = result.created_at ? new Date(result.created_at).toLocaleDateString() : 'Unknown date';
+      const updatedAt = result.updated_at ? new Date(result.updated_at).toLocaleDateString() : 'Unknown date';
+      
+      return `List Details:
+ID: ${listId}
+Name: ${listName}
+Object Type: ${objectType}
+${entryCount}
+Created: ${createdAt}
+Updated: ${updatedAt}
+${result.description ? `\nDescription: ${result.description}` : ''}`;
+    }
   } as ToolConfig,
   getListEntries: {
     name: "get-list-entries",

--- a/src/handlers/tools/dispatcher.ts
+++ b/src/handlers/tools/dispatcher.ts
@@ -431,13 +431,24 @@ export async function executeToolRequest(request: CallToolRequest) {
       }
     }
     
-    // Handle getListDetails tool
+    /**
+     * Handle getListDetails tool
+     * 
+     * This handler processes requests for the get-list-details tool, which retrieves
+     * information about a specific Attio list by ID.
+     * 
+     * The handler:
+     * 1. Validates the required listId parameter
+     * 2. Calls the getListDetails function with the list ID
+     * 3. Formats the response using the tool's formatResult function
+     * 4. Handles API errors with proper error formatting
+     */
     if (toolType === 'getListDetails') {
       const listId = request.params.arguments?.listId as string;
       
       if (!listId) {
         return createErrorResult(
-          new Error("listId parameter is required"),
+          new Error("Missing required parameter: listId"),
           "/lists/details",
           "GET",
           { status: 400, message: "Missing required parameter: listId" }

--- a/src/handlers/tools/dispatcher.ts
+++ b/src/handlers/tools/dispatcher.ts
@@ -431,6 +431,37 @@ export async function executeToolRequest(request: CallToolRequest) {
       }
     }
     
+    // Handle getListDetails tool
+    if (toolType === 'getListDetails') {
+      const listId = request.params.arguments?.listId as string;
+      
+      if (!listId) {
+        return createErrorResult(
+          new Error("listId parameter is required"),
+          "/lists/details",
+          "GET",
+          { status: 400, message: "Missing required parameter: listId" }
+        );
+      }
+      
+      try {
+        const result = await toolConfig.handler(listId);
+        // Format the result
+        const formattedResult = toolConfig.formatResult 
+          ? toolConfig.formatResult(result)
+          : JSON.stringify(result, null, 2);
+        
+        return formatResponse(formattedResult);
+      } catch (error) {
+        return createErrorResult(
+          error instanceof Error ? error : new Error("Unknown error"),
+          `/lists/${listId}`,
+          "GET",
+          hasResponseData(error) ? error.response.data : {}
+        );
+      }
+    }
+    
     // Handle getListEntries tool
     if (toolType === 'getListEntries') {
       const listId = request.params.arguments?.listId as string;

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,100 @@
+# Tests for Attio MCP Server
+
+This directory contains various tests for the Attio MCP Server project.
+
+## Test Structure
+
+The tests are organized as follows:
+
+- `api/`: Tests that interact with the Attio API directly
+- `handlers/`: Unit tests for tool handler functions
+- `integration/`: Integration tests using mock API responses
+- `manual/`: Manual test scripts for development and debugging
+- `utils/`: Tests for utility functions
+
+## Running Tests
+
+### Unit and Integration Tests
+
+Run all tests with Jest:
+
+```bash
+npm test
+```
+
+Run a specific test file:
+
+```bash
+npm test -- path/to/test/file.test.ts
+```
+
+For example, to run only the list details tests:
+
+```bash
+npm test -- handlers/tools.list-details.test.ts
+```
+
+### API Integration Tests
+
+The API tests require an Attio API key. To run these tests:
+
+1. Set your Attio API key:
+
+```bash
+export ATTIO_API_KEY=your_api_key_here
+```
+
+2. Optionally, set a specific test list ID:
+
+```bash
+export TEST_LIST_ID=your_test_list_id
+```
+
+3. Run the API tests:
+
+```bash
+npm test -- api/list-details.api.test.ts
+```
+
+To skip integration tests that require an API key:
+
+```bash
+export SKIP_INTEGRATION_TESTS=true
+npm test
+```
+
+### Manual Test Scripts
+
+For manual testing and debugging, use the scripts in the `manual/` directory:
+
+```bash
+node test/manual/test-get-list-details.js your_list_id
+```
+
+## Writing Tests
+
+### Unit Tests
+
+Unit tests should test individual functions and components in isolation, using mocks for dependencies.
+
+Example:
+
+```typescript
+describe('function name', () => {
+  it('should do something specific', () => {
+    // Test code here
+  });
+});
+```
+
+### Integration Tests
+
+Integration tests should test how components work together, but may still mock external APIs.
+
+### API Tests
+
+API tests should verify that our code works correctly with the actual Attio API. These tests should:
+
+1. Always check for SKIP_INTEGRATION_TESTS environment variable
+2. Have proper timeouts (30s is recommended)
+3. Not modify production data unexpectedly

--- a/test/api/list-details.api.test.ts
+++ b/test/api/list-details.api.test.ts
@@ -1,0 +1,111 @@
+/**
+ * End-to-end tests for get-list-details API interaction
+ * 
+ * This test will use the real Attio API if SKIP_INTEGRATION_TESTS is not set
+ * and ATTIO_API_KEY is provided
+ */
+import { initializeAttioClient } from '../../src/api/attio-client';
+import { getListDetails } from '../../src/objects/lists';
+import { executeToolRequest } from '../../src/handlers/tools/dispatcher';
+
+// Test config
+const TIMEOUT = 30000; // 30 seconds timeout for API tests
+const TEST_LIST_ID = process.env.TEST_LIST_ID || 'default-test-list-id';
+
+describe('get-list-details API test', () => {
+  
+  // Skip all tests if SKIP_INTEGRATION_TESTS is set or no API key
+  const shouldSkip = process.env.SKIP_INTEGRATION_TESTS === 'true' || !process.env.ATTIO_API_KEY;
+
+  // Conditional Jest test that respects the SKIP_INTEGRATION_TESTS flag
+  const conditionalTest = shouldSkip ? test.skip : test;
+  
+  beforeAll(() => {
+    if (!shouldSkip) {
+      // Initialize the API client with the actual API key
+      initializeAttioClient(process.env.ATTIO_API_KEY as string);
+      
+      // Log so we know tests are running
+      console.log('Running Attio API integration tests with real API key');
+    } else {
+      console.log('Skipping Attio API integration tests (SKIP_INTEGRATION_TESTS=true or no ATTIO_API_KEY)');
+    }
+  });
+
+  conditionalTest('should fetch list details directly from API', async () => {
+    // This test will be skipped if shouldSkip is true
+    const result = await getListDetails(TEST_LIST_ID);
+    
+    // Verify we got a valid list response
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+    expect(result.id.list_id).toBeDefined();
+    expect(typeof result.id.list_id).toBe('string');
+    
+    // Expect some common fields
+    expect(result.title || result.name).toBeDefined();
+    expect(result.object_slug).toBeDefined();
+    
+    // Log the result for debugging
+    console.log('API Response:', JSON.stringify(result, null, 2));
+  }, TIMEOUT);
+
+  conditionalTest('should format list details through MCP tool', async () => {
+    // Create a mock request for the MCP tool
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: TEST_LIST_ID
+        }
+      }
+    };
+
+    // Execute the request through the MCP tool
+    const response = await executeToolRequest(mockRequest);
+    
+    // Check the basic response structure
+    expect(response).toBeDefined();
+    expect(response.isError).toBeFalsy();
+    expect(response.content).toBeDefined();
+    expect(response.content[0].type).toBe('text');
+    
+    // Verify the content contains the expected sections
+    const textContent = response.content[0].text;
+    expect(textContent).toContain('List Details:');
+    expect(textContent).toContain('ID:');
+    expect(textContent).toContain('Name:');
+    expect(textContent).toContain('Object Type:');
+    
+    // Log the formatted response for debugging
+    console.log('Formatted Response:', textContent);
+  }, TIMEOUT);
+
+  conditionalTest('should handle non-existent list ID', async () => {
+    // Try to fetch a non-existent list
+    const nonExistentId = 'non-existent-list-' + Date.now();
+    
+    // Create a mock request
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: nonExistentId
+        }
+      }
+    };
+
+    // Execute the request and expect an error
+    const response = await executeToolRequest(mockRequest);
+    
+    // Check error response
+    expect(response).toBeDefined();
+    expect(response.isError).toBeTruthy();
+    expect(response.error).toBeDefined();
+    expect(response.error.code).toBe(404);
+    expect(response.error.type).toBe('not_found_error');
+    
+    // Log the error response for debugging
+    console.log('Error Response:', JSON.stringify(response.error, null, 2));
+  }, TIMEOUT);
+});

--- a/test/handlers/tools.list-details.test.ts
+++ b/test/handlers/tools.list-details.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for get-list-details tool handler
+ */
+import { findToolConfig } from '../../src/handlers/tools/registry';
+import { executeToolRequest } from '../../src/handlers/tools/dispatcher';
+import { getListDetails } from '../../src/objects/lists';
+import { ResourceType } from '../../src/types/attio';
+
+// Mock the lists module
+jest.mock('../../src/objects/lists', () => ({
+  getListDetails: jest.fn()
+}));
+
+describe('get-list-details tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should find the tool config correctly', () => {
+    const toolInfo = findToolConfig('get-list-details');
+    
+    expect(toolInfo).toBeDefined();
+    expect(toolInfo?.resourceType).toBe(ResourceType.LISTS);
+    expect(toolInfo?.toolType).toBe('getListDetails');
+    expect(toolInfo?.toolConfig).toBeDefined();
+    expect(toolInfo?.toolConfig.handler).toBeDefined();
+    expect(toolInfo?.toolConfig.formatResult).toBeDefined();
+  });
+
+  it('should handle successful list details retrieval', async () => {
+    // Mock the getListDetails function to return a successful response
+    const mockList = {
+      id: { list_id: 'list123' },
+      title: 'Test List',
+      name: 'Test List',
+      description: 'A test list',
+      object_slug: 'people',
+      workspace_id: 'workspace123',
+      created_at: '2023-01-01T00:00:00Z',
+      updated_at: '2023-01-02T00:00:00Z',
+      entry_count: 10
+    };
+    
+    (getListDetails as jest.Mock).mockResolvedValue(mockList);
+
+    // Create a mock request
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: 'list123'
+        }
+      }
+    };
+
+    // Execute the request
+    const response = await executeToolRequest(mockRequest);
+
+    // Check the response
+    expect(response).toBeDefined();
+    expect(response.isError).toBeFalsy();
+    expect(response.content).toBeDefined();
+    expect(response.content[0].type).toBe('text');
+    
+    // Verify the content contains the expected information
+    const textContent = response.content[0].text;
+    expect(textContent).toContain('List Details:');
+    expect(textContent).toContain('ID: list123');
+    expect(textContent).toContain('Name: Test List');
+    expect(textContent).toContain('Object Type: people');
+    expect(textContent).toContain('10 entries');
+    expect(textContent).toContain('Description: A test list');
+
+    // Verify the handler was called with the correct parameters
+    expect(getListDetails).toHaveBeenCalledTimes(1);
+    expect(getListDetails).toHaveBeenCalledWith('list123');
+  });
+
+  it('should handle missing listId parameter', async () => {
+    // Create a mock request without listId
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {}
+      }
+    };
+
+    // Execute the request
+    const response = await executeToolRequest(mockRequest);
+
+    // Check the response
+    expect(response).toBeDefined();
+    expect(response.isError).toBeTruthy();
+    expect(response.error).toBeDefined();
+    expect(response.error.message).toContain('listId parameter is required');
+    
+    // Verify the handler was not called
+    expect(getListDetails).not.toHaveBeenCalled();
+  });
+
+  it('should handle API errors', async () => {
+    // Mock the getListDetails function to throw an error
+    const mockError = new Error('API Error');
+    mockError.response = { 
+      status: 404,
+      data: { message: 'List not found' }
+    };
+    
+    (getListDetails as jest.Mock).mockRejectedValue(mockError);
+
+    // Create a mock request
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: 'nonexistent123'
+        }
+      }
+    };
+
+    // Execute the request
+    const response = await executeToolRequest(mockRequest);
+
+    // Check the response
+    expect(response).toBeDefined();
+    expect(response.isError).toBeTruthy();
+    expect(response.error).toBeDefined();
+    expect(response.error.code).toBe(404);
+    expect(response.error.message).toContain('not found');
+    
+    // Verify the handler was called with the correct parameters
+    expect(getListDetails).toHaveBeenCalledTimes(1);
+    expect(getListDetails).toHaveBeenCalledWith('nonexistent123');
+  });
+});

--- a/test/handlers/tools.list-details.test.ts
+++ b/test/handlers/tools.list-details.test.ts
@@ -92,7 +92,7 @@ describe('get-list-details tool', () => {
     expect(response).toBeDefined();
     expect(response.isError).toBeTruthy();
     expect(response.error).toBeDefined();
-    expect(response.error.message).toContain('listId parameter is required');
+    expect(response.error.message).toContain('Missing required parameter: listId');
     
     // Verify the handler was not called
     expect(getListDetails).not.toHaveBeenCalled();

--- a/test/integration/lists/get-list-details.integration.test.ts
+++ b/test/integration/lists/get-list-details.integration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Integration tests for get-list-details tool
+ */
+import axios from 'axios';
+import { initializeAttioClient } from '../../../src/api/attio-client';
+import { executeToolRequest } from '../../../src/handlers/tools/dispatcher';
+
+// Mock axios to simulate API responses
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('get-list-details integration test', () => {
+  beforeAll(() => {
+    // Mock axios.create to return an object with get, post, etc. methods
+    mockedAxios.create.mockReturnValue({
+      get: mockedAxios.get,
+      post: mockedAxios.post,
+      put: mockedAxios.put,
+      delete: mockedAxios.delete,
+      patch: mockedAxios.patch,
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() }
+      }
+    } as any);
+    
+    // Initialize the API client with a dummy key
+    initializeAttioClient('test-api-key');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch and format list details successfully', async () => {
+    // Setup mock response for the API call
+    const mockApiResponse = {
+      data: {
+        data: {
+          id: { list_id: 'list456' },
+          title: 'Integration Test List',
+          name: 'Integration Test List',
+          description: 'A list for integration testing',
+          object_slug: 'companies',
+          workspace_id: 'workspace789',
+          created_at: '2023-02-01T00:00:00Z',
+          updated_at: '2023-02-02T00:00:00Z',
+          entry_count: 25
+        }
+      }
+    };
+    
+    mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
+
+    // Create a mock request
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: 'list456'
+        }
+      }
+    };
+
+    // Execute the request
+    const response = await executeToolRequest(mockRequest);
+
+    // Check that axios was called correctly
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/lists/list456');
+
+    // Check the response
+    expect(response).toBeDefined();
+    expect(response.isError).toBeFalsy();
+    expect(response.content).toBeDefined();
+    expect(response.content[0].type).toBe('text');
+    
+    // Verify the content contains the expected information
+    const textContent = response.content[0].text;
+    expect(textContent).toContain('List Details:');
+    expect(textContent).toContain('ID: list456');
+    expect(textContent).toContain('Name: Integration Test List');
+    expect(textContent).toContain('Object Type: companies');
+    expect(textContent).toContain('25 entries');
+    expect(textContent).toContain('Description: A list for integration testing');
+  });
+
+  it('should handle API error responses', async () => {
+    // Setup mock error response
+    const errorResponse = {
+      response: {
+        status: 404,
+        data: {
+          message: 'List not found',
+          error: 'Not Found',
+          path: ['/lists/nonexistent456']
+        }
+      }
+    };
+    
+    mockedAxios.get.mockRejectedValueOnce(errorResponse);
+
+    // Create a mock request with non-existent list ID
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: 'nonexistent456'
+        }
+      }
+    };
+
+    // Execute the request
+    const response = await executeToolRequest(mockRequest);
+
+    // Check that axios was called correctly
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/lists/nonexistent456');
+
+    // Check the response
+    expect(response).toBeDefined();
+    expect(response.isError).toBeTruthy();
+    expect(response.error).toBeDefined();
+    expect(response.error.code).toBe(404);
+    expect(response.error.message).toContain('List not found');
+  });
+
+  it('should handle API rate limit responses', async () => {
+    // Setup mock rate limit error response
+    const rateLimitResponse = {
+      response: {
+        status: 429,
+        data: {
+          message: 'Too many requests',
+          error: 'Rate Limited',
+        }
+      }
+    };
+    
+    mockedAxios.get.mockRejectedValueOnce(rateLimitResponse);
+
+    // Create a mock request
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: 'list789'
+        }
+      }
+    };
+
+    // Execute the request
+    const response = await executeToolRequest(mockRequest);
+
+    // Check that axios was called correctly
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/lists/list789');
+
+    // Check the response
+    expect(response).toBeDefined();
+    expect(response.isError).toBeTruthy();
+    expect(response.error).toBeDefined();
+    expect(response.error.code).toBe(429);
+    expect(response.error.type).toBe('rate_limit_error');
+    expect(response.error.message).toContain('Rate limit exceeded');
+  });
+
+  it('should handle missing data in API response', async () => {
+    // Setup mock response with missing data
+    const mockApiResponseMissingData = {
+      data: {
+        // Missing the 'data' field that should contain the list details
+        id: 'list999'
+      }
+    };
+    
+    mockedAxios.get.mockResolvedValueOnce(mockApiResponseMissingData);
+
+    // Create a mock request
+    const mockRequest = {
+      params: {
+        name: 'get-list-details',
+        arguments: {
+          listId: 'list999'
+        }
+      }
+    };
+
+    // Execute the request
+    const response = await executeToolRequest(mockRequest);
+
+    // Check that axios was called correctly
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/lists/list999');
+
+    // Check the response - it should still work but with limited data
+    expect(response).toBeDefined();
+    expect(response.isError).toBeFalsy();
+    expect(response.content).toBeDefined();
+    expect(response.content[0].type).toBe('text');
+    
+    // Verify the content adapts to missing fields
+    const textContent = response.content[0].text;
+    expect(textContent).toContain('List Details:');
+    expect(textContent).toContain('ID: unknown');
+    expect(textContent).toContain('Name: Unnamed List');
+    expect(textContent).toContain('Object Type: unknown');
+    expect(textContent).toContain('Unknown entry count');
+  });
+});

--- a/test/integration/lists/get-list-details.integration.test.ts
+++ b/test/integration/lists/get-list-details.integration.test.ts
@@ -43,8 +43,8 @@ describe('get-list-details integration test', () => {
           description: 'A list for integration testing',
           object_slug: 'companies',
           workspace_id: 'workspace789',
-          created_at: '2023-02-01T00:00:00Z',
-          updated_at: '2023-02-02T00:00:00Z',
+          created_at: '2023-02-01T00:00:00Z', // Will format to 2023-02-01 in ISO format
+          updated_at: '2023-02-02T00:00:00Z', // Will format to 2023-02-02 in ISO format
           entry_count: 25
         }
       }
@@ -82,6 +82,8 @@ describe('get-list-details integration test', () => {
     expect(textContent).toContain('Name: Integration Test List');
     expect(textContent).toContain('Object Type: companies');
     expect(textContent).toContain('25 entries');
+    expect(textContent).toContain('Created: 2023-02-01'); // ISO format date
+    expect(textContent).toContain('Updated: 2023-02-02'); // ISO format date
     expect(textContent).toContain('Description: A list for integration testing');
   });
 

--- a/test/manual/test-get-list-details.js
+++ b/test/manual/test-get-list-details.js
@@ -1,0 +1,78 @@
+/**
+ * Test for the get-list-details tool
+ * 
+ * This test script directly calls the getListDetails function to identify issues
+ * with the get-list-details MCP tool.
+ */
+
+// Import the necessary modules
+import { getListDetails } from '../../src/objects/lists.js';
+import { executeToolRequest } from '../../src/handlers/tools/dispatcher.js';
+import { initializeAttioClient } from '../../src/api/attio-client.js';
+
+// Initialize the Attio client with the API key from environment variables
+const apiKey = process.env.ATTIO_API_KEY;
+
+if (!apiKey) {
+  console.error('ERROR: You must set ATTIO_API_KEY environment variable to run this test');
+  process.exit(1);
+}
+
+// Initialize the API client
+initializeAttioClient(apiKey);
+
+// Create a test function to run the test
+async function testGetListDetails() {
+  try {
+    console.log('Testing direct getListDetails function:');
+    console.log('=====================================');
+    
+    // Test with a sample list ID - replace with a valid list ID from your Attio workspace
+    // You may need to create a list in Attio and get its ID
+    const listId = process.argv[2]; // Take list ID from command line argument
+    
+    if (!listId) {
+      console.error('Please provide a list ID as a command line argument');
+      console.error('Usage: node test-get-list-details.js <list-id>');
+      process.exit(1);
+    }
+    
+    console.log(`Getting details for list with ID: ${listId}`);
+    
+    // First, test the direct function call to see if the API works
+    try {
+      const result = await getListDetails(listId);
+      console.log('Function success! Result:', JSON.stringify(result, null, 2));
+    } catch (error) {
+      console.error('Function error:', error);
+      console.error('Error details:', error.response?.data || error.message);
+    }
+    
+    console.log('\nTesting the MCP tool implementation:');
+    console.log('==================================');
+    
+    // Now, test the MCP tool request to find where the error happens
+    try {
+      const mockRequest = {
+        params: {
+          name: 'get-list-details',
+          arguments: {
+            listId: listId
+          }
+        }
+      };
+      
+      const toolResponse = await executeToolRequest(mockRequest);
+      console.log('Tool success! Response:', JSON.stringify(toolResponse, null, 2));
+    } catch (error) {
+      console.error('Tool error:', error);
+      console.error('Error details:', error.response?.data || error.message);
+    }
+    
+  } catch (error) {
+    console.error('Unexpected error:', error);
+  }
+}
+
+// Run the test
+testGetListDetails().catch(console.error);


### PR DESCRIPTION
## Summary
- Fixed issue #179: get-list-details tool failing with API error
- Added dedicated handler for getListDetails tool type in dispatcher.ts
- Added formatResult function to format list details response
- Included test scripts to verify the fix

## Test plan
1. Build the project with npm run build
2. Set up ATTIO_API_KEY in the environment
3. Create a test list in Attio and note its ID
4. Run the test script: node scripts/test-get-list-details.js <list-id>
5. Verify the tool returns properly formatted list details