### PR TITLE
Refactor records formatting

### DIFF
--- a/src/handlers/tool-configs/index.ts
+++ b/src/handlers/tool-configs/index.ts
@@ -5,7 +5,7 @@ export { companyToolConfigs, companyToolDefinitions } from './companies/index.js
 export { peopleToolConfigs, peopleToolDefinitions } from './people.js';
 export { listsToolConfigs, listsToolDefinitions } from './lists.js';
 export { promptsToolConfigs, promptsToolDefinitions } from './prompts.js';
-export { recordToolConfigs, recordToolDefinitions } from './records.js';
+export { recordToolConfigs, recordToolDefinitions } from './records/index.js';
 export { paginatedPeopleToolConfigs, paginatedPeopleToolDefinitions } from './paginated-people.js';
 export { tasksToolConfigs, tasksToolDefinitions } from './tasks.js';
 export { 

--- a/src/handlers/tool-configs/records.ts
+++ b/src/handlers/tool-configs/records.ts
@@ -11,7 +11,7 @@ import {
   batchCreateObjectRecords,
   batchUpdateObjectRecords,
   formatRecordAttributes,
-} from '../../objects/records.js';
+} from '../../objects/records/index.js';
 import { ToolConfig } from '../tool-types.js';
 
 // Define new tool type interfaces specific to records

--- a/src/handlers/tool-configs/records/index.ts
+++ b/src/handlers/tool-configs/records/index.ts
@@ -1,7 +1,7 @@
 /**
  * Records-related tool configurations
  */
-import { AttioRecord } from '../../types/attio.js';
+import { AttioRecord } from '../../../types/attio.js';
 import {
   createObjectRecord,
   getObjectRecord,
@@ -11,8 +11,8 @@ import {
   batchCreateObjectRecords,
   batchUpdateObjectRecords,
   formatRecordAttributes,
-} from '../../objects/records/index.js';
-import { ToolConfig } from '../tool-types.js';
+} from '../../../objects/records/index.js';
+import { ToolConfig } from '../../tool-types.js';
 
 // Define new tool type interfaces specific to records
 export interface RecordCreateToolConfig extends ToolConfig {

--- a/src/handlers/tools.ts.old
+++ b/src/handlers/tools.ts.old
@@ -56,7 +56,7 @@ import {
   RecordListToolConfig,
   RecordBatchCreateToolConfig,
   RecordBatchUpdateToolConfig
-} from "./tool-configs/records.js";
+} from "./tool-configs/records/index.js";
 
 // Consolidated tool configurations from modular files
 const TOOL_CONFIGS = {

--- a/src/handlers/tools/dispatcher.ts
+++ b/src/handlers/tools/dispatcher.ts
@@ -154,7 +154,8 @@ import {
   RecordListToolConfig,
   RecordBatchCreateToolConfig,
   RecordBatchUpdateToolConfig,
-} from '../tool-configs/records.js';
+} from '../tool-configs/records/index.js';
+
 
 // Import resource-specific tool configuration
 

--- a/src/handlers/tools/registry.ts
+++ b/src/handlers/tools/registry.ts
@@ -24,7 +24,7 @@ import {
 import {
   recordToolConfigs,
   recordToolDefinitions
-} from "../tool-configs/records.js";
+} from "../tool-configs/records/index.js";
 
 /**
  * Consolidated tool configurations from modular files

--- a/src/objects/base-operations.ts
+++ b/src/objects/base-operations.ts
@@ -6,7 +6,7 @@ import {
   createObjectRecord,
   updateObjectRecord,
   deleteObjectRecord,
-} from './records.js';
+} from './records/index.js';
 import { ResourceType, AttioRecord } from '../types/attio.js';
 import { getAttributeSlug } from '../utils/attribute-mapping/index.js';
 

--- a/src/objects/records/formatters.ts
+++ b/src/objects/records/formatters.ts
@@ -1,0 +1,65 @@
+/**
+ * Record formatting utilities
+ */
+import { RecordAttributes } from '../../types/attio.js';
+
+/**
+ * Helper function to format a single record attribute based on type
+ *
+ * @param key - Attribute key
+ * @param value - Attribute value to format
+ * @returns Properly formatted attribute value for the API
+ */
+export function formatRecordAttribute(key: string, value: any): any {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (
+    typeof value === 'number' &&
+    (key.includes('price') || key.includes('revenue') || key.includes('cost'))
+  ) {
+    return value;
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (key.includes('address') || key.includes('location'))
+  ) {
+    if ('street' in value || 'city' in value || 'country' in value) {
+      return value;
+    }
+  }
+
+  if (typeof value === 'string' && value.match(/^record_[a-z0-9]+$/)) {
+    return {
+      record_id: value,
+    };
+  }
+
+  return value;
+}
+
+/**
+ * Formats a full set of record attributes for API requests
+ *
+ * @param attributes - Raw attribute key-value pairs
+ * @returns Formatted attributes object ready for API submission
+ */
+export function formatRecordAttributes(
+  attributes: Record<string, any>
+): RecordAttributes {
+  const formattedAttributes: RecordAttributes = {};
+
+  for (const [key, value] of Object.entries(attributes)) {
+    formattedAttributes[key] = formatRecordAttribute(key, value);
+  }
+
+  return formattedAttributes;
+}

