### PR TITLE
Fix create-person duplicate and company validation

### DIFF
--- a/src/api/attribute-types.ts
+++ b/src/api/attribute-types.ts
@@ -204,6 +204,23 @@ export function clearAttributeCache(objectSlug?: string): void {
 }
 
 /**
+ * Looks up the API slug for an attribute by its ID
+ *
+ * @param objectSlug - The object type
+ * @param attributeId - The attribute's unique ID
+ * @returns The corresponding slug or null if not found
+ */
+export async function getAttributeSlugById(objectSlug: string, attributeId: string): Promise<string | null> {
+  const metadata = await getObjectAttributeMetadata(objectSlug);
+  for (const [slug, attr] of metadata.entries()) {
+    if (attr.id.attribute_id === attributeId) {
+      return slug;
+    }
+  }
+  return null;
+}
+
+/**
  * Gets field validation rules based on attribute metadata
  * 
  * @param objectSlug - The object type

--- a/test/validators/person-validator-enhanced.test.ts
+++ b/test/validators/person-validator-enhanced.test.ts
@@ -1,0 +1,54 @@
+import { PersonValidator } from '../../src/objects/people-write.js';
+import { searchPeopleByEmail } from '../../src/objects/people/search.js';
+import { searchCompaniesByName } from '../../src/objects/companies/search.js';
+
+vi.mock('../../src/objects/people/search.js', () => ({
+  searchPeopleByEmail: vi.fn(),
+}));
+
+vi.mock('../../src/objects/companies/search.js', () => ({
+  searchCompaniesByName: vi.fn(),
+}));
+
+describe('PersonValidator.validateCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reject duplicate email addresses', async () => {
+    (searchPeopleByEmail as vi.Mock).mockResolvedValue([
+      { id: { record_id: 'p1' } },
+    ]);
+    const attrs = { name: 'Test', email_addresses: ['dup@example.com'] } as any;
+    await expect(PersonValidator.validateCreate(attrs)).rejects.toThrow(
+      'Person with email dup@example.com already exists'
+    );
+  });
+
+  it('should resolve company name to record id', async () => {
+    (searchPeopleByEmail as vi.Mock).mockResolvedValue([]);
+    (searchCompaniesByName as vi.Mock).mockResolvedValue([
+      { id: { record_id: 'comp_1' } },
+    ]);
+    const attrs = {
+      name: 'Test',
+      company: 'Acme',
+      email_addresses: ['a@b.com'],
+    } as any;
+    const result = await PersonValidator.validateCreate(attrs);
+    expect(result.company).toEqual({ record_id: 'comp_1' });
+  });
+
+  it('should throw error when company name not found', async () => {
+    (searchPeopleByEmail as vi.Mock).mockResolvedValue([]);
+    (searchCompaniesByName as vi.Mock).mockResolvedValue([]);
+    const attrs = {
+      name: 'Test',
+      company: 'None',
+      email_addresses: ['a@b.com'],
+    } as any;
+    await expect(PersonValidator.validateCreate(attrs)).rejects.toThrow(
+      "Company 'None' not found. Provide a valid company ID."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- detect duplicate emails when creating a person
- resolve company names to IDs when creating a person
- map attribute ID to slug on uniqueness error
- add helper `getAttributeSlugById`
- test enhanced person validation

## Testing
- `npm run build`
- `npm test` *(fails: API client not initialized)*
- `npm run lint:check` *(fails: wireit not found)*
- `npm run check:format` *(fails: code style issues)*