### PR TITLE
Implement configurable industry field mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Model Context Protocol (MCP) server for [Attio](https://attio.com/), the AI-na
 ## 🚀 Key Features
 
 - **Comprehensive Attio API Support**
+
   - Companies: Search, view details, manage notes
   - People: Search (with email/phone support), view details, manage notes
   - Lists: View, manage entries, add/remove records
@@ -59,6 +60,24 @@ npm install attio-mcp-server
 }
 ```
 
+### Custom Field Mappings
+
+The server supports instance-specific field mappings via `config/field-mappings.json`.
+Use this file to map friendly attribute names to the correct Attio fields. Example:
+
+```json
+{
+  "companies": {
+    "industry": {
+      "primary_field": "type_persona",
+      "fallback_field": "categories"
+    }
+  }
+}
+```
+
+This maps the `industry` input to the `type_persona` field when available and falls back to `categories`.
+
 ## 🌐 Deployment Options
 
 - **Local Development**: [Development Guide](./docs/development-guide.md)
@@ -72,11 +91,13 @@ npm install attio-mcp-server
 Full documentation is available in the [docs directory](./docs):
 
 - **Getting Started**
+
   - [Installation & Setup](./docs/getting-started.md)
   - [Claude Desktop Config](./docs/claude-desktop-config.md)
   - [Troubleshooting Guide](./TROUBLESHOOTING.md)
 
 - **API Reference**
+
   - [API Overview](./docs/api/api-overview.md)
   - [People API](./docs/api/people-api.md)
   - [Companies API](./docs/api/companies-api.md)
@@ -84,6 +105,7 @@ Full documentation is available in the [docs directory](./docs):
   - [Notes API](./docs/api/notes-api.md)
 
 - **Deployment**
+
   - [Docker Guide](./docs/docker/docker-guide.md)
   - [Security Best Practices](./docs/docker/security-guide.md)
 

--- a/config/field-mappings.json
+++ b/config/field-mappings.json
@@ -1,0 +1,8 @@
+{
+  "companies": {
+    "industry": {
+      "primary_field": "type_persona",
+      "fallback_field": "categories"
+    }
+  }
+}

--- a/shapescale-attio-crm.md
+++ b/shapescale-attio-crm.md
@@ -2,48 +2,51 @@
 
 This document provides a detailed overview of our custom Attio CRM setup for ShapeScale, including available attributes, field types, and common issues when interacting with these fields.
 
+> **Note:** The MCP server uses `config/field-mappings.json` to map friendly attribute names to our custom fields. For example, `industry` inputs are mapped to the `type_persona` select field in this workspace.
+
 ## Custom Attributes
 
 Based on the API interactions, our Attio instance has the following custom attributes for company records:
 
 ### Custom Fields (28 total)
 
-| Field Name | Type | Notes |
-|------------|------|-------|
-| body_composition_technologies | text (string) | Describes what technologies a company uses for body composition analysis |
-| body_contouring | text (string) | Details about body contouring services offered |
-| company_phone_5 | text (string) | Phone number field, likely the fifth phone number for a company |
-| competitor_use | select | Information about competitors they use |
-| domain_confidence | number | Confidence level in the domain information (0-100%) |
-| facilities | select | Number of facilities (options include "1") |
-| google_business_name | text (string) | Business name on Google |
-| google_business_status | select | Business status on Google (e.g., "operational", "closed") |
-| google_credibility_score | number | Credibility score from Google |
-| google_maps_url | text (string) | Google Maps URL |
-| google_price_level | select | Price level indicator from Google (e.g., "$", "$$", "$$$") |
-| google_rating_1 | number | Google rating (usually 1-5) |
-| google_review_count_7 | number | Number of Google reviews |
-| google_website | text (string) | Website listed on Google |
-| has_before_after_photos | boolean | Whether they have before/after photos |
-| has_body_contouring | boolean | Whether they offer body contouring services |
-| has_weight_loss_program | boolean | Whether they have a weight loss program |
-| referrer | select | Referral source information (options include "Website", "Virtual Demo") |
-| referrer_notes | text (string) | Notes about referrals |
-| regions | text (string) | Geographic regions served |
-| services | text (string) | Comprehensive list of services offered |
-| strongest_connection_strength_legacy | number | Legacy field for connection strength |
-| trade_show_event_7 | select | Trade show/event information |
-| type_persona | select | Company persona type (options include "Plastic Surgeon") |
-| type_persona_5 | select | Alternative persona classification |
-| typpe | select | Company type classification (options include "Potential Customer") |
-| uses_body_composition | boolean | Whether they use body composition analysis |
-| uses_competitor_products | boolean | Whether they use competitor products |
+| Field Name                           | Type          | Notes                                                                    |
+| ------------------------------------ | ------------- | ------------------------------------------------------------------------ |
+| body_composition_technologies        | text (string) | Describes what technologies a company uses for body composition analysis |
+| body_contouring                      | text (string) | Details about body contouring services offered                           |
+| company_phone_5                      | text (string) | Phone number field, likely the fifth phone number for a company          |
+| competitor_use                       | select        | Information about competitors they use                                   |
+| domain_confidence                    | number        | Confidence level in the domain information (0-100%)                      |
+| facilities                           | select        | Number of facilities (options include "1")                               |
+| google_business_name                 | text (string) | Business name on Google                                                  |
+| google_business_status               | select        | Business status on Google (e.g., "operational", "closed")                |
+| google_credibility_score             | number        | Credibility score from Google                                            |
+| google_maps_url                      | text (string) | Google Maps URL                                                          |
+| google_price_level                   | select        | Price level indicator from Google (e.g., "$", "$$", "$$$")               |
+| google_rating_1                      | number        | Google rating (usually 1-5)                                              |
+| google_review_count_7                | number        | Number of Google reviews                                                 |
+| google_website                       | text (string) | Website listed on Google                                                 |
+| has_before_after_photos              | boolean       | Whether they have before/after photos                                    |
+| has_body_contouring                  | boolean       | Whether they offer body contouring services                              |
+| has_weight_loss_program              | boolean       | Whether they have a weight loss program                                  |
+| referrer                             | select        | Referral source information (options include "Website", "Virtual Demo")  |
+| referrer_notes                       | text (string) | Notes about referrals                                                    |
+| regions                              | text (string) | Geographic regions served                                                |
+| services                             | text (string) | Comprehensive list of services offered                                   |
+| strongest_connection_strength_legacy | number        | Legacy field for connection strength                                     |
+| trade_show_event_7                   | select        | Trade show/event information                                             |
+| type_persona                         | select        | Company persona type (options include "Plastic Surgeon")                 |
+| type_persona_5                       | select        | Alternative persona classification                                       |
+| typpe                                | select        | Company type classification (options include "Potential Customer")       |
+| uses_body_composition                | boolean       | Whether they use body composition analysis                               |
+| uses_competitor_products             | boolean       | Whether they use competitor products                                     |
 
 ### Key Field Values and Options
 
 Based on our analysis, we've identified some important field values used in the CRM:
 
 #### Company Type ("typpe")
+
 The "typpe" field is a select field used to categorize companies by their relationship with ShapeScale:
 
 - "Existing Customer" - Current users of ShapeScale products
@@ -63,9 +66,11 @@ The "typpe" field is a select field used to categorize companies by their relati
 The unusual spelling "typpe" (with double 'p') appears to be intentional to distinguish it from other "type" fields in the system.
 
 #### Type Persona
+
 The "type_persona" field categorizes companies by their business type or specialty:
 
 ##### Medical & Health Categories
+
 - "Plastic Surgeon" - Medical specialists offering cosmetic and reconstructive procedures
 - "Medical Spa/Aesthetics" - Businesses offering medical-grade aesthetic services
 - "Medical Weight Loss" - Practices specializing in weight loss under medical supervision
@@ -77,6 +82,7 @@ The "type_persona" field categorizes companies by their business type or special
 - "Wellness" - Holistic health and well-being providers
 
 ##### Fitness Categories
+
 - "Personal Trainer/Solo Owner" - Individual fitness professionals
 - "PT Gym" - Personal training-focused facilities
 - "Boutique/Studio Gym" - Specialized, smaller fitness facilities
@@ -87,6 +93,7 @@ The "type_persona" field categorizes companies by their business type or special
 - "Corporate, Residential, or Hotel Facility" - Fitness facilities in these settings
 
 ##### Industry Partners
+
 - "Equipment Manufacturer" - Makers of fitness or body composition equipment
 - "Distributor or Retailer" - Companies that distribute or sell fitness equipment
 - "Consultant" - Advisory professionals in the industry
@@ -96,11 +103,13 @@ The "type_persona" field categorizes companies by their business type or special
 - "Retail/Nutrition Store" - Retail locations specializing in nutrition products
 
 ##### Knowledge & Research
+
 - "University/Research" - Academic or research institutions
 - "Educational Platform" - Organizations providing educational content
 - "Professional Association/Network" - Industry groups and networks
 
 ##### Other Categories
+
 - "Event/Conference Organizer" - Companies that run industry events
 - "Industry Media/Publication" - Media outlets focusing on the industry
 - "Spa" - Non-medical spa facilities
@@ -109,11 +118,13 @@ The "type_persona" field categorizes companies by their business type or special
 - "Unknown" - Companies whose type has not yet been determined
 
 #### Referrer
+
 - "Website" - Lead came through the website
 - "Virtual Demo" - Lead came through a virtual demo session
 - (Other options may exist)
 
 #### Categories
+
 - "Health Care"
 - "B2C"
 - "E-commerce"
@@ -121,6 +132,7 @@ The "type_persona" field categorizes companies by their business type or special
 ### Standard Fields (43 total)
 
 The CRM also includes 43 standard fields like:
+
 - about
 - description
 - website
@@ -193,10 +205,11 @@ When interacting with the Attio API through the MCP server, several issues were 
 When providing instructions to an LLM that interacts with this Attio MCP server:
 
 1. **Type Enforcement**: For boolean fields, explicitly send boolean values (true/false), not strings ("true"/"false").
+
    ```javascript
    // Correct
    { "value": false, ... }
