### PR TITLE
Fix: Boolean string values now convert to booleans during attribute updates

### DIFF
--- a/src/objects/companies/basic.ts
+++ b/src/objects/companies/basic.ts
@@ -259,14 +259,15 @@ export async function updateCompanyAttribute(
   attributeValue: any
 ): Promise<Company> {
   try {
-    // Validate attribute update
-    await CompanyValidator.validateAttributeUpdate(companyId, attributeName, attributeValue);
+    // Validate attribute update and get processed value
+    // This will handle conversion of string values to boolean for boolean fields
+    const processedValue = await CompanyValidator.validateAttributeUpdate(companyId, attributeName, attributeValue);
     
     return await updateObjectAttributeWithDynamicFields<Company>(
       ResourceType.COMPANIES,
       companyId,
       attributeName,
-      attributeValue,
+      processedValue,
       updateCompany
     );
   } catch (error) {

--- a/src/utils/attribute-mapping/attribute-mappers.ts
+++ b/src/utils/attribute-mapping/attribute-mappers.ts
@@ -13,6 +13,25 @@ import {
   handleSpecialCases
 } from './mapping-utils.js';
 
+/**
+ * Converts a value to a boolean based on common string representations
+ * 
+ * @param value - The value to convert to boolean
+ * @returns Boolean representation of the value
+ */
+export function convertToBoolean(value: any): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const lowerValue = value.toLowerCase();
+    if (['true', 'yes', 'y', '1'].includes(lowerValue)) return true;
+    if (['false', 'no', 'n', '0'].includes(lowerValue)) return false;
+  }
+  if (typeof value === 'number') return value !== 0;
+  
+  // If we can't determine, return the original value as boolean
+  return Boolean(value);
+}
+
 // Error class for attribute mapping errors
 export class AttributeMappingError extends Error {
   constructor(message: string, public details: Record<string, any> = {}) {

--- a/test/api/boolean-attribute-update.test.ts
+++ b/test/api/boolean-attribute-update.test.ts
@@ -1,0 +1,156 @@
+/**
+ * End-to-end tests for boolean attribute updates with actual Attio API
+ * 
+ * These tests require a valid ATTIO_API_KEY environment variable.
+ * They can be skipped by setting SKIP_INTEGRATION_TESTS=true.
+ */
+import { 
+  createCompany,
+  updateCompany,
+  updateCompanyAttribute,
+  deleteCompany
+} from '../../src/objects/companies/basic.js';
+import { Company } from '../../src/types/attio.js';
+
+// Test configuration
+const SKIP_TESTS = process.env.SKIP_INTEGRATION_TESTS === 'true';
+const TEST_TIMEOUT = 30000; // 30 seconds
+const TEST_COMPANY_NAME = `Test Company ${Date.now()}`;
+
+describe('Boolean Attribute API Tests', () => {
+  let testCompany: Company;
+  
+  // Skip all tests if integration tests are disabled
+  beforeAll(() => {
+    if (SKIP_TESTS) {
+      console.warn('Skipping boolean attribute API tests because SKIP_INTEGRATION_TESTS=true');
+    } else if (!process.env.ATTIO_API_KEY) {
+      console.warn('Skipping boolean attribute API tests because ATTIO_API_KEY is not set');
+    }
+  });
+  
+  // Create a test company before all tests
+  beforeAll(async () => {
+    // Skip setup if tests are disabled
+    if (SKIP_TESTS || !process.env.ATTIO_API_KEY) {
+      return;
+    }
+    
+    try {
+      testCompany = await createCompany({
+        name: TEST_COMPANY_NAME,
+        is_active: true,
+        uses_body_composition: true
+      });
+      
+      console.log(`Created test company: ${testCompany.id?.record_id}`);
+    } catch (error) {
+      console.error('Error creating test company:', error);
+      throw error;
+    }
+  }, TEST_TIMEOUT);
+  
+  // Clean up after all tests
+  afterAll(async () => {
+    // Skip cleanup if tests are disabled or if no test company was created
+    if (SKIP_TESTS || !process.env.ATTIO_API_KEY || !testCompany?.id?.record_id) {
+      return;
+    }
+    
+    try {
+      await deleteCompany(testCompany.id.record_id);
+      console.log(`Deleted test company: ${testCompany.id.record_id}`);
+    } catch (error) {
+      console.error('Error deleting test company:', error);
+    }
+  }, TEST_TIMEOUT);
+  
+  // Test updating a boolean attribute with string 'false'
+  test('updates boolean attribute with string "false"', async () => {
+    // Skip if tests are disabled
+    if (SKIP_TESTS || !process.env.ATTIO_API_KEY) {
+      return;
+    }
+    
+    const companyId = testCompany.id?.record_id;
+    expect(companyId).toBeDefined();
+    
+    // Update the is_active attribute with string 'false'
+    const result = await updateCompanyAttribute(companyId!, 'is_active', 'false');
+    
+    // Verify the result
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+    
+    // Check if the boolean was properly updated (the actual value format will depend on Attio's API response)
+    const isActiveValue = result.values?.is_active;
+    expect(isActiveValue).toBeDefined();
+    
+    // The format might be an array of objects with a value property
+    if (Array.isArray(isActiveValue) && isActiveValue.length > 0) {
+      expect(isActiveValue[0].value).toBe(false);
+    }
+  }, TEST_TIMEOUT);
+  
+  // Test updating a boolean attribute with string 'true'
+  test('updates boolean attribute with string "true"', async () => {
+    // Skip if tests are disabled
+    if (SKIP_TESTS || !process.env.ATTIO_API_KEY) {
+      return;
+    }
+    
+    const companyId = testCompany.id?.record_id;
+    expect(companyId).toBeDefined();
+    
+    // Update the is_active attribute with string 'true'
+    const result = await updateCompanyAttribute(companyId!, 'is_active', 'true');
+    
+    // Verify the result
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+    
+    // Check if the boolean was properly updated
+    const isActiveValue = result.values?.is_active;
+    expect(isActiveValue).toBeDefined();
+    
+    if (Array.isArray(isActiveValue) && isActiveValue.length > 0) {
+      expect(isActiveValue[0].value).toBe(true);
+    }
+  }, TEST_TIMEOUT);
+  
+  // Test updating multiple boolean attributes in a single request
+  test('updates multiple boolean attributes with string values', async () => {
+    // Skip if tests are disabled
+    if (SKIP_TESTS || !process.env.ATTIO_API_KEY) {
+      return;
+    }
+    
+    const companyId = testCompany.id?.record_id;
+    expect(companyId).toBeDefined();
+    
+    // Update multiple boolean attributes with string values
+    const result = await updateCompany(companyId!, {
+      is_active: 'no',
+      uses_body_composition: 'yes'
+    });
+    
+    // Verify the result
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+    
+    // Check if the boolean values were properly updated
+    const isActiveValue = result.values?.is_active;
+    const usesBodyCompositionValue = result.values?.uses_body_composition;
+    
+    expect(isActiveValue).toBeDefined();
+    expect(usesBodyCompositionValue).toBeDefined();
+    
+    if (Array.isArray(isActiveValue) && isActiveValue.length > 0) {
+      expect(isActiveValue[0].value).toBe(false);
+    }
+    
+    if (Array.isArray(usesBodyCompositionValue) && usesBodyCompositionValue.length > 0) {
+      expect(usesBodyCompositionValue[0].value).toBe(true);
+    }
+  }, TEST_TIMEOUT);
+});

--- a/test/integration/boolean-attribute-update.test.ts
+++ b/test/integration/boolean-attribute-update.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration tests for boolean attribute update functionality
+ */
+import { 
+  updateCompanyAttribute,
+  updateCompany 
+} from '../../src/objects/companies/basic.js';
+import { CompanyValidator } from '../../src/validators/company-validator.js';
+import { getAttioClient } from '../../src/api/attio-client.js';
+import { ResourceType } from '../../src/types/attio.js';
+import { detectFieldType } from '../../src/api/attribute-types.js';
+
+// Mock the attio client
+jest.mock('../../src/api/attio-client.js');
+jest.mock('../../src/api/attribute-types.js');
+
+describe('Boolean Attribute Updates Integration', () => {
+  let mockApiClient: any;
+  const MOCK_COMPANY_ID = 'comp_12345';
+  
+  beforeEach(() => {
+    // Clear all mocks
+    jest.clearAllMocks();
+    
+    // Reset the field type cache
+    CompanyValidator.clearFieldTypeCache();
+    
+    // Set up mock API client
+    mockApiClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn()
+    };
+    
+    // Mock the getAttioClient to return our mock client
+    (getAttioClient as jest.Mock).mockReturnValue(mockApiClient);
+    
+    // Mock the detectFieldType to return 'boolean' for specific fields
+    (detectFieldType as jest.Mock).mockImplementation((resourceType: string, fieldName: string) => {
+      if (fieldName === 'is_active' || fieldName === 'uses_body_composition') {
+        return Promise.resolve('boolean');
+      }
+      return Promise.resolve('string');
+    });
+  });
+  
+  describe('updateCompanyAttribute', () => {
+    test('converts string "false" to boolean false before updating API', async () => {
+      // Mock API responses
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            is_active: [{ value: true }]
+          }
+        }
+      });
+      
+      mockApiClient.patch.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            is_active: [{ value: false }]
+          }
+        }
+      });
+      
+      // Call function with string 'false'
+      const result = await updateCompanyAttribute(MOCK_COMPANY_ID, 'is_active', 'false');
+      
+      // Check that the API was called with boolean false, not string 'false'
+      expect(mockApiClient.patch).toHaveBeenCalledTimes(1);
+      
+      const patchCall = mockApiClient.patch.mock.calls[0];
+      const requestData = patchCall[1]; // Second argument is the payload
+      
+      // Verify the patch request contains the correct boolean value
+      expect(requestData.values.is_active).toBe(false);
+      expect(typeof requestData.values.is_active).toBe('boolean');
+      
+      // Verify the result is correctly returned
+      expect(result.id).toBe(MOCK_COMPANY_ID);
+      expect(result.values.is_active[0].value).toBe(false);
+    });
+    
+    test('converts string "true" to boolean true before updating API', async () => {
+      // Mock API responses
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            uses_body_composition: [{ value: false }]
+          }
+        }
+      });
+      
+      mockApiClient.patch.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            uses_body_composition: [{ value: true }]
+          }
+        }
+      });
+      
+      // Call function with string 'true'
+      const result = await updateCompanyAttribute(MOCK_COMPANY_ID, 'uses_body_composition', 'true');
+      
+      // Check that the API was called with boolean true, not string 'true'
+      expect(mockApiClient.patch).toHaveBeenCalledTimes(1);
+      
+      const patchCall = mockApiClient.patch.mock.calls[0];
+      const requestData = patchCall[1]; // Second argument is the payload
+      
+      // Verify the patch request contains the correct boolean value
+      expect(requestData.values.uses_body_composition).toBe(true);
+      expect(typeof requestData.values.uses_body_composition).toBe('boolean');
+      
+      // Verify the result is correctly returned
+      expect(result.id).toBe(MOCK_COMPANY_ID);
+      expect(result.values.uses_body_composition[0].value).toBe(true);
+    });
+    
+    test('correctly handles alternative string boolean values ("yes"/"no")', async () => {
+      // Mock API responses
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            is_active: [{ value: false }]
+          }
+        }
+      });
+      
+      mockApiClient.patch.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            is_active: [{ value: true }]
+          }
+        }
+      });
+      
+      // Call function with string 'yes'
+      const result = await updateCompanyAttribute(MOCK_COMPANY_ID, 'is_active', 'yes');
+      
+      // Check that the API was called with boolean true
+      expect(mockApiClient.patch).toHaveBeenCalledTimes(1);
+      
+      const patchCall = mockApiClient.patch.mock.calls[0];
+      const requestData = patchCall[1]; // Second argument is the payload
+      
+      // Verify the patch request contains the correct boolean value
+      expect(requestData.values.is_active).toBe(true);
+      expect(typeof requestData.values.is_active).toBe('boolean');
+    });
+  });
+  
+  describe('updateCompany', () => {
+    test('converts multiple boolean string values in a single update', async () => {
+      // Mock API responses
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            is_active: [{ value: true }],
+            uses_body_composition: [{ value: true }]
+          }
+        }
+      });
+      
+      mockApiClient.patch.mockResolvedValueOnce({
+        data: {
+          id: MOCK_COMPANY_ID,
+          values: {
+            name: [{ value: 'Test Company' }],
+            is_active: [{ value: false }],
+            uses_body_composition: [{ value: false }]
+          }
+        }
+      });
+      
+      // Call updateCompany with multiple string boolean values
+      const result = await updateCompany(MOCK_COMPANY_ID, {
+        is_active: 'no',
+        uses_body_composition: 'false'
+      });
+      
+      // Check that the API was called with correct boolean values
+      expect(mockApiClient.patch).toHaveBeenCalledTimes(1);
+      
+      const patchCall = mockApiClient.patch.mock.calls[0];
+      const requestData = patchCall[1]; // Second argument is the payload
+      
+      // Verify the patch request contains the correct boolean values
+      expect(requestData.values.is_active).toBe(false);
+      expect(typeof requestData.values.is_active).toBe('boolean');
+      expect(requestData.values.uses_body_composition).toBe(false);
+      expect(typeof requestData.values.uses_body_composition).toBe('boolean');
+      
+      // Verify the result is correctly returned
+      expect(result.id).toBe(MOCK_COMPANY_ID);
+      expect(result.values.is_active[0].value).toBe(false);
+      expect(result.values.uses_body_composition[0].value).toBe(false);
+    });
+  });
+});

