### PR TITLE
Fix email search filter

### DIFF
--- a/src/api/operations/search.ts
+++ b/src/api/operations/search.ts
@@ -38,7 +38,7 @@ export async function searchObject<T extends AttioRecord>(
     filter = {
       "$or": [
         { name: { "$contains": query } },
-        { email: { "$contains": query } },
+        { email_addresses: { "$contains": query } },
         { phone: { "$contains": query } }
       ]
     };

--- a/test/objects/people.test.ts
+++ b/test/objects/people.test.ts
@@ -103,7 +103,7 @@ describe('People API functions', () => {
         filter: {
           "$or": [
             { name: { "$contains": "john.doe@example.com" } },
-            { email: { "$contains": "john.doe@example.com" } },
+            { email_addresses: { "$contains": "john.doe@example.com" } },
             { phone: { "$contains": "john.doe@example.com" } }
           ]
         }
@@ -144,7 +144,7 @@ describe('People API functions', () => {
         filter: {
           "$or": [
             { name: { "$contains": "+1234567890" } },
-            { email: { "$contains": "+1234567890" } },
+            { email_addresses: { "$contains": "+1234567890" } },
             { phone: { "$contains": "+1234567890" } }
           ]
         }


### PR DESCRIPTION
## Summary
- ensure searchPeopleByEmail uses the correct `email_addresses` attribute
- update tests for the new filter slug

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '../../src/api/attio-client.js')*
- `npm run lint:check` *(fails: wireit not found)*
- `npm run check:format` *(fails: code style issues found in many files)*