### PR TITLE
Fix: log retrieval errors when fetching company lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "dotenv": "^16.5.0",
     "handlebars": "^4.7.8",
     "ora": "^7.0.1",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "axios": "^1.9.0"
   },
   "author": "@hmk",
   "license": "BSD-3-Clause",
@@ -58,7 +59,6 @@
     "@types/jest": "^29.5.14",
     "@types/string-similarity": "^4.0.2",
     "@types/yargs": "^17.0.33",
-    "axios": "^1.9.0",
     "jest": "^29.7.0",
     "shx": "^0.4.0",
     "ts-jest": "^29.2.5",

--- a/src/objects/companies/relationships.ts
+++ b/src/objects/companies/relationships.ts
@@ -1,9 +1,11 @@
 /**
  * Relationship-based queries for companies
  */
-import { 
-  ResourceType, 
-  Company 
+import {
+  ResourceType,
+  Company,
+  AttioList,
+  AttioListEntry
 } from "../../types/attio.js";
 import { ListEntryFilters } from "../../api/operations/index.js";
 import { FilterValidationError } from "../../errors/api-errors.js";
@@ -171,8 +173,9 @@ export async function getCompanyLists(
       try {
         const detail = await getListDetails(listId);
         lists.push(detail);
-      } catch {
-        // ignore retrieval errors
+      } catch (error) {
+        // ignore retrieval errors but log for debugging
+        console.error(`Failed to retrieve list ${listId}:`, error);
       }
     }
   }


### PR DESCRIPTION
## Summary
- import missing AttioList types
- move axios to runtime dependencies
- log errors when fetching list details in `getCompanyLists`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run check` *(fails: cannot find module 'axios' and missing @types/node)*