--- a/test/manual/boolean-update-test.js
+++ b/test/manual/boolean-update-test.js
@@ -1,0 +1,203 @@
+/**
+ * Manual test script for boolean attribute updates
+ * 
+ * This script demonstrates and tests the string-to-boolean conversion for Attio
+ * company attributes using both the low-level and high-level APIs.
+ * 
+ * Usage:
+ *   export ATTIO_API_KEY=your_api_key
+ *   node test/manual/boolean-update-test.js
+ * 
+ * Or provide a specific company ID to update an existing company:
+ *   node test/manual/boolean-update-test.js comp_12345
+ */
+import { getAttioClient } from '../../src/api/attio-client.js';
+import { 
+  createCompany,
+  updateCompany,
+  updateCompanyAttribute, 
+  getCompanyDetails,
+  deleteCompany
+} from '../../src/objects/companies/basic.js';
+import { convertToBoolean } from '../../src/utils/attribute-mapping/attribute-mappers.js';
+
+// Set API key from environment
+const API_KEY = process.env.ATTIO_API_KEY;
+if (!API_KEY) {
+  console.error('Error: ATTIO_API_KEY environment variable is required');
+  process.exit(1);
+}
+
+// Colors for console output
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  white: '\x1b[37m'
+};
+
+// Test company data
+const TEST_COMPANY_NAME = `Boolean Test Company ${Date.now()}`;
+const BOOLEAN_FIELD_NAMES = ['is_active', 'uses_body_composition'];
+
+// Function to display string-to-boolean conversion results
+function testStringBooleanConversion() {
+  console.log(`\n${colors.cyan}Testing string-to-boolean conversion:${colors.reset}`);
+  
+  const testValues = [
+    // Truthy values
+    'true', 'TRUE', 'yes', 'YES', 'y', 'Y', '1',
+    // Falsy values
+    'false', 'FALSE', 'no', 'NO', 'n', 'N', '0',
+    // Boolean values
+    true, false,
+    // Number values
+    1, 0
+  ];
+  
+  testValues.forEach(value => {
+    const result = convertToBoolean(value);
+    const valueType = typeof value;
+    const resultColor = result ? colors.green : colors.red;
+    
+    console.log(`${colors.yellow}${value}${colors.reset} (${valueType}) → ${resultColor}${result}${colors.reset}`);
+  });
+}
+
+// Function to create a test company with boolean fields
+async function createTestCompany() {
+  console.log(`\n${colors.cyan}Creating test company:${colors.reset}`);
+  
+  try {
+    const company = await createCompany({
+      name: TEST_COMPANY_NAME,
+      is_active: true,
+      uses_body_composition: false
+    });
+    
+    console.log(`${colors.green}Created company:${colors.reset} ${company.id.record_id}`);
+    console.log(`Name: ${company.values.name[0].value}`);
+    console.log(`is_active: ${company.values.is_active[0].value}`);
+    console.log(`uses_body_composition: ${company.values.uses_body_composition[0].value}`);
+    
+    return company;
+  } catch (error) {
+    console.error(`${colors.red}Error creating company:${colors.reset}`, error.message);
+    throw error;
+  }
+}
+
+// Function to test updating a single boolean attribute with a string value
+async function testSingleBooleanUpdate(companyId) {
+  console.log(`\n${colors.cyan}Testing single boolean attribute update:${colors.reset}`);
+  
+  try {
+    // Update is_active with string 'false'
+    console.log(`Updating 'is_active' to string value 'false'...`);
+    const result = await updateCompanyAttribute(companyId, 'is_active', 'false');
+    
+    // Display result
+    console.log(`${colors.green}Update successful:${colors.reset}`);
+    console.log(`is_active: ${result.values.is_active[0].value}`);
+    
+    // Verify the type in the response
+    const isBoolean = typeof result.values.is_active[0].value === 'boolean';
+    console.log(`Value is boolean: ${isBoolean ? colors.green + 'Yes' : colors.red + 'No'}${colors.reset}`);
+    
+    return result;
+  } catch (error) {
+    console.error(`${colors.red}Error updating boolean attribute:${colors.reset}`, error.message);
+    throw error;
+  }
+}
+
+// Function to test updating multiple boolean attributes with string values
+async function testMultipleBooleanUpdate(companyId) {
+  console.log(`\n${colors.cyan}Testing multiple boolean attribute update:${colors.reset}`);
+  
+  try {
+    // Update multiple boolean fields with string values
+    console.log(`Updating 'is_active' to 'yes' and 'uses_body_composition' to 'no'...`);
+    const result = await updateCompany(companyId, {
+      is_active: 'yes',
+      uses_body_composition: 'no'
+    });
+    
+    // Display result
+    console.log(`${colors.green}Update successful:${colors.reset}`);
+    console.log(`is_active: ${result.values.is_active[0].value}`);
+    console.log(`uses_body_composition: ${result.values.uses_body_composition[0].value}`);
+    
+    // Verify the types in the response
+    const isActiveIsBoolean = typeof result.values.is_active[0].value === 'boolean';
+    const usesBodyCompositionIsBoolean = typeof result.values.uses_body_composition[0].value === 'boolean';
+    
+    console.log(`'is_active' is boolean: ${isActiveIsBoolean ? colors.green + 'Yes' : colors.red + 'No'}${colors.reset}`);
+    console.log(`'uses_body_composition' is boolean: ${usesBodyCompositionIsBoolean ? colors.green + 'Yes' : colors.red + 'No'}${colors.reset}`);
+    
+    return result;
+  } catch (error) {
+    console.error(`${colors.red}Error updating multiple boolean attributes:${colors.reset}`, error.message);
+    throw error;
+  }
+}
+
+// Main test function
+async function runTests() {
+  console.log(`${colors.magenta}===== Boolean Attribute Update Test =====\n${colors.reset}`);
+  
+  // Check if a company ID was provided as argument
+  const providedCompanyId = process.argv[2];
+  let testCompany;
+  let companyId;
+  
+  if (providedCompanyId) {
+    companyId = providedCompanyId;
+    console.log(`${colors.yellow}Using provided company ID: ${companyId}${colors.reset}`);
+    
+    // Verify the company exists
+    try {
+      testCompany = await getCompanyDetails(companyId);
+      console.log(`Found company: ${testCompany.values.name[0].value}`);
+    } catch (error) {
+      console.error(`${colors.red}Error: Company not found with ID ${companyId}${colors.reset}`);
+      process.exit(1);
+    }
+  } else {
+    // Create a new test company
+    testCompany = await createTestCompany();
+    companyId = testCompany.id.record_id;
+  }
+  
+  // Test the string-to-boolean conversion utility
+  testStringBooleanConversion();
+  
+  // Test updating a single boolean attribute
+  await testSingleBooleanUpdate(companyId);
+  
+  // Test updating multiple boolean attributes
+  await testMultipleBooleanUpdate(companyId);
+  
+  // Clean up test company if we created it
+  if (!providedCompanyId) {
+    console.log(`\n${colors.cyan}Cleaning up test company...${colors.reset}`);
+    try {
+      await deleteCompany(companyId);
+      console.log(`${colors.green}Deleted test company: ${companyId}${colors.reset}`);
+    } catch (error) {
+      console.error(`${colors.red}Error deleting test company:${colors.reset}`, error.message);
+    }
+  }
+  
+  console.log(`\n${colors.magenta}===== Test Complete =====\n${colors.reset}`);
+}
+
+// Run the tests
+runTests().catch(error => {
+  console.error(`${colors.red}Test failed with error:${colors.reset}`, error);
+  process.exit(1);
+});

