### PR TITLE
Fix categories and postal code handling

### DIFF
--- a/src/utils/attribute-mapping/legacy-maps.ts
+++ b/src/utils/attribute-mapping/legacy-maps.ts
@@ -30,8 +30,8 @@ export const LEGACY_ATTRIBUTE_MAP: Record<string, string> = {
   'City': 'city',
   'State': 'state',
   'Country': 'country',
-  'ZIP': 'zip',
-  'Postal Code': 'zip',
+  'ZIP': 'postal_code',
+  'Postal Code': 'postal_code',
 
   // People attributes 
   'First Name': 'first_name',

--- a/src/validators/company-validator.ts
+++ b/src/validators/company-validator.ts
@@ -96,21 +96,31 @@ export class CompanyValidator {
         CompanyValidator.fieldTypeCache.set(fieldName, fieldType);
       }
         
-      // Convert value if it's a boolean field but the value is a string or number
+      // Convert booleans represented as strings/numbers
       if (fieldType === 'boolean' && (typeof value === 'string' || typeof value === 'number')) {
         return convertToBoolean(value);
       }
+
+      // Convert single string to array for multiselect fields
+      if (fieldType === 'array' && typeof value === 'string') {
+        return [value];
+      }
     } catch (error) {
       // If field type detection fails, try a heuristic approach based on field naming
-      if (CompanyValidator.isBooleanFieldByName(fieldName) && 
+      if (CompanyValidator.isBooleanFieldByName(fieldName) &&
           (typeof value === 'string' || typeof value === 'number')) {
         try {
           return convertToBoolean(value);
         } catch (conversionError) {
-          console.warn(`Failed to convert potential boolean value for field '${fieldName}':`, 
+          console.warn(`Failed to convert potential boolean value for field '${fieldName}':`,
             conversionError instanceof Error ? conversionError.message : String(conversionError));
           // Return the original value if conversion fails
         }
+      }
+
+      // Heuristic for array fields when type detection fails
+      if (fieldName.toLowerCase().includes('categories') && typeof value === 'string') {
+        return [value];
       }
     }
     

--- a/test/integration/attribute-validation-integration.test.ts
+++ b/test/integration/attribute-validation-integration.test.ts
@@ -57,6 +57,14 @@ const MOCK_ATTRIBUTE_METADATA = {
     attioType: 'url',
     metadata: { api_slug: 'website', type: 'url' }
   },
+  categories: {
+    fieldType: 'array',
+    isArray: true,
+    isRequired: false,
+    isUnique: false,
+    attioType: 'select',
+    metadata: { api_slug: 'categories', type: 'select', is_multiselect: true }
+  },
   tags: {
     fieldType: 'array',
     isArray: true,
@@ -114,6 +122,7 @@ describe('Attribute Validation Integration', () => {
         founded_date: '2020-01-15',
         website: 'https://acme.example.com',
         tags: 'enterprise',        // Single string that should be in array
+        categories: 'Health Care', // Single string to convert to array
         description: 'A test company'
       };
       
@@ -128,6 +137,7 @@ describe('Attribute Validation Integration', () => {
         founded_date: '2020-01-15',
         website: 'https://acme.example.com',
         tags: ['enterprise'],      // Converted to array
+        categories: ['Health Care'], // Converted to array
         description: 'A test company'
       });
       
@@ -137,6 +147,7 @@ describe('Attribute Validation Integration', () => {
       expect(result.company_size).toBe(250);        // String converted to number
       expect(result.is_customer).toBe(true);        // String converted to boolean
       expect(result.tags).toEqual(['enterprise']);  // String converted to array
+      expect(result.categories).toEqual(['Health Care']);
     });
     
     it('should validate and convert company update attributes', async () => {
@@ -144,7 +155,8 @@ describe('Attribute Validation Integration', () => {
       const companyData = {
         company_size: '500',        // String that should be converted to number
         is_customer: 0,             // Number that should be converted to boolean (false)
-        tags: ['enterprise', 'b2b'] // Array that remains array
+        tags: ['enterprise', 'b2b'],
+        categories: ['B2C']         // Array input should remain array
       };
       
       // Validate using the enhanced validator
@@ -154,7 +166,8 @@ describe('Attribute Validation Integration', () => {
       expect(result).toMatchObject({
         company_size: 500,          // Converted to number
         is_customer: false,         // Converted to boolean
-        tags: ['enterprise', 'b2b'] // Still an array
+        tags: ['enterprise', 'b2b'],
+        categories: ['B2C']
       });
       
       // Verify that validation occurred and data was processed correctly

--- a/test/utils/attribute-mapping-enhancement.test.ts
+++ b/test/utils/attribute-mapping-enhancement.test.ts
@@ -159,9 +159,24 @@ describe('Enhanced Attribute Mapping', () => {
           relationships: {},
         },
       });
-      
+
       // Should convert snake case to display name and then look up
       expect(getAttributeSlug('account_manager')).toBe('account_manager');
+    });
+
+    it('should map postal code fields without converting to zip', () => {
+      (configLoader.loadMappingConfig as vi.Mock).mockReturnValue({
+        version: '1.0',
+        mappings: {
+          attributes: { common: {}, objects: {}, custom: {} },
+          objects: {},
+          lists: {},
+          relationships: {},
+        },
+      });
+
+      expect(getAttributeSlug('postal_code')).toBe('postal_code');
+      expect(getAttributeSlug('ZIP')).toBe('postal_code');
     });
   });
   


### PR DESCRIPTION
## Summary
- convert single strings to arrays for multiselect fields such as categories
- update legacy attribute mapping so postal codes map to `postal_code`
- test category string conversion in validator integration tests
- test postal code mapping in attribute mapping tests

## Testing
- `npm run build`
- `npm run check` *(fails: wireit not found)*
- `npm test:offline` *(fails: multiple tests fail in offline environment)*
- `npm run lint:check` *(fails: wireit not found)*
- `npm run check:format`