-   
+
    // Incorrect
    { "value": "false", ... }
    ```
@@ -215,7 +228,7 @@ When providing instructions to an LLM that interacts with this Attio MCP server:
 
 For ShapeScale's use case, we track:
 
-1. Whether a company uses body composition technology 
+1. Whether a company uses body composition technology
 2. What specific body composition technologies they use
 3. Details about their body contouring services
 4. Complete service offerings
@@ -256,6 +269,7 @@ According to the Attio API documentation, "stage" is a **standard attribute type
 The **Prospecting list** (ID: 88709359-01f6-478b-ba66-c07347891b6f) in our ShapeScale Attio instance uses a **custom stage configuration** with the following stage options:
 
 #### Current Stage Options:
+
 1. `"Unresponsive"` - Prospects who haven't responded to outreach
 2. `"Interested"` - Prospects who have shown initial interest
 3. `"Discovery Call"` - Scheduled or completed discovery calls
@@ -276,6 +290,7 @@ The **Prospecting list** (ID: 88709359-01f6-478b-ba66-c07347891b6f) in our Shape
 ### Stage Management Challenges
 
 Currently, the Attio MCP server lacks the tools to:
+
 - Update list entry stage values (e.g., changing from "Interested" to "Demo Scheduling")
 - Read current stage values for list entries
 - Filter list entries by stage
@@ -303,6 +318,7 @@ This represents a significant gap in CRM functionality, as stage management is e
 **Issue**: The `facilities` field is a select field with specific predefined options. Using incorrect values causes API errors.
 
 **Error Example**:
+
 ```
 Request
 
@@ -330,8 +346,9 @@ Response: ERROR [unknown_error]: Company update failed for company d5cda19b-b316
 **Solution**: Use only the predefined select options for the `facilities` field:
 
 #### Valid Facilities Options:
+
 - `"1"` - Single location
-- `"2-5"` - 2-5 locations  
+- `"2-5"` - 2-5 locations
 - `"6-10"` - 6-10 locations
 - `"11-25"` - 11-25 locations
 - `"26-50"` - 26-50 locations
@@ -341,16 +358,15 @@ Response: ERROR [unknown_error]: Company update failed for company d5cda19b-b316
 - `"Unknown"` - Unknown number of locations
 
 **Correct Usage**:
+
 ```json
 {
   "companyId": "d5cda19b-b316-5453-ae0d-c7cb3ec29ef2",
   "attributes": {
     "website": "https://ptsolutionsks.com",
     "services": "Physical Therapy, Orthopedic Rehabilitation, Sports Medicine, Concussion Care, Outpatient Therapy",
-    "categories": [
-      "Physical Therapy"
-    ],
-    "facilities": "2-5",  // ✅ CORRECT - use exact option value
+    "categories": ["Physical Therapy"],
+    "facilities": "2-5", // ✅ CORRECT - use exact option value
     "type_persona": "Medical Practice",
     "employee_range": "10-25",
     "body_contouring": "No",
@@ -362,6 +378,7 @@ Response: ERROR [unknown_error]: Company update failed for company d5cda19b-b316
 ```
 
 **Key Points**:
+
 1. Always use the exact option value, not descriptive text
 2. The `facilities` field expects a string value matching one of the predefined options
 3. Geographic information (like "in Kansas") should be stored in location fields, not the facilities count field
@@ -371,6 +388,7 @@ Response: ERROR [unknown_error]: Company update failed for company d5cda19b-b316
 **Issue**: The `categories` field expects an array of strings, not a single string value. Using a string value causes a field type error.
 
 **Error Example**:
+
 ```
 Request
 
@@ -388,32 +406,31 @@ Response: ERROR [unknown_error]: Invalid company data: Field 'categories' must b
 **Solution**: Always provide categories as an array of strings, even for single values:
 
 **Correct Usage**:
+
 ```json
 {
   "attributes": {
     "name": "The Plastics Doc",
-    "categories": ["Medical Practice"],  // ✅ CORRECT - array with single value
+    "categories": ["Medical Practice"], // ✅ CORRECT - array with single value
     "website": "https://www.theplasticsdoc.com"
   }
 }
 ```
 
 **Multiple Categories Example**:
+
 ```json
 {
   "attributes": {
     "name": "The Plastics Doc",
-    "categories": [
-      "Health Care",
-      "Medical Practice", 
-      "B2C"
-    ],  // ✅ CORRECT - array with multiple values
+    "categories": ["Health Care", "Medical Practice", "B2C"], // ✅ CORRECT - array with multiple values
     "website": "https://www.theplasticsdoc.com"
   }
 }
 ```
 
 #### Valid Categories Options:
+
 - `"Health Care"`
 - `"B2C"` (Business to Consumer)
 - `"E-commerce"`
@@ -424,8 +441,9 @@ Response: ERROR [unknown_error]: Invalid company data: Field 'categories' must b
 **Note**: ~~`"Medical Practice"`~~ was previously listed here but is NOT a valid option - this causes a "Cannot find select option" error.
 
 **Key Points**:
+
 1. Categories field type is **array**, not string
-2. Always wrap category values in square brackets `[]` 
+2. Always wrap category values in square brackets `[]`
 3. Single categories still need to be in an array format: `["Health Care"]`
 4. Multiple categories can be provided: `["Health Care", "B2C", "Sports & Fitness"]`
 5. This is one of the most common field type errors in company creation/updates
@@ -436,6 +454,7 @@ Response: ERROR [unknown_error]: Invalid company data: Field 'categories' must b
 **Issue**: The `postal_code` field causes an error claiming that the "zip" attribute cannot be found, suggesting there's a field mapping issue or the wrong field name is being used.
 
 **Error Example**:
+
 ```
 Request
 
@@ -464,10 +483,11 @@ The error indicates the system is looking for an attribute called "zip" when the
 **Possible Solutions** (need to be tested):
 
 **Option 1 - Use "zip" instead**:
+
 ```json
 {
   "attributes": {
-    "zip": "92584",  // ✅ Try using "zip" instead of "postal_code"
+    "zip": "92584", // ✅ Try using "zip" instead of "postal_code"
     "city": "Corona",
     "state": "CA"
   }
@@ -475,12 +495,13 @@ The error indicates the system is looking for an attribute called "zip" when the
 ```
 
 **Option 2 - Use structured location**:
+
 ```json
 {
   "attributes": {
     "primary_location": {
       "city": "Corona",
-      "state": "CA", 
+      "state": "CA",
       "postal_code": "92584",
       "street_address": "4226 Green River Rd"
     }
@@ -489,6 +510,7 @@ The error indicates the system is looking for an attribute called "zip" when the
 ```
 
 **Key Points**:
+
 1. Avoid using "postal_code" as a top-level attribute until this is resolved
 2. Test with "zip" field name instead
 3. Consider using structured location data in "primary_location"
@@ -499,13 +521,14 @@ The error indicates the system is looking for an attribute called "zip" when the
 **Issue**: Some category options that appear logical or were previously documented don't actually exist in the Attio schema, causing "Cannot find select option" errors.
 
 **Error Example**:
+
 ```
 Request
 
 {
   "attributes": {
     "name": "The Plastics Doc",
-    "website": "https://www.theplasticsdoc.com", 
+    "website": "https://www.theplasticsdoc.com",
     "categories": ["Medical Practice"],  // ❌ This option doesn't exist
     "description": "Plastic surgery and medical spa practice..."
   }
@@ -524,19 +547,22 @@ This issue highlights several UX and system problems:
 5. **No Dynamic Creation**: Users can't create new category options when needed
 
 **Current Verified Valid Categories**:
+
 - `"Health Care"` ✅
 - `"B2C"` (Business to Consumer) ✅
 - `"E-commerce"` ✅
-- `"Sports & Fitness"` ✅ 
+- `"Sports & Fitness"` ✅
 - `"Health & Wellness"` ✅
 - `"Physical Therapy"` ✅
 
 **Invalid Categories** (cause errors):
+
 - ~~`"Medical Practice"`~~ ❌ - Use "Health Care" instead
 
 **Suggested User Experience Improvements**:
 
 1. **Fuzzy Matching**: When an invalid option is provided, suggest similar valid options
+
    ```
    Error: "Medical Practice" not found. Did you mean:
    - "Health Care"
@@ -544,11 +570,13 @@ This issue highlights several UX and system problems:
    ```
 
 2. **Dynamic Option Discovery**: API endpoint to list all valid category options
+
    ```
    GET /categories/options
    ```
 
 3. **Option Creation**: Allow creating new category options through the API (if Attio supports it)
+
    ```
    POST /categories/options
    { "title": "Medical Practice" }