--- a/test/utils/attribute-mapping/attribute-mappers.test.ts
+++ b/test/utils/attribute-mapping/attribute-mappers.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for attribute mapping utilities
+ */
+import { 
+  convertToBoolean,
+  getAttributeSlug, 
+  getObjectSlug,
+  getListSlug,
+  invalidateConfigCache
+} from '../../../src/utils/attribute-mapping/attribute-mappers.js';
+
+describe('Attribute Mappers', () => {
+  describe('convertToBoolean', () => {
+    test('correctly converts string truthy values to boolean true', () => {
+      const truthyValues = ['true', 'TRUE', 'True', 'yes', 'YES', 'Yes', 'y', 'Y', '1'];
+      
+      truthyValues.forEach(value => {
+        expect(convertToBoolean(value)).toBe(true);
+      });
+    });
+    
+    test('correctly converts string falsy values to boolean false', () => {
+      const falsyValues = ['false', 'FALSE', 'False', 'no', 'NO', 'No', 'n', 'N', '0'];
+      
+      falsyValues.forEach(value => {
+        expect(convertToBoolean(value)).toBe(false);
+      });
+    });
+    
+    test('handles actual boolean values correctly', () => {
+      expect(convertToBoolean(true)).toBe(true);
+      expect(convertToBoolean(false)).toBe(false);
+    });
+    
+    test('converts numeric values correctly', () => {
+      expect(convertToBoolean(1)).toBe(true);
+      expect(convertToBoolean(42)).toBe(true);
+      expect(convertToBoolean(-1)).toBe(true);
+      expect(convertToBoolean(0)).toBe(false);
+    });
+    
+    test('handles edge cases by using JavaScript truthy/falsy rules', () => {
+      // These should be truthy
+      expect(convertToBoolean({})).toBe(true);
+      expect(convertToBoolean([])).toBe(true);
+      expect(convertToBoolean('any string')).toBe(true);
+      
+      // These should be falsy
+      expect(convertToBoolean(null)).toBe(false);
+      expect(convertToBoolean(undefined)).toBe(false);
+      expect(convertToBoolean('')).toBe(false);
+      expect(convertToBoolean(NaN)).toBe(false);
+    });
+    
+    test('handles mixed case strings', () => {
+      expect(convertToBoolean('True')).toBe(true);
+      expect(convertToBoolean('FALSE')).toBe(false);
+      expect(convertToBoolean('yEs')).toBe(true);
+      expect(convertToBoolean('No')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes issue #178 by adding string-to-boolean conversion during attribute updates
- Implements  utility function in attribute mapping module
- Updates validators to detect and convert string representations to booleans
- Supports common formats like 'true'/'false', 'yes'/'no', '1'/'0', etc.
- Adds comprehensive test suite with unit, integration, and E2E tests

## Test plan
- Verify string values like 'false', 'no', 'n', or '0' convert to boolean false
- Verify string values like 'true', 'yes', 'y', or '1' convert to boolean true
- Run unit tests for the string-to-boolean conversion
- Run integration tests with mocked API responses
- Run E2E tests with a real Attio API connection (if credentials available)
- Manually test with the included test script