### PR TITLE
Fix array field validation

### DIFF
--- a/src/validators/company-validator.ts
+++ b/src/validators/company-validator.ts
@@ -382,6 +382,10 @@ export class CompanyValidator {
         
       case 'array':
         if (!Array.isArray(value)) {
+          // Allow single string values to be converted to an array later
+          if (typeof value === 'string') {
+            return;
+          }
           throw new InvalidCompanyFieldTypeError(field, 'array', actualType);
         }
         break;


### PR DESCRIPTION
## Summary
- allow string values for array fields in company validator so single value `categories` input works

## Testing
- `npm run build`
- `npm run check` *(fails: `wireit: not found`)*
- `npm test` *(fails: API client not initialized and other errors)*
- `npm run lint:check` *(fails: `wireit: not found`)*
- `npm run check:format` *(fails: syntax errors in test files)*