--- a/src/objects/records/index.ts
+++ b/src/objects/records/index.ts
@@ -1,7 +1,7 @@
 /**
  * Record-related functionality
  */
-import { getAttioClient } from '../api/attio-client.js';
+import { getAttioClient } from '../../api/attio-client.js';
 import {
   createRecord,
   getRecord,
@@ -12,13 +12,13 @@ import {
   batchUpdateRecords,
   BatchConfig,
   BatchResponse,
-} from '../api/operations/index.js';
+} from '../../api/operations/index.js';
 import {
   ResourceType,
   AttioRecord,
   RecordAttributes,
   RecordListParams,
-} from '../types/attio.js';
+} from '../../types/attio.js';
 
 /**
  * Creates a new record for a specific object type
@@ -99,6 +99,7 @@ export async function createObjectRecord<T extends AttioRecord>(
     }
   }
 }
+
 
 /**
  * Gets details for a specific record
@@ -479,79 +480,9 @@ export async function batchUpdateObjectRecords<T extends AttioRecord>(
   }
 }
 
-/**
- * Helper function to format record attribute values based on their type
- *
- * @param key - Attribute key
- * @param value - Attribute value to format
- * @returns Properly formatted attribute value for the API
- */
-export function formatRecordAttribute(key: string, value: any): any {
-  // If value is null or undefined, return it as is
-  if (value === null || value === undefined) {
-    return value;
-  }
 
-  // Handle Date objects
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-
-  // Handle different attribute types based on common patterns
-
-  // Currency attributes
-  if (
-    typeof value === 'number' &&
-    (key.includes('price') || key.includes('revenue') || key.includes('cost'))
-  ) {
-    // Simple number format
-    return value;
-
-    // Alternative: Full currency object format
-    // return {
-    //   amount: value,
-    //   currency: 'USD' // Default currency
-    // };
-  }
-
-  // Address attributes
-  if (
-    typeof value === 'object' &&
-    value !== null &&
-    !Array.isArray(value) &&
-    (key.includes('address') || key.includes('location'))
-  ) {
-    // Check if it's already in the expected format
-    if ('street' in value || 'city' in value || 'country' in value) {
-      return value;
-    }
-  }
-
-  // Link attributes (references to other records)
-  if (typeof value === 'string' && value.match(/^record_[a-z0-9]+$/)) {
-    return {
-      record_id: value,
-    };
-  }
-
-  // Default: return as is
-  return value;
-}
-
-/**
- * Formats a complete set of record attributes for API requests
- *
- * @param attributes - Raw attribute key-value pairs
- * @returns Formatted attributes object ready for API submission
- */
-export function formatRecordAttributes(
-  attributes: Record<string, any>
-): RecordAttributes {
-  const formattedAttributes: RecordAttributes = {};
-
-  for (const [key, value] of Object.entries(attributes)) {
-    formattedAttributes[key] = formatRecordAttribute(key, value);
-  }
-
-  return formattedAttributes;
-}
+// Re-export formatting utilities
+export {
+  formatRecordAttribute,
+  formatRecordAttributes,
+} from './formatters.js';


### PR DESCRIPTION
## Summary
- move records.ts to a directory structure
- extract formatting helpers into `formatters.ts`
- re-export formatters from new `records/index.ts`
- update imports referencing records module

## Testing
- `npm run build` *(fails: Property 'record' does not exist on type '{}')*
- `npm run check` *(fails: Cannot find script named "syncpack:check")*
- `npm test` *(fails to run vitest due to missing API keys and module errors)*
- `npm run lint:check` *(fails with lint errors)*
- `npm run check:format` *(fails with formatting errors)*