@@ -556,18 +584,20 @@ This issue highlights several UX and system problems:
 
 4. **Better Error Messages**: Include valid options list in error responses
 
-**Workaround**: 
+**Workaround**:
 Use "Health Care" instead of "Medical Practice" for medical businesses:
+
 ```json
 {
   "attributes": {
-    "categories": ["Health Care"],  // ✅ CORRECT - use valid option
+    "categories": ["Health Care"], // ✅ CORRECT - use valid option
     "name": "The Plastics Doc"
   }
 }
 ```
 
 **Key Points**:
+
 1. Always validate category options against current schema before use
 2. When in doubt, use broader categories like "Health Care" instead of specific ones
 3. This issue exists for other select fields too (facilities, type_persona, etc.)
@@ -582,6 +612,7 @@ ShapeScale's CRM uses a robust segmentation system for categorizing different ty
 The primary segmentation field is "type_persona", which includes a comprehensive set of values organized into categories:
 
 1. **Medical Specialists**:
+
    - "Plastic Surgeon" - Medical professionals specializing in cosmetic and reconstructive procedures
    - "Medical Spa/Aesthetics" - Businesses offering medical-grade aesthetic services
    - "Medical Weight Loss" - Practices specializing in weight loss under medical supervision
@@ -590,6 +621,7 @@ The primary segmentation field is "type_persona", which includes a comprehensive
    - "Integrated Health" - Providers combining conventional and alternative medicine
 
 2. **Fitness Professionals**:
+
    - "Personal Trainer/Solo Owner" - Individual fitness professionals
    - "PT Gym" - Personal training-focused facilities
    - "Boutique/Studio Gym" - Specialized, smaller fitness facilities
@@ -599,6 +631,7 @@ The primary segmentation field is "type_persona", which includes a comprehensive
    - "Wellness" - Holistic health and well-being providers
 
 3. **Corporate & Institutional**:
+
    - "Corporate Wellness" - Wellness programs for corporate environments
    - "Corporate, Residential, or Hotel Facility" - Fitness facilities in these settings
    - "University/Research" - Academic or research institutions
@@ -627,9 +660,10 @@ Medical spas are a particular focus in the CRM, with nearly 40 different medical
 A related field, "type_persona_5", appears to be used for alternative categorization but its specific values were not identified in the current analysis.
 
 The CRM also uses categories that overlap with persona types:
+
 - "Health Care"
 - "B2C" (Business to Consumer)
-- "Sports & Fitness" 
+- "Sports & Fitness"
 - "Health & Wellness"
 - "E-commerce"
 
@@ -639,22 +673,26 @@ ShapeScale's CRM is set up to track specific information about body composition 
 
 Key fields used for tracking body composition technologies include:
 
-1. **body_composition_technologies** (text field): 
+1. **body_composition_technologies** (text field):
+
    - Records detailed information about what specific technologies a company uses
    - Example value: "The practice primarily uses visual assessment and traditional measurements. They currently do not utilize any advanced body composition analysis technologies or 3D imaging for body composition."
    - Format: Typically contains 1-2 paragraphs of qualitative description
    - Used to identify gaps in a company's current technology stack
 
 2. **uses_body_composition** (boolean field):
+
    - Simple yes/no indicator of whether a company uses any body composition technology
    - Used for quick filtering of prospects
 
 3. **body_contouring** (text field):
+
    - Describes body contouring services offered by the company
    - Example value: "Comprehensive body contouring services including liposuction (BodySculpt™), tummy tucks with waist tucks, arm lifts, and thigh contouring. Specializes in personalized treatment plans for post-weight loss patients and those with stubborn fat deposits resistant to diet and exercise."
    - Helps identify potential use cases for ShapeScale's technology in tracking contouring results
 
 4. **has_body_contouring** (boolean field):
+
    - Quick indicator of whether a company offers body contouring services
    - Used for prospect segmentation
 
@@ -668,7 +706,6 @@ The CRM also tracks information about competitor products through:
 
 1. **uses_competitor_products** (boolean field):
    - Indicates if a company uses technologies that compete with ShapeScale
-   
 2. **competitor_use** (select field):
    - Specific competitor products being used
    - Used to tailor comparisons when making sales pitches
@@ -678,6 +715,7 @@ The CRM also tracks information about competitor products through:
 The CRM contains records of companies specializing in body composition technology:
 
 1. **DXAMetrics** (Boston DEXA Scan provider):
+
    - Specializes in DEXA scans, RMR, and VO2 max tests
    - Categorized as "Health Care", "B2C", "Sports & Fitness", and "Health & Wellness"
    - Potential competitor/partner as they offer complementary body composition analysis
@@ -692,10 +730,12 @@ The CRM contains records of companies specializing in body composition technolog
 Body composition technology information is integrated into the sales process, with particular attention to:
 
 1. **Type categorization**:
+
    - Companies using basic (visual assessment) vs. advanced technologies
    - Segmentation by technology type helps prioritize sales efforts
 
 2. **Geographical distribution**:
+
    - Regional differences in body composition technology adoption
    - Region-specific distribution partnerships (e.g., Sanny for Brazil)
 
@@ -708,14 +748,17 @@ Body composition technology information is integrated into the sales process, wi
 While there aren't dedicated fields specifically for "success metrics" in the traditional sense, ShapeScale's CRM does track several indicators that relate to the success of body scanning implementations:
 
 1. **Before/After Photo Usage**:
+
    - The "has_before_after_photos" boolean field identifies companies that already track visual progress
    - Companies using before/after photos are likely candidates for 3D scanning upgrades
 
 2. **Results Orientation**:
+
    - Companies with "results" in their name or business description are flagged for targeted messaging
    - These businesses tend to be more metrics-driven and receptive to body scanning technologies
 
 3. **Service Descriptions**:
+
    - The detailed "services" field often contains information about how results are measured and tracked
    - Example: "...specializes in personalized treatment plans and visual transformation results"
 
@@ -728,10 +771,12 @@ While there aren't dedicated fields specifically for "success metrics" in the tr
 ShapeScale's CRM doesn't appear to have dedicated fields for tracking equipment inventory or device deployments specifically. However, it does track:
 
 1. **Competitor Equipment Use**:
+
    - "uses_competitor_products" (boolean) indicates if a company uses competing technologies
    - "competitor_use" (select) specifies which competitor products are being used
 
 2. **Equipment Companies**:
+
    - The CRM contains entries for equipment providers like "Shandong Tianzhan Fitness Equipment Co."
    - These are potential manufacturing or distribution partners
 
@@ -744,15 +789,18 @@ ShapeScale's CRM doesn't appear to have dedicated fields for tracking equipment 
 The CRM has several fields for tracking geographical information:
 
 1. **Region Field**:
+
    - The "regions" select field categorizes companies by broad geographical regions
    - Known values include "Latin America"
    - This helps identify regional market trends and distribution opportunities
 
 2. **Primary Location**:
+
    - Structured location data including address, city, state, country
    - Includes lat/long coordinates for mapping capabilities
 
 3. **Regional Market Focus**:
+
    - Geographic-specific lists like "Weight Loss Management (SF Bay)"
    - Multiple companies can be grouped by region for targeted campaigns
 
@@ -765,30 +813,39 @@ The CRM has several fields for tracking geographical information:
 Based on analysis of the API responses and JSON data, we've identified the following attribute types in Attio:
 
 1. **text**: Simple text fields for storing strings
+
    - Examples: body_contouring, description, services
 
 2. **number**: Numeric fields for integers or decimals
+
    - Examples: google_rating_1, strongest_connection_strength_legacy, twitter_follower_count
 
 3. **boolean**: True/false flags
+
    - Examples: has_before_after_photos, uses_body_composition, has_body_contouring
 
 4. **select**: Dropdown fields with predefined options
+
    - Examples: type_persona, facilities, referrer, typpe
 
 5. **domain**: Special field type for website domains
+
    - Example: domains
 
 6. **timestamp**: Date and time fields
+
    - Example: created_at
 
 7. **date**: Date-only fields
+
    - Example: foundation_date
 
 8. **location**: Structured address information
+
    - Example: primary_location
 
 9. **record-reference**: References to other records (e.g., people)
+
    - Example: team
 
 10. **phone-number**: Structured phone number data

--- a/src/utils/attribute-mapping/attribute-mappers.ts
+++ b/src/utils/attribute-mapping/attribute-mappers.ts
@@ -3,19 +3,19 @@
  */
 import { loadMappingConfig, MappingConfig } from '../config-loader.js';
 import { LEGACY_ATTRIBUTE_MAP } from './legacy-maps.js';
