### PR TITLE
Fix: implement missing create/update/delete tool handlers in dispatcher (#259)

### DIFF
--- a/src/handlers/tools/dispatcher/core.ts
+++ b/src/handlers/tools/dispatcher/core.ts
@@ -96,6 +96,26 @@ export async function executeToolRequest(request: CallToolRequest) {
       return await handleGetListsOperation(request, toolConfig as GetListsToolConfig);
     }
 
+    // Handle create tools
+    if (toolType === 'create') {
+      return await handleCreateOperation(request, toolConfig as ToolConfig, resourceType);
+    }
+
+    // Handle update tools
+    if (toolType === 'update') {
+      return await handleUpdateOperation(request, toolConfig as ToolConfig, resourceType);
+    }
+
+    // Handle updateAttribute tools
+    if (toolType === 'updateAttribute') {
+      return await handleUpdateAttributeOperation(request, toolConfig as ToolConfig, resourceType);
+    }
+
+    // Handle delete tools
+    if (toolType === 'delete') {
+      return await handleDeleteOperation(request, toolConfig as ToolConfig, resourceType);
+    }
+
     // Placeholder for other operations - will be extracted to modules later
     throw new Error(`Tool handler not implemented for tool type: ${toolType}`);
   } catch (error) {
@@ -379,6 +399,195 @@ async function handleGetListsOperation(
       error instanceof Error ? error : new Error('Unknown error'),
       '/lists',
       'GET',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
+ * Handle create operation
+ */
+async function handleCreateOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig,
+  resourceType: ResourceType
+) {
+  try {
+    const attributes = request.params.arguments?.attributes;
+    
+    if (!attributes) {
+      return createErrorResult(
+        new Error('Attributes parameter is required for create operation'),
+        `/${resourceType}`,
+        'POST',
+        { status: 400, message: 'Missing required parameter: attributes' }
+      );
+    }
+
+    const result = await toolConfig.handler(attributes);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(result)
+      : `${resourceType.slice(0, -1)} created successfully`;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/${resourceType}`,
+      'POST',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
+ * Handle update operation
+ */
+async function handleUpdateOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig,
+  resourceType: ResourceType
+) {
+  try {
+    const id = resourceType === ResourceType.COMPANIES
+      ? (request.params.arguments?.companyId as string)
+      : (request.params.arguments?.personId as string);
+    
+    const attributes = request.params.arguments?.attributes;
+    
+    if (!id) {
+      const idParamName = resourceType === ResourceType.COMPANIES ? 'companyId' : 'personId';
+      return createErrorResult(
+        new Error(`${idParamName} parameter is required for update operation`),
+        `/${resourceType}`,
+        'PUT',
+        { status: 400, message: `Missing required parameter: ${idParamName}` }
+      );
+    }
+    
+    if (!attributes) {
+      return createErrorResult(
+        new Error('Attributes parameter is required for update operation'),
+        `/${resourceType}/${id}`,
+        'PUT',
+        { status: 400, message: 'Missing required parameter: attributes' }
+      );
+    }
+
+    const result = await toolConfig.handler(id, attributes);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(result)
+      : `${resourceType.slice(0, -1)} updated successfully`;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/${resourceType}`,
+      'PUT',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
+ * Handle updateAttribute operation
+ */
+async function handleUpdateAttributeOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig,
+  resourceType: ResourceType
+) {
+  try {
+    const id = resourceType === ResourceType.COMPANIES
+      ? (request.params.arguments?.companyId as string)
+      : (request.params.arguments?.personId as string);
+    
+    const attributeName = request.params.arguments?.attributeName as string;
+    const value = request.params.arguments?.value;
+    
+    if (!id) {
+      const idParamName = resourceType === ResourceType.COMPANIES ? 'companyId' : 'personId';
+      return createErrorResult(
+        new Error(`${idParamName} parameter is required for updateAttribute operation`),
+        `/${resourceType}`,
+        'PATCH',
+        { status: 400, message: `Missing required parameter: ${idParamName}` }
+      );
+    }
+    
+    if (!attributeName) {
+      return createErrorResult(
+        new Error('attributeName parameter is required for updateAttribute operation'),
+        `/${resourceType}/${id}`,
+        'PATCH',
+        { status: 400, message: 'Missing required parameter: attributeName' }
+      );
+    }
+    
+    if (value === undefined) {
+      return createErrorResult(
+        new Error('value parameter is required for updateAttribute operation'),
+        `/${resourceType}/${id}`,
+        'PATCH',
+        { status: 400, message: 'Missing required parameter: value' }
+      );
+    }
+
+    const result = await toolConfig.handler(id, attributeName, value);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(result)
+      : `${resourceType.slice(0, -1)} attribute updated successfully`;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/${resourceType}`,
+      'PATCH',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
+ * Handle delete operation
+ */
+async function handleDeleteOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig,
+  resourceType: ResourceType
+) {
+  try {
+    const id = resourceType === ResourceType.COMPANIES
+      ? (request.params.arguments?.companyId as string)
+      : (request.params.arguments?.personId as string);
+    
+    if (!id) {
+      const idParamName = resourceType === ResourceType.COMPANIES ? 'companyId' : 'personId';
+      return createErrorResult(
+        new Error(`${idParamName} parameter is required for delete operation`),
+        `/${resourceType}`,
+        'DELETE',
+        { status: 400, message: `Missing required parameter: ${idParamName}` }
+      );
+    }
+
+    const result = await toolConfig.handler(id);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(result)
+      : `${resourceType.slice(0, -1)} deleted successfully`;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    const id = resourceType === ResourceType.COMPANIES
+      ? (request.params.arguments?.companyId as string)
+      : (request.params.arguments?.personId as string);
+    
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/${resourceType}/${id || 'unknown'}`,
+      'DELETE',
       hasResponseData(error) ? error.response.data : {}
     );
   }


### PR DESCRIPTION
# Fix: Implement missing create/update/delete tool handlers in dispatcher

Fixes #259 

## Problem
The create-company tool was failing with 'Tool handler not implemented for tool type: create' because the dispatcher was missing handlers for several core tool types.

## Solution  
- Added create tool handler to fix critical company creation functionality
- Added update and delete handlers for completeness
- Maintained existing error handling patterns and TypeScript types
- Followed established handler implementation patterns

## Testing
- ✅ TypeScript compilation passes
- ✅ Core create-company functionality restored
- ✅ No regressions in existing handlers

## Impact
- 🔧 **CRITICAL FIX**: create-company tool now works properly
- 🔧 Enhanced: update and delete tools also implemented
- 🔧 Consistent: All handlers follow same error handling pattern