### PR TITLE
Feature: list company memberships

### DIFF
--- a/docs/ATTIO_MCP_TOOLS_DOCUMENTATION.md
+++ b/docs/ATTIO_MCP_TOOLS_DOCUMENTATION.md
@@ -467,6 +467,21 @@ get-company-social-info(
 )
 ```
 
+#### 27. get-company-lists
+
+List the Attio lists that include a company.
+
+**Parameters**:
+- `companyId` (string, required): ID of the company
+- `limit` (number, optional): Maximum number of list entries to check (default: 50)
+
+**Example**:
+```
+get-company-lists(
+  companyId: "12345abc-6789-def0-1234-56789abcdef"
+)
+```
+
 ### People Tools
 
 #### 1. create-person

--- a/docs/tools/attio-tools-reference.md
+++ b/docs/tools/attio-tools-reference.md
@@ -73,6 +73,7 @@ This document provides a comprehensive guide to all Attio MCP tools available, t
 | `get-company-business-info` | Get business information about a company | When you need industry, revenue, and employee data | `companyId`: Company record ID |
 | `get-company-contact-info` | Get contact information for a company | When you need address and phone details | `companyId`: Company record ID |
 | `get-company-social-info` | Get social media information for a company | When you need links to social profiles | `companyId`: Company record ID |
+| `get-company-lists` | List the Attio lists that include a company | When you need to know a company's list memberships | `companyId`: Company record ID |
 | `get-company-json` | Get raw JSON representation of a company | When you need the complete data structure for a company | `companyId`: Company record ID |
 | `get-company-notes` | Get notes associated with a company | When you need to see the note history for a company | `companyId`: Company record ID |
 | `create-company-note` | Create a new note for a company | When you need to add a note to a company's record | `companyId`: Company ID, `title`: Optional note title, `content`: Note text |

--- a/shapescale-attio-crm.md
+++ b/shapescale-attio-crm.md
@@ -269,7 +269,7 @@ These stages are likely used to track prospects through the sales process, thoug
 3. advanced-search-companies tool fails with API errors (Issue #182)
 4. get-company-attributes tool fails with API errors (Issue #183)
 5. Missing attribute validation before updates can cause errors (Issue #181)
-6. No tool to easily find which lists a company belongs to (Issue #184)
+6. Resolved: use the `get-company-lists` tool to see which lists a company belongs to (Issue #184)
 7. Type checking in the MCP server appears inconsistent
 8. Intermittent connectivity issues with certain tools
 

--- a/src/handlers/tool-configs/companies/relationships.ts
+++ b/src/handlers/tool-configs/companies/relationships.ts
@@ -2,11 +2,13 @@
  * Relationship-based tool configurations for companies
  */
 import { CompanyRecord } from "./types.js";
-import { 
+import {
   searchCompaniesByPeople,
   searchCompaniesByPeopleList,
-  searchCompaniesByNotes
+  searchCompaniesByNotes,
+  getCompanyLists
 } from "../../../objects/companies/index.js";
+import { AttioList } from "../../../types/attio.js";
 import { ToolConfig } from "../../tool-types.js";
 
 // Company relationship tool configurations
@@ -33,8 +35,17 @@ export const relationshipToolConfigs = {
     name: "search-companies-by-notes",
     handler: searchCompaniesByNotes,
     formatResult: (results: CompanyRecord[]) => {
-      return `Found ${results.length} companies with matching notes:\n${results.map((company: any) => 
+      return `Found ${results.length} companies with matching notes:\n${results.map((company: any) =>
         `- ${company.values?.name?.[0]?.value || 'Unnamed'} (ID: ${company.id?.record_id || 'unknown'})`).join('\n')}`;
+    }
+  } as ToolConfig,
+
+  listsForCompany: {
+    name: "get-company-lists",
+    handler: getCompanyLists,
+    formatResult: (results: AttioList[]) => {
+      return `Company belongs to ${results.length} lists:\n${results.map((list: any) =>
+        `- ${list.name || list.title} (ID: ${list.id?.list_id || list.id || 'unknown'})`).join('\n')}`;
     }
   } as ToolConfig
 };
@@ -140,6 +151,24 @@ export const relationshipToolDefinitions = [
         }
       },
       required: ["searchText"]
+    }
+  },
+  {
+    name: "get-company-lists",
+    description: "Get lists that a company belongs to",
+    inputSchema: {
+      type: "object",
+      properties: {
+        companyId: {
+          type: "string",
+          description: "ID of the company"
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of list entries to check (default: 50)"
+        }
+      },
+      required: ["companyId"]
     }
   }
 ];

--- a/src/objects/companies/index.ts
+++ b/src/objects/companies/index.ts
@@ -27,7 +27,8 @@ export {
 export {
   searchCompaniesByPeople,
   searchCompaniesByPeopleList,
-  searchCompaniesByNotes
+  searchCompaniesByNotes,
+  getCompanyLists
 } from "./relationships.js";
 
 // Note operations

--- a/test/objects/companies.test.ts
+++ b/test/objects/companies.test.ts
@@ -1,8 +1,9 @@
 import { 
   searchCompanies, 
   listCompanies, 
-  getCompanyDetails, 
-  getCompanyNotes, 
+  getCompanyDetails,
+  getCompanyNotes,
+  getCompanyLists,
   createCompanyNote,
   createCompany,
   updateCompany,
@@ -204,9 +205,33 @@ describe('companies', () => {
       await getCompanyNotes(companyId);
 
       // Assert
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         `/notes?limit=10&offset=0&parent_object=companies&parent_record_id=${companyId}`
       );
+    });
+  });
+
+  describe('getCompanyLists', () => {
+    it('should fetch lists for a company', async () => {
+      const companyId = 'comp123';
+      const mockResponse = {
+        data: {
+          data: [
+            { list_id: 'list1', id: { entry_id: 'e1' }, list: { id: { list_id: 'list1' }, name: 'List A' } },
+            { list_id: 'list2', id: { entry_id: 'e2' }, list: { id: { list_id: 'list2' }, name: 'List B' } }
+          ]
+        }
+      };
+      mockAxiosInstance.post.mockResolvedValue(mockResponse);
+
+      const result = await getCompanyLists(companyId);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/lists-entries/query', {
+        filter: { record_id: { '$equals': companyId } },
+        expand: ['list'],
+        limit: 50
+      });
+      expect(result).toEqual([mockResponse.data.data[0].list, mockResponse.data.data[1].list]);
     });
   });
 


### PR DESCRIPTION
## Summary
- add `getCompanyLists` to fetch all lists a company belongs to
- expose the new helper via company index
- add `get-company-lists` tool config and definition
- document the tool and mark Issue #184 resolved
- update tool reference docs
- test retrieving company lists
- fix newline endings in docs and code

## Testing
- `npm run build` *(fails: Cannot find module 'axios' or its corresponding type declarations)*
- `npm test` *(fails: jest not found)*