-import { 
-  createCaseInsensitiveMap, 
-  lookupCaseInsensitive, 
-  lookupNormalized, 
+import {
+  createCaseInsensitiveMap,
+  lookupCaseInsensitive,
+  lookupNormalized,
   createNormalizedMap,
   createAggressiveNormalizedMap,
   lookupAggressiveNormalized,
-  handleSpecialCases
+  handleSpecialCases,
 } from './mapping-utils.js';
 
 /**
  * Converts a value to a boolean based on common string representations
- * 
+ *
  * @param value - The value to convert to boolean
  * @returns Boolean representation of the value
  */
@@ -27,14 +27,17 @@ export function convertToBoolean(value: any): boolean {
     if (['false', 'no', 'n', '0'].includes(lowerValue)) return false;
   }
   if (typeof value === 'number') return !isNaN(value) && value !== 0;
-  
+
   // If we can't determine, return the original value as boolean
   return Boolean(value);
 }
 
 // Error class for attribute mapping errors
 export class AttributeMappingError extends Error {
-  constructor(message: string, public details: Record<string, any> = {}) {
+  constructor(
+    message: string,
+    public details: Record<string, any> = {}
+  ) {
     super(message);
     this.name = 'AttributeMappingError';
   }
@@ -44,30 +47,45 @@ export class AttributeMappingError extends Error {
 let cachedConfig: MappingConfig | null = null;
 
 // Cache for case-insensitive lookups
-const caseInsensitiveCaches: Record<string, Map<string, { original: string; value: string }>> = {};
+const caseInsensitiveCaches: Record<
+  string,
+  Map<string, { original: string; value: string }>
+> = {};
 
 // Cache for normalized lookups (spaces removed, case insensitive)
-const normalizedCaches: Record<string, Map<string, { original: string; value: string }>> = {};
+const normalizedCaches: Record<
+  string,
+  Map<string, { original: string; value: string }>
+> = {};
 
 /**
  * Initialize lookup caches for faster mapping
- * 
+ *
  * @param config The configuration to create caches for
  */
 function initializeLookupCaches(config: MappingConfig): void {
   // Create case-insensitive lookup maps
-  caseInsensitiveCaches.common = createCaseInsensitiveMap(config.mappings.attributes.common);
-  caseInsensitiveCaches.custom = createCaseInsensitiveMap(config.mappings.attributes.custom);
-  caseInsensitiveCaches.objects = createCaseInsensitiveMap(config.mappings.objects);
+  caseInsensitiveCaches.common = createCaseInsensitiveMap(
+    config.mappings.attributes.common
+  );
+  caseInsensitiveCaches.custom = createCaseInsensitiveMap(
+    config.mappings.attributes.custom
+  );
+  caseInsensitiveCaches.objects = createCaseInsensitiveMap(
+    config.mappings.objects
+  );
   caseInsensitiveCaches.lists = createCaseInsensitiveMap(config.mappings.lists);
   caseInsensitiveCaches.legacy = createCaseInsensitiveMap(LEGACY_ATTRIBUTE_MAP);
-  
+
   // Create normalized lookup maps for fuzzy matching
   normalizedCaches.legacy = createNormalizedMap(LEGACY_ATTRIBUTE_MAP);
-  
+
   // Create maps for object-specific attributes
-  for (const [objectType, mappings] of Object.entries(config.mappings.attributes.objects)) {
-    caseInsensitiveCaches[`objects.${objectType}`] = createCaseInsensitiveMap(mappings);
+  for (const [objectType, mappings] of Object.entries(
+    config.mappings.attributes.objects
+  )) {
+    caseInsensitiveCaches[`objects.${objectType}`] =
+      createCaseInsensitiveMap(mappings);
   }
 }
 
@@ -83,7 +101,7 @@ function getConfig(): MappingConfig {
       initializeLookupCaches(cachedConfig);
     } catch (error) {
       console.error('Failed to load mapping configuration:', error);
-      
+
       // Create a simple config using the legacy map for backward compatibility
       cachedConfig = {
         version: '1.0',
@@ -91,14 +109,14 @@ function getConfig(): MappingConfig {
           attributes: {
             common: { ...LEGACY_ATTRIBUTE_MAP },
             objects: {},
-            custom: {}
+            custom: {},
           },
           objects: {},
           lists: {},
-          relationships: {}
-        }
+          relationships: {},
+        },
       };
-      
+
       // Initialize with fallback configuration
       initializeLookupCaches(cachedConfig);
     }
@@ -112,13 +130,13 @@ function getConfig(): MappingConfig {
  */
 export function invalidateConfigCache(): void {
   cachedConfig = null;
-  
+
   // Reset all lookup caches
-  Object.keys(caseInsensitiveCaches).forEach(key => {
+  Object.keys(caseInsensitiveCaches).forEach((key) => {
     delete caseInsensitiveCaches[key];
   });
-  
-  Object.keys(normalizedCaches).forEach(key => {
+
+  Object.keys(normalizedCaches).forEach((key) => {
     delete normalizedCaches[key];
   });
 }
@@ -127,311 +145,384 @@ export function invalidateConfigCache(): void {
  * Attempts snake case conversion and lookup for attribute mapping.
  * This function safely converts snake_case attributes to Display Case format
  * and looks them up in the mapping caches without causing infinite recursion.
- * 
+ *
  * @param attributeName - The snake_case attribute name to convert and lookup
  * @returns The mapped slug if found, or undefined if no mapping exists
- * 
+ *
  * @example
  * ```typescript
  * // For input "b2b_segment", converts to "B2b Segment" and looks up mapping
  * const result = trySnakeCaseConversion("b2b_segment"); // Returns "type_persona"
  * ```
  */
-function trySnakeCaseConversion(attributeName: string): string | undefined {
+function trySnakeCaseConversion(
+  attributeName: string,
+  objectType?: string
+): string | undefined {
   // Guard conditions to prevent infinite recursion
   // Skip if name already contains spaces or has no underscores to convert
   if (attributeName.includes(' ') || !attributeName.includes('_')) {
     return undefined;
   }
-  
+
   try {
     // Convert snake_case to Display Case (e.g., "b2b_segment" -> "B2b Segment")
     const potentialDisplayName = attributeName
       .replace(/_/g, ' ')
       .replace(/(\w)(\w*)/g, (_, first, rest) => first.toUpperCase() + rest);
-    
+
     // Additional safety check: if conversion results in same string, avoid lookup
     if (potentialDisplayName === attributeName) {
       return undefined;
     }
-    
+
     // Use direct cache lookups to avoid recursive getAttributeSlug calls
     // This prevents infinite recursion while maintaining mapping functionality
-    
+
     // Try special cases first (highest priority)
-    let result = handleSpecialCases(potentialDisplayName);
+    let result = handleSpecialCases(potentialDisplayName, objectType);
     if (result) return result;
-    
+
     // Try cache lookups in order of priority
     if (caseInsensitiveCaches.common) {
-      result = lookupCaseInsensitive(caseInsensitiveCaches.common, potentialDisplayName);
+      result = lookupCaseInsensitive(
+        caseInsensitiveCaches.common,
+        potentialDisplayName
+      );
       if (result) return result;
     }
-    
+
     if (caseInsensitiveCaches.custom) {
-      result = lookupCaseInsensitive(caseInsensitiveCaches.custom, potentialDisplayName);
+      result = lookupCaseInsensitive(
+        caseInsensitiveCaches.custom,
+        potentialDisplayName
+      );
       if (result) return result;
     }
-    
+
     if (caseInsensitiveCaches.legacy) {
-      result = lookupCaseInsensitive(caseInsensitiveCaches.legacy, potentialDisplayName);
+      result = lookupCaseInsensitive(
+        caseInsensitiveCaches.legacy,
+        potentialDisplayName
+      );
       if (result) return result;
     }
-    
+
     return undefined;
   } catch (err) {
     // Graceful error handling: log warning but don't throw
-    console.warn(`[attribute-mappers] Error in snake case conversion for "${attributeName}": ${err}`);
+    console.warn(
+      `[attribute-mappers] Error in snake case conversion for "${attributeName}": ${err}`
+    );
     return undefined;
   }
 }
 
 /**
  * Looks up a human-readable attribute name and returns the corresponding slug
- * 
+ *
  * @param attributeName - The user-provided attribute name
  * @param objectType - Optional object type for object-specific mappings
  * @returns The slug if found, or the original attributeName if not mapped
  */
-export function getAttributeSlug(attributeName: string, objectType?: string): string {
+export function getAttributeSlug(
+  attributeName: string,
+  objectType?: string
+): string {
   if (!attributeName) return attributeName;
-  
+
   try {
     // First check for special cases that commonly need to be handled
-    const specialCaseResult = handleSpecialCases(attributeName);
+    const specialCaseResult = handleSpecialCases(attributeName, objectType);
     if (specialCaseResult) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Special case match: "${attributeName}" -> "${specialCaseResult}"`);
+        console.log(
+          `[attribute-mappers] Special case match: "${attributeName}" -> "${specialCaseResult}"`
+        );
       }
       return specialCaseResult;
     }
-    
+
     // Make sure config is loaded (in case we haven't initialized caches yet)
     const config = getConfig();
-    
+
     // Ensure at least the basic lookup caches exist (this can happen if called before initialization)
-    if (!caseInsensitiveCaches.common || !caseInsensitiveCaches.custom || !caseInsensitiveCaches.legacy) {
+    if (
+      !caseInsensitiveCaches.common ||
+      !caseInsensitiveCaches.custom ||
+      !caseInsensitiveCaches.legacy
+    ) {
       // Initialize lookup caches if missing
       initializeLookupCaches(config);
     }
-    
+
     // Create aggressive normalized caches if they don't exist
     if (!normalizedCaches.aggressiveLegacy) {
-      normalizedCaches.aggressiveLegacy = createAggressiveNormalizedMap(LEGACY_ATTRIBUTE_MAP);
+      normalizedCaches.aggressiveLegacy =
+        createAggressiveNormalizedMap(LEGACY_ATTRIBUTE_MAP);
     }
-    
+
     let result: string | undefined;
-    
+
     // TIER 1: Check object-specific mappings if objectType is provided (exact matches)
     if (objectType) {
       const cacheKey = `objects.${objectType}`;
       // Make sure this object-specific cache exists
-      if (!caseInsensitiveCaches[cacheKey] && config.mappings.attributes.objects[objectType]) {
-        caseInsensitiveCaches[cacheKey] = createCaseInsensitiveMap(config.mappings.attributes.objects[objectType]);
+      if (
+        !caseInsensitiveCaches[cacheKey] &&
+        config.mappings.attributes.objects[objectType]
+      ) {
+        caseInsensitiveCaches[cacheKey] = createCaseInsensitiveMap(
+          config.mappings.attributes.objects[objectType]
+        );
       }
-      
+
       const objectSpecificCache = caseInsensitiveCaches[cacheKey];
       if (objectSpecificCache) {
         result = lookupCaseInsensitive(objectSpecificCache, attributeName);
         if (result) {
           if (process.env.NODE_ENV === 'development') {
-            console.log(`[attribute-mappers] Object-specific case-insensitive match for ${objectType}: "${attributeName}" -> "${result}"`);
+            console.log(
+              `[attribute-mappers] Object-specific case-insensitive match for ${objectType}: "${attributeName}" -> "${result}"`
+            );
           }
           return result;
         }
       }
     }
-    
+
     // TIER 2: Check custom and common mappings with case-insensitive lookup
     result = lookupCaseInsensitive(caseInsensitiveCaches.custom, attributeName);
     if (result) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Custom case-insensitive match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Custom case-insensitive match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
+
     result = lookupCaseInsensitive(caseInsensitiveCaches.common, attributeName);
     if (result) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Common case-insensitive match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Common case-insensitive match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
+
     // TIER 3: Legacy mapping with case-insensitive lookup
     result = lookupCaseInsensitive(caseInsensitiveCaches.legacy, attributeName);
     if (result) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Legacy case-insensitive match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Legacy case-insensitive match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
+
     // TIER 4: Try normalized lookup (removes spaces, case-insensitive)
     // Create normalized caches for object-specific mappings if they don't exist
     if (objectType) {
       const normalizedCacheKey = `normalized.objects.${objectType}`;
-      if (!normalizedCaches[normalizedCacheKey] && config.mappings.attributes.objects[objectType]) {
-        normalizedCaches[normalizedCacheKey] = createNormalizedMap(config.mappings.attributes.objects[objectType]);
+      if (
+        !normalizedCaches[normalizedCacheKey] &&
+        config.mappings.attributes.objects[objectType]
+      ) {
+        normalizedCaches[normalizedCacheKey] = createNormalizedMap(
+          config.mappings.attributes.objects[objectType]
+        );
       }
-      
-      const normalizedObjectSpecificCache = normalizedCaches[normalizedCacheKey];
+
+      const normalizedObjectSpecificCache =
+        normalizedCaches[normalizedCacheKey];
       if (normalizedObjectSpecificCache) {
         result = lookupNormalized(normalizedObjectSpecificCache, attributeName);
         if (result) {
           if (process.env.NODE_ENV === 'development') {
-            console.log(`[attribute-mappers] Object-specific normalized match for ${objectType}: "${attributeName}" -> "${result}"`);
+            console.log(
+              `[attribute-mappers] Object-specific normalized match for ${objectType}: "${attributeName}" -> "${result}"`
+            );
           }
           return result;
         }
       }
     }
-    
+
     // Check common and custom normalized caches
     if (!normalizedCaches.common) {
-      normalizedCaches.common = createNormalizedMap(config.mappings.attributes.common);
+      normalizedCaches.common = createNormalizedMap(
+        config.mappings.attributes.common
+      );
     }
-    
+
     if (!normalizedCaches.custom) {
-      normalizedCaches.custom = createNormalizedMap(config.mappings.attributes.custom);
+      normalizedCaches.custom = createNormalizedMap(
+        config.mappings.attributes.custom
+      );
     }
-    
+
     result = lookupNormalized(normalizedCaches.custom, attributeName);
     if (result) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Custom normalized match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Custom normalized match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
+
     result = lookupNormalized(normalizedCaches.common, attributeName);
     if (result) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Common normalized match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Common normalized match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
+
     // Check legacy normalized
     if (!normalizedCaches.legacy) {
       normalizedCaches.legacy = createNormalizedMap(LEGACY_ATTRIBUTE_MAP);
     }
-    
+
     result = lookupNormalized(normalizedCaches.legacy, attributeName);
     if (result) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Legacy normalized match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Legacy normalized match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
+
     // TIER 5: Aggressive normalization (removes all non-alphanumeric characters)
-    result = lookupAggressiveNormalized(normalizedCaches.aggressiveLegacy, attributeName);
+    result = lookupAggressiveNormalized(
+      normalizedCaches.aggressiveLegacy,
+      attributeName
+    );
     if (result) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Aggressive normalized match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Aggressive normalized match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
+
     // TIER 6: Snake case conversion fallback (last resort)
-    result = trySnakeCaseConversion(attributeName);
+    result = trySnakeCaseConversion(attributeName, objectType);
     if (result && result !== attributeName) {
       if (process.env.NODE_ENV === 'development') {
-        console.log(`[attribute-mappers] Snake case conversion match: "${attributeName}" -> "${result}"`);
+        console.log(
+          `[attribute-mappers] Snake case conversion match: "${attributeName}" -> "${result}"`
+        );
       }
       return result;
     }
-    
   } catch (error) {
     // If there's an error with the config, log detailed error and suggestions
-    const errorMsg = error instanceof AttributeMappingError
-      ? `${error.message} - ${JSON.stringify(error.details)}`
-      : `Error using config for attribute mapping: ${error}`;
-    
+    const errorMsg =
+      error instanceof AttributeMappingError
+        ? `${error.message} - ${JSON.stringify(error.details)}`
+        : `Error using config for attribute mapping: ${error}`;
+
     console.error(errorMsg);
-    console.warn('Falling back to legacy behavior. Check your configuration files for errors.');
-    
+    console.warn(
+      'Falling back to legacy behavior. Check your configuration files for errors.'
+    );
+
     // Try special cases as a last resort, even if there was an error earlier
-    const specialCaseResult = handleSpecialCases(attributeName);
+    const specialCaseResult = handleSpecialCases(attributeName, objectType);
     if (specialCaseResult) {
-      console.log(`[attribute-mappers] Special case match after error: "${attributeName}" -> "${specialCaseResult}"`);
+      console.log(
+        `[attribute-mappers] Special case match after error: "${attributeName}" -> "${specialCaseResult}"`
+      );
       return specialCaseResult;
     }
   }
-  
+
   // Log that no match was found for easier debugging
   if (process.env.NODE_ENV === 'development') {
-    console.warn(`[attribute-mappers] No mapping found for attribute: "${attributeName}"`);
+    console.warn(
+      `[attribute-mappers] No mapping found for attribute: "${attributeName}"`
+    );
   }
-  
+
   // If no match found, return the original
   return attributeName;
 }
 
 /**
  * Gets the slug for an object type (e.g., "Companies" -> "companies")
- * 
+ *
  * @param objectName - The human-readable object name
  * @returns The corresponding slug, or a normalized version of the original name if not found
  */
 export function getObjectSlug(objectName: string): string {
   if (!objectName) return objectName;
-  
+
   try {
     // Make sure config is loaded (in case we haven't initialized caches yet)
     const config = getConfig();
-    
+
     // Ensure the lookup caches exist (this can happen if called before initialization)
     if (!caseInsensitiveCaches.objects) {
       // Initialize lookup caches if missing
       initializeLookupCaches(config);
     }
-    
+
     // Use case-insensitive lookup
-    const result = lookupCaseInsensitive(caseInsensitiveCaches.objects, objectName);
+    const result = lookupCaseInsensitive(
+      caseInsensitiveCaches.objects,
+      objectName
+    );
     if (result) return result;
-    
   } catch (error) {
     // If there's an error with the config, fall back to simple normalization
     console.error('Error using config for object mapping:', error);
-    console.warn('Check your configuration files for errors in the objects section.');
+    console.warn(
+      'Check your configuration files for errors in the objects section.'
+    );
   }
-  
+
   // If no match is found, convert to lowercase and remove spaces as a fallback
   return objectName.toLowerCase().replace(/\s+/g, '_');
 }
 
 /**
  * Gets the slug for a list name
- * 
+ *
  * @param listName - The human-readable list name
  * @returns The corresponding slug, or the original name if not found
  */
 export function getListSlug(listName: string): string {
   if (!listName) return listName;
-  
+
   try {
     // Make sure config is loaded (in case we haven't initialized caches yet)
     const config = getConfig();
-    
+
     // Ensure the lookup caches exist (this can happen if called before initialization)
     if (!caseInsensitiveCaches.lists) {
       // Initialize lookup caches if missing
       initializeLookupCaches(config);
     }
-    
+
     // Use case-insensitive lookup
     const result = lookupCaseInsensitive(caseInsensitiveCaches.lists, listName);
     if (result) return result;
-    
   } catch (error) {
     // If there's an error with the config, fall back to simple normalization
     console.error('Error using config for list mapping:', error);
-    console.warn('Check your configuration files for errors in the lists section.');
+    console.warn(
+      'Check your configuration files for errors in the lists section.'
+    );
   }
-  
+
   // If no match is found, return the original
   return listName;
 }

--- a/src/utils/attribute-mapping/mapping-utils.ts
+++ b/src/utils/attribute-mapping/mapping-utils.ts
@@ -3,9 +3,11 @@
  * This file contains helper functions used by the attribute mapping system
  */
 
+import { getFieldMapping } from '../field-mapping.js';
+
 /**
  * Creates a case-insensitive lookup map for faster lookups
- * 
+ *
  * @param mappings - Original mapping object with string keys
  * @returns A Map with lowercase keys for case-insensitive lookups
  */
@@ -13,18 +15,18 @@ export function createCaseInsensitiveMap<T>(
   mappings: Record<string, T>
 ): Map<string, { original: string; value: T }> {
   const map = new Map<string, { original: string; value: T }>();
-  
+
   // Pre-process all keys to lowercase for faster lookups
   for (const [key, value] of Object.entries(mappings)) {
     map.set(key.toLowerCase(), { original: key, value });
   }
-  
+
   return map;
 }
 
 /**
  * Lookup a value in a case-insensitive map
- * 
+ *
  * @param map - The case-insensitive map to search in
  * @param key - The key to look up (will be converted to lowercase)
  * @returns The value if found, or undefined if not found
@@ -39,7 +41,7 @@ export function lookupCaseInsensitive<T>(
 
 /**
  * Normalizes a string by removing spaces and converting to lowercase
- * 
+ *
  * @param input - The string to normalize
  * @returns The normalized string
  */
@@ -49,7 +51,7 @@ export function normalizeString(input: string): string {
 
 /**
  * More aggressive normalization that removes all non-alphanumeric characters
- * 
+ *
  * @param input - The string to normalize
  * @returns The normalized string
  */
@@ -59,7 +61,7 @@ export function aggressiveNormalizeString(input: string): string {
 
 /**
  * Creates a normalized lookup map for fuzzy matching
- * 
+ *
  * @param mappings - Original mapping object with string keys
  * @returns A Map with normalized keys (lowercase, no spaces) for fuzzy lookups
  */
@@ -67,19 +69,19 @@ export function createNormalizedMap<T>(
   mappings: Record<string, T>
 ): Map<string, { original: string; value: T }> {
   const map = new Map<string, { original: string; value: T }>();
-  
+
   // Pre-process all keys to normalized form for faster lookups
   for (const [key, value] of Object.entries(mappings)) {
     map.set(normalizeString(key), { original: key, value });
   }
-  
+
   return map;
 }
 
 /**
  * Creates a more aggressively normalized lookup map for fuzzy matching
  * Removes all non-alphanumeric characters
- * 
+ *
  * @param mappings - Original mapping object with string keys
  * @returns A Map with aggressively normalized keys for fuzzy lookups
  */
@@ -87,18 +89,18 @@ export function createAggressiveNormalizedMap<T>(
   mappings: Record<string, T>
 ): Map<string, { original: string; value: T }> {
   const map = new Map<string, { original: string; value: T }>();
-  
+
   // Pre-process all keys to normalized form for faster lookups
   for (const [key, value] of Object.entries(mappings)) {
     map.set(aggressiveNormalizeString(key), { original: key, value });
   }
-  
+
   return map;
 }
 
 /**
  * Lookup a value in a normalized map (removes spaces, case-insensitive)
- * 
+ *
  * @param map - The normalized map to search in
  * @param key - The key to look up (will be normalized)
  * @returns The value if found, or undefined if not found
@@ -113,7 +115,7 @@ export function lookupNormalized<T>(
 
 /**
  * Lookup a value in an aggressively normalized map
- * 
+ *
  * @param map - The aggressively normalized map to search in
  * @param key - The key to look up (will be aggressively normalized)
  * @returns The value if found, or undefined if not found
@@ -128,44 +130,49 @@ export function lookupAggressiveNormalized<T>(
 
 /**
  * Special case handling for common problematic attribute names
- * 
+ *
  * @param key - The attribute name to check
  * @returns The mapped value if it's a special case, or undefined
  */
-export function handleSpecialCases(key: string): string | undefined {
+export function handleSpecialCases(
+  key: string,
+  objectType?: string
+): string | undefined {
   // Convert to lowercase for consistency
   const lowerKey = key.toLowerCase();
-  
+
   // Map of special cases with their mappings
   const specialCases: Record<string, string> = {
     // B2B segment mappings
-    'b2b_segment': 'type_persona',
+    b2b_segment: 'type_persona',
     'b2b segment': 'type_persona',
-    'b2bsegment': 'type_persona',
-    'b2b': 'type_persona',
-    'segment': 'type_persona',
+    b2bsegment: 'type_persona',
+    b2b: 'type_persona',
+    segment: 'type_persona',
     'business segment': 'type_persona',
     'business type': 'type_persona',
     'company segment': 'type_persona',
     'client segment': 'type_persona',
     'customer segment': 'type_persona',
-    'company_segment': 'type_persona',
-    'client_segment': 'type_persona',
-    'customer_segment': 'type_persona',
-    
-    // Industry mappings
-    // Note: In Attio's API, the concept of 'industry' is represented through the 'categories' field.
-    // This mapping ensures compatibility between MCP tools that use 'industry' and the Attio API
-    // which uses 'categories' for industry classification. (Issue #176)
-    'industry': 'categories',
-    'industry type': 'categories',
+    company_segment: 'type_persona',
+    client_segment: 'type_persona',
+    customer_segment: 'type_persona',
   };
-  
+
+  // Dynamic industry mapping from configuration
+  if (objectType) {
+    const industryMap = getFieldMapping(objectType, 'industry');
+    if (industryMap) {
+      specialCases['industry'] = industryMap.primary_field;
+      specialCases['industry type'] = industryMap.primary_field;
+    }
+  }
+
   // Check for exact matches in the special cases
   if (specialCases[lowerKey]) {
     return specialCases[lowerKey];
   }
-  
+
   // Check for normalized matches
   const normalizedKey = normalizeString(lowerKey);
   for (const [specialKey, value] of Object.entries(specialCases)) {
@@ -173,7 +180,7 @@ export function handleSpecialCases(key: string): string | undefined {
       return value;
     }
   }
-  
+
   // No special case found
   return undefined;
 }

--- a/src/utils/field-mapping.ts
+++ b/src/utils/field-mapping.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface FieldMapping {
+  primary_field: string;
+  fallback_field?: string;
+}
+
+export interface FieldMappingConfig {
+  [objectType: string]: Record<string, FieldMapping>;
+}
+
+const CONFIG_PATH = path.resolve(process.cwd(), 'config/field-mappings.json');
+
+let cachedConfig: FieldMappingConfig | null = null;
+
+function loadConfig(): FieldMappingConfig {
+  if (!cachedConfig) {
+    try {
+      if (fs.existsSync(CONFIG_PATH)) {
+        const data = fs.readFileSync(CONFIG_PATH, 'utf8');
+        cachedConfig = JSON.parse(data) as FieldMappingConfig;
+      } else {
+        cachedConfig = {};
+      }
+    } catch {
+      cachedConfig = {};
+    }
+  }
+  return cachedConfig;
+}
+
+export function invalidateFieldMappingCache(): void {
+  cachedConfig = null;
+}
+
+export function getFieldMapping(
+  objectType: string,
+  field: string
+): FieldMapping | undefined {
+  const config = loadConfig();
+  const objectMappings = config[objectType];
+  if (!objectMappings) return undefined;
+  return objectMappings[field];
+}

--- a/test/integration/industry-mapping.test.ts
+++ b/test/integration/industry-mapping.test.ts
@@ -1,19 +1,33 @@
 /**
- * Integration tests for industry-to-categories field mapping for companies
- * Tests issue #176 fix for the incorrect industry field mapping
+ * Integration tests for dynamic industry field mapping for companies
+ * Ensures the configurable mapping system works as expected
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, jest } from 'vitest';
-import { createCompany, updateCompany } from '../../src/objects/companies/index';
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  jest,
+} from 'vitest';
+import {
+  createCompany,
+  updateCompany,
+} from '../../src/objects/companies/index';
 import { getAttributeSlug } from '../../src/utils/attribute-mapping/index';
 import { initializeAttioClient } from '../../src/api/attio-client';
 import * as attioClient from '../../src/api/attio-client';
-import { createMockApiClient, type MockCompanyUpdate } from '../types/test-types';
+import {
+  createMockApiClient,
+  type MockCompanyUpdate,
+} from '../types/test-types';
 
 // Mock the attioClient module
 vi.mock('../../src/api/attio-client', () => {
   const actual = vi.requireActual('../../src/api/attio-client');
   return {
-    ...actual as any,
+    ...(actual as any),
     getAttioClient: vi.fn(),
     initializeAttioClient: vi.fn(),
   };
@@ -21,28 +35,28 @@ vi.mock('../../src/api/attio-client', () => {
 
 describe('Industry Field Mapping - Integration Tests', () => {
   let mockApiCall: vi.Mock;
-  
+
   beforeAll(() => {
     initializeAttioClient('test-api-key');
   });
-  
+
   beforeEach(() => {
     mockApiCall = vi.fn();
     const mockClient = createMockApiClient();
     mockClient.post = mockApiCall;
     mockClient.put = mockApiCall;
     mockClient.patch = mockApiCall;
-    
+
     vi.mocked(attioClient.getAttioClient).mockReturnValue(mockClient as any);
   });
-  
+
   afterEach(() => {
     vi.clearAllMocks();
   });
-  
-  describe('Industry to Categories Mapping', () => {
+
+  describe('Industry Field Mapping', () => {
     describe('Company Creation', () => {
-      it('should map "industry" to "categories" when creating a company', async () => {
+      it('should map "industry" to the configured field when creating a company', async () => {
         // Prepare mock response
         const mockCompanyId = 'test-company-id';
         const mockResponse = {
@@ -51,30 +65,30 @@ describe('Industry Field Mapping - Integration Tests', () => {
             name: [{ value: 'Test Company' }],
             categories: [{ value: 'Technology' }],
             // Note: No 'industry' field in the response
-          }
+          },
         };
-        
+
         (mockApiCall as any).mockResolvedValueOnce({ data: mockResponse });
-        
+
         // Create a company with 'industry' field
         const companyData = {
           name: 'Test Company',
-          industry: 'Technology'
+          industry: 'Technology',
         };
-        
+
         const result = await createCompany(companyData);
-        
+
         // Verify the API call was made
         expect(mockApiCall).toHaveBeenCalledTimes(1);
-        
+
         // Get the transformed data sent to the API
         const apiCallArg = mockApiCall.mock.calls[0][1] as any;
-        
-        // Verify that categories mapping occurred correctly
+
+        // Verify that mapping occurred correctly
         expect(mockApiCall).toHaveBeenCalledTimes(1);
         // Note: The specific structure verification is handled by the mapping logic
       });
-      
+
       it('should not include the original industry field in the API request', async () => {
         // Prepare mock response
         const mockCompanyId = 'test-company-id';
@@ -82,31 +96,31 @@ describe('Industry Field Mapping - Integration Tests', () => {
           id: { record_id: mockCompanyId },
           values: {
             name: [{ value: 'Test Company' }],
-            categories: [{ value: 'Technology' }]
-          }
+            categories: [{ value: 'Technology' }],
+          },
         };
-        
+
         (mockApiCall as any).mockResolvedValueOnce({ data: mockResponse });
-        
+
         // Create a company with 'industry' field
         const companyData = {
           name: 'Test Company',
-          industry: 'Technology'
+          industry: 'Technology',
         };
-        
+
         await createCompany(companyData);
-        
+
         // Get the transformed data sent to the API
         const apiCallArg = mockApiCall.mock.calls[0][1] as any;
-        
+
         // Verify that the API call was made and mapping occurred
         expect(mockApiCall).toHaveBeenCalledTimes(1);
         // Note: The specific field exclusion verification is handled by the mapping logic
       });
     });
-    
+
     describe('Company Updates', () => {
-      it('should map "industry" to "categories" when updating a company', async () => {
+      it('should map "industry" to the configured field when updating a company', async () => {
         // Prepare mock response
         const mockCompanyId = 'test-company-id';
         const mockResponse = {
@@ -114,26 +128,26 @@ describe('Industry Field Mapping - Integration Tests', () => {
           values: {
             name: [{ value: 'Test Company' }],
             categories: [{ value: 'Finance' }],
-          }
+          },
         };
-        
+
         (mockApiCall as any).mockResolvedValueOnce({ data: mockResponse });
-        
+
         // Update a company with 'industry' field
         const updates = {
-          industry: 'Finance'
+          industry: 'Finance',
         };
-        
+
         await updateCompany(mockCompanyId, updates);
-        
+
         // Get the transformed data sent to the API
         const apiCallArg = mockApiCall.mock.calls[0][1] as any;
-        
-        // Verify that categories mapping occurred correctly
+
+        // Verify that mapping occurred correctly
         expect(mockApiCall).toHaveBeenCalledTimes(1);
         // Note: The specific structure verification is handled by the mapping logic
       });
-      
+
       it('should not include the original industry field in the update request', async () => {
         // Prepare mock response
         const mockCompanyId = 'test-company-id';
@@ -141,49 +155,53 @@ describe('Industry Field Mapping - Integration Tests', () => {
           id: { record_id: mockCompanyId },
           values: {
             categories: [{ value: 'Finance' }],
-          }
+          },
         };
-        
+
         (mockApiCall as any).mockResolvedValueOnce({ data: mockResponse });
-        
+
         // Update a company with 'industry' field
         const updates = {
-          industry: 'Finance'
+          industry: 'Finance',
         };
-        
+
         await updateCompany(mockCompanyId, updates);
-        
+
         // Get the transformed data sent to the API
         const apiCallArg = mockApiCall.mock.calls[0][1] as any;
-        
+
         // Verify that the API call was made and mapping occurred
         expect(mockApiCall).toHaveBeenCalledTimes(1);
         // Note: The specific field exclusion verification is handled by the mapping logic
       });
     });
-    
+
     describe('Field Name Case Handling', () => {
-      it('should map lowercase "industry" to "categories"', async () => {
-        expect(getAttributeSlug('industry')).toBe('categories');
+      it('should map lowercase "industry" to the configured field', async () => {
+        expect(getAttributeSlug('industry', 'companies')).toBe('type_persona');
       });
-      
-      it('should map capitalized "Industry" to "categories"', async () => {
-        expect(getAttributeSlug('Industry')).toBe('categories');
+
+      it('should map capitalized "Industry" to the configured field', async () => {
+        expect(getAttributeSlug('Industry', 'companies')).toBe('type_persona');
       });
-      
-      it('should map uppercase "INDUSTRY" to "categories"', async () => {
-        expect(getAttributeSlug('INDUSTRY')).toBe('categories');
+
+      it('should map uppercase "INDUSTRY" to the configured field', async () => {
+        expect(getAttributeSlug('INDUSTRY', 'companies')).toBe('type_persona');
       });
-      
-      it('should map "industry type" to "categories"', async () => {
-        expect(getAttributeSlug('industry type')).toBe('categories');
+
+      it('should map "industry type" to the configured field', async () => {
+        expect(getAttributeSlug('industry type', 'companies')).toBe(
+          'type_persona'
+        );
       });
-      
-      it('should map "Industry Type" to "categories"', async () => {
-        expect(getAttributeSlug('Industry Type')).toBe('categories');
+
+      it('should map "Industry Type" to the configured field', async () => {
+        expect(getAttributeSlug('Industry Type', 'companies')).toBe(
+          'type_persona'
+        );
       });
     });
-    
+
     describe('Field Prioritization', () => {
       it('should prioritize "industry" value over "categories" when both are provided', async () => {
         // Prepare mock response
@@ -193,22 +211,22 @@ describe('Industry Field Mapping - Integration Tests', () => {
           values: {
             name: [{ value: 'Test Company' }],
             categories: [{ value: 'Healthcare' }],
-          }
+          },
         };
-        
+
         (mockApiCall as any).mockResolvedValueOnce({ data: mockResponse });
-        
-        // Update a company using both fields  
+
+        // Update a company using both fields
         const updates = {
           industry: 'Healthcare',
-          categories: 'Should not be used' // This should be overridden
+          categories: 'Should not be used', // This should be overridden
         };
-        
+
         await updateCompany(mockCompanyId, updates as any);
-        
+
         // Get the transformed data sent to the API
         const apiCallArg = mockApiCall.mock.calls[0][1] as any;
-        
+
         // Verify that categories mapping occurred correctly
         expect(mockApiCall).toHaveBeenCalledTimes(1);
         // Note: The specific structure verification is handled by the mapping logic

--- a/test/utils/attribute-mappers.test.ts
+++ b/test/utils/attribute-mappers.test.ts
@@ -1,7 +1,10 @@
 /**
  * Tests for attribute mapping functionality
  */
-import { getAttributeSlug, invalidateConfigCache } from '../../src/utils/attribute-mapping/attribute-mappers';
+import {
+  getAttributeSlug,
+  invalidateConfigCache,
+} from '../../src/utils/attribute-mapping/attribute-mappers';
 import * as mappingUtils from '../../src/utils/attribute-mapping/mapping-utils';
 import * as configLoader from '../../src/utils/config-loader';
 
@@ -12,25 +15,25 @@ vi.mock('../../src/utils/config-loader', () => ({
     mappings: {
       attributes: {
         common: {
-          'Industry': 'categories', // The problem field that can cause infinite recursion
-          'Company Name': 'name'
+          Industry: 'categories', // The problem field that can cause infinite recursion
+          'Company Name': 'name',
         },
         objects: {
           companies: {
             'Medical Field': 'categories',
-            'Healthcare Industry': 'categories'
-          }
+            'Healthcare Industry': 'categories',
+          },
         },
-        custom: {}
+        custom: {},
       },
       objects: {
-        'Companies': 'companies',
-        'People': 'people'
+        Companies: 'companies',
+        People: 'people',
       },
       lists: {},
-      relationships: {}
-    }
-  }))
+      relationships: {},
+    },
+  })),
 }));
 
 describe('Attribute Mappers', () => {
@@ -42,9 +45,9 @@ describe('Attribute Mappers', () => {
 
   describe('getAttributeSlug', () => {
     it('should return mapped slug for known attributes', () => {
-      expect(getAttributeSlug('Industry')).toBe('categories');
+      expect(getAttributeSlug('Industry', 'companies')).toBe('type_persona');
       expect(getAttributeSlug('company name')).toBe('name');
-      expect(getAttributeSlug('INDUSTRY')).toBe('categories');
+      expect(getAttributeSlug('INDUSTRY', 'companies')).toBe('type_persona');
     });
 
     it('should return original attribute name if no mapping exists', () => {
@@ -53,18 +56,20 @@ describe('Attribute Mappers', () => {
 
     it('should handle object-specific mappings', () => {
       expect(getAttributeSlug('medical field', 'companies')).toBe('categories');
-      expect(getAttributeSlug('healthcare industry', 'companies')).toBe('categories');
+      expect(getAttributeSlug('healthcare industry', 'companies')).toBe(
+        'categories'
+      );
     });
 
     it('should NOT fall into infinite recursion when handling special cases', () => {
       // This line would trigger infinite recursion before the fix
-      expect(getAttributeSlug('industry')).toBe('categories');
-      
+      expect(getAttributeSlug('industry', 'companies')).toBe('type_persona');
+
       // Test the fix for other similar cases
       expect(getAttributeSlug('categories')).toBe('categories');
       expect(getAttributeSlug('category')).toBe('category');
     });
-    
+
     it('should handle snake case conversion without infinite recursion', () => {
       // Mock handleSpecialCases to simulate the problematic behavior
       const originalHandleSpecialCases = mappingUtils.handleSpecialCases;
@@ -73,10 +78,10 @@ describe('Attribute Mappers', () => {
         if (key.toLowerCase() === 'categories') return 'industry'; // This creates a circular reference
         return originalHandleSpecialCases(key);
       });
-      
+
       // This would cause infinite recursion without our fix
       expect(() => getAttributeSlug('industry_type')).not.toThrow();
-      
+
       // Restore original function
       (mappingUtils.handleSpecialCases as vi.Mock).mockRestore();
     });
@@ -85,7 +90,7 @@ describe('Attribute Mappers', () => {
       // Test attribute names that should not trigger snake case conversion
       expect(getAttributeSlug('already has spaces')).toBe('already has spaces');
       expect(getAttributeSlug('nounderscores')).toBe('nounderscores');
-      
+
       // Test valid snake case conversion
       expect(getAttributeSlug('company_name')).toBe('name'); // Based on mock config
     });

--- a/test/utils/attribute-mapping.test.ts
+++ b/test/utils/attribute-mapping.test.ts
@@ -1,12 +1,12 @@
 /**
  * Tests for the attribute mapping utilities
  */
-import { 
-  getAttributeSlug, 
-  getObjectSlug, 
+import {
+  getAttributeSlug,
+  getObjectSlug,
   getListSlug,
   translateAttributeNamesInFilters,
-  COMMON_ATTRIBUTE_MAP
+  COMMON_ATTRIBUTE_MAP,
 } from '../../src/utils/attribute-mapping/index';
 import * as configLoader from '../../src/utils/config-loader';
 
@@ -29,8 +29,8 @@ describe('Attribute Mapping', () => {
         mappings: {
           attributes: {
             common: {
-              'Name': 'name',
-              'Email': 'email',
+              Name: 'name',
+              Email: 'email',
             },
             objects: {
               companies: {
@@ -65,7 +65,7 @@ describe('Attribute Mapping', () => {
         mappings: {
           attributes: {
             common: {
-              'Name': 'name',
+              Name: 'name',
             },
             objects: {},
             custom: {},
@@ -126,18 +126,18 @@ describe('Attribute Mapping', () => {
       expect(getAttributeSlug('')).toBe('');
       expect(getAttributeSlug(undefined as any)).toBe(undefined);
     });
-    
-    it('should map industry to categories via special case handling', () => {
+
+    it('should map industry to the configured field via special case handling', () => {
       // Reset modules to ensure fresh state
       vi.resetModules();
-      
+
       // Industry should map to categories through special case handling
-      const result = getAttributeSlug('industry');
-      expect(result).toBe('categories');
-      
+      const result = getAttributeSlug('industry', 'companies');
+      expect(result).toBe('type_persona');
+
       // Industry type should also map to categories
-      const resultType = getAttributeSlug('industry type');
-      expect(resultType).toBe('categories');
+      const resultType = getAttributeSlug('industry type', 'companies');
+      expect(resultType).toBe('type_persona');
     });
 
     it('should prioritize object-specific mappings over common mappings', () => {
@@ -147,11 +147,11 @@ describe('Attribute Mapping', () => {
         mappings: {
           attributes: {
             common: {
-              'Name': 'name_common',
+              Name: 'name_common',
             },
             objects: {
               companies: {
-                'Name': 'name_companies',
+                Name: 'name_companies',
               },
             },
             custom: {},
@@ -164,11 +164,11 @@ describe('Attribute Mapping', () => {
 
       // Reset cached config first to ensure we use the mock
       vi.resetModules();
-      
+
       // Should use the company-specific mapping
       const companySlug = getAttributeSlug('Name', 'companies');
       expect(companySlug).toBe('name_companies');
-      
+
       // Should use the common mapping without object type
       const commonSlug = getAttributeSlug('Name');
       expect(commonSlug).toBe('name_common');
@@ -187,8 +187,8 @@ describe('Attribute Mapping', () => {
             custom: {},
           },
           objects: {
-            'Companies': 'companies',
-            'People': 'people',
+            Companies: 'companies',
+            People: 'people',
           },
           lists: {},
           relationships: {},
@@ -211,7 +211,7 @@ describe('Attribute Mapping', () => {
             custom: {},
           },
           objects: {
-            'Companies': 'companies',
+            Companies: 'companies',
           },
           lists: {},
           relationships: {},
@@ -266,11 +266,11 @@ describe('Attribute Mapping', () => {
 
       // Reset cached config to ensure we use the latest mock
       vi.resetModules();
-      
+
       // Test list mappings
       const importantLeadsSlug = getListSlug('Important Leads');
       expect(importantLeadsSlug).toBe('important_leads');
-      
+
       const vipContactsSlug = getListSlug('VIP Contacts');
       expect(vipContactsSlug).toBe('vip_contacts');
     });
@@ -293,7 +293,7 @@ describe('Attribute Mapping', () => {
 
       // Reset cached config to ensure we use the latest mock
       vi.resetModules();
-      
+
       // Test with an unknown list name
       expect(getListSlug('Unknown List')).toBe('Unknown List');
     });
@@ -303,25 +303,25 @@ describe('Attribute Mapping', () => {
     beforeEach(() => {
       // Reset modules before each test to ensure fresh state
       vi.resetModules();
-      
+
       // Mock the config loader with a comprehensive test configuration
       (configLoader.loadMappingConfig as vi.Mock).mockReturnValue({
         version: '1.0',
         mappings: {
           attributes: {
             common: {
-              'Name': 'name',
-              'Email': 'email',
-              'Phone': 'phone',
+              Name: 'name',
+              Email: 'email',
+              Phone: 'phone',
             },
             objects: {
               companies: {
-                'Name': 'name_companies',
-                'Industry': 'industry',
+                Name: 'name_companies',
+                Industry: 'industry',
               },
               people: {
-                'Name': 'name_people',
-                'Phone': 'phone_number',
+                Name: 'name_people',
+                Phone: 'phone_number',
               },
             },
             custom: {
@@ -329,8 +329,8 @@ describe('Attribute Mapping', () => {
             },
           },
           objects: {
-            'Companies': 'companies',
-            'People': 'people',
+            Companies: 'companies',
+            People: 'people',
           },
           lists: {
             'Important Leads': 'important_leads',
@@ -471,13 +471,19 @@ describe('Attribute Mapping', () => {
       };
 
       const translated = translateAttributeNamesInFilters(complexFilter);
-      
+
       // Check nested OR filters
-      expect(translated.filters[0].filters[0].attribute.slug).toBe('name_companies');
-      expect(translated.filters[0].filters[1].attribute.slug).toBe('categories'); // Industry maps to categories
-      
+      expect(translated.filters[0].filters[0].attribute.slug).toBe(
+        'name_companies'
+      );
+      expect(translated.filters[0].filters[1].attribute.slug).toBe(
+        'type_persona'
+      ); // Industry maps to configured field
+
       // Check object-specific sections
-      expect(translated.filters[1].companies.attribute.slug).toBe('name_companies');
+      expect(translated.filters[1].companies.attribute.slug).toBe(
+        'name_companies'
+      );
       expect(translated.filters[2].people.attribute.slug).toBe('phone_number');
     });
   });


### PR DESCRIPTION
## Summary
- introduce `field-mappings.json` to define workspace specific field slugs
- load field mappings with new utility `field-mapping.ts`
- adjust `handleSpecialCases` to read dynamic mapping
- update related tests and documentation

## Testing
- `npm run build`
- `npm run check:offline`
- `npm run test:offline` *(fails: many tests fail in environment)*
- `npm run check:format` *(fails: code style issues)*