### PR TITLE
Refactor: replace some any types with unknown

### DIFF
--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -8,7 +8,7 @@ import { RetryConfig, ListEntryFilter } from "../api/operations/index.js";
  */
 export interface AttioValue<T> {
   value: T;
-  [key: string]: any; // Additional fields that might be present
+  [key: string]: unknown; // Additional fields that might be present
 }
 
 /**
@@ -178,7 +178,7 @@ export interface BatchItemResult<R> {
   id?: string;     // Optional ID matching the request ID if provided
   success: boolean; // Whether this specific operation succeeded
   data?: R;        // The result data if successful
-  error?: any;     // Error information if failed
+  error?: unknown;     // Error information if failed
 }
 
 /**
@@ -315,12 +315,12 @@ export enum RelationshipType {
  */
 export interface AttioErrorResponse {
   status?: number;
-  data?: any;
+  data?: unknown;
   headers?: Record<string, string>;
   error?: string;
   message?: string;
-  details?: any;
-  [key: string]: any;
+  details?: unknown;
+  [key: string]: unknown;
 }
 
 /**
@@ -365,7 +365,7 @@ export interface PersonCreateAttributes {
   phone_numbers?: string[];
   job_title?: string;
   company?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface Company extends AttioRecord {

--- a/src/types/company-types.ts
+++ b/src/types/company-types.ts
@@ -20,7 +20,7 @@ export interface CompanyCreateInput {
     postal_code?: string;
     country?: string;
   };
-  [key: string]: any; // Allow additional properties
+  [key: string]: unknown; // Allow additional properties
 }
 
 /**
@@ -41,7 +41,7 @@ export interface CompanyUpdateInput {
     postal_code?: string;
     country?: string;
   };
-  [key: string]: any; // Allow additional properties
+  [key: string]: unknown; // Allow additional properties
 }
 
 /**

--- a/src/types/overrides/cacheable-request.d.ts
+++ b/src/types/overrides/cacheable-request.d.ts
@@ -31,7 +31,7 @@ declare module 'cacheable-request' {
   }
   
   interface Options {
-    cache?: any;
+    cache?: unknown;
     strictTtl?: boolean;
     automaticFailover?: boolean;
     forceRefresh?: boolean;

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -34,9 +34,9 @@ export interface ToolResponse {
     code: number;
     message: string;
     type?: string;
-    details?: any;
+    details?: unknown;
   };
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -60,7 +60,7 @@ export interface ListResponse<T> {
  */
 export function formatSuccessResponse(
   message: string,
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 ): ToolResponse {
   return {
     content: [
@@ -89,7 +89,7 @@ export function formatListResponse<T>(
   items: T[],
   formatter: (item: T) => string,
   pagination?: { total?: number; hasMore?: boolean; nextCursor?: string },
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 ): ToolResponse {
   const itemsText = items.length > 0
     ? items.map(formatter).join('\n')
@@ -132,7 +132,7 @@ export function formatRecordResponse<T>(
   title: string,
   record: T,
   formatter: (record: T) => string,
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 ): ToolResponse {
   return {
     content: [
@@ -159,8 +159,8 @@ export function formatRecordResponse<T>(
  */
 export function formatJsonResponse(
   title: string,
-  data: any,
-  metadata?: Record<string, any>
+  data: unknown,
+  metadata?: Record<string, unknown>
 ): ToolResponse {
   const response = {
     content: [
@@ -190,7 +190,7 @@ export function formatJsonResponse(
 export function formatMarkdownResponse(
   title: string,
   markdown: string,
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 ): ToolResponse {
   return {
     content: [
@@ -215,7 +215,7 @@ export function formatMarkdownResponse(
 export function formatMultiPartResponse(
   title: string,
   parts: ResponseContent[],
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 ): ToolResponse {
   return {
     content: [
@@ -237,7 +237,7 @@ export function formatMultiPartResponse(
  * @returns Formatted tool response
  */
 export function formatEmptyResponse(
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 ): ToolResponse {
   return {
     content: [],
@@ -259,7 +259,7 @@ export function formatErrorResponse(
   message: string,
   code: number = 500,
   type: string = 'unknown_error',
-  details?: any
+  details?: unknown
 ): ToolResponse {
   const response = {
     content: [


### PR DESCRIPTION
## Summary
- update company type definitions to avoid `any`
- clean up cacheable-request override types
- improve API fallback error handling
- tighten tool response typing and generics
- tweak Attio shared types

## Testing
- `npm run build`
- `npm test` *(fails: API client not initialized)*
- `npm run lint:check` *(fails: wireit not found)*
- `npm run check:format` *(fails: code style issues)*