### PR TITLE
Fix main_contact attribute update format for Attio API

### DIFF
--- a/docs/api/company-write-operations.md
+++ b/docs/api/company-write-operations.md
@@ -229,6 +229,24 @@ Common field types and their expected formats:
 | foundation_date | date | ISO 8601 | "2020-01-15" |
 | industry | string | Any text | "Technology" |
 
+### Record Reference Attributes
+
+Record reference attributes are used to link a company to another record in Attio.
+
+#### main_contact
+
+- **Type:** array
+- **Format:** Record reference
+- **Example:** `[{"target_record_id": "person_id", "target_object": "people"}]`
+
+**Important notes when using the Attio API directly:**
+
+1. The API requires the array format even for a single reference
+2. Field names must be `target_record_id` and `target_object` (not `record_id` and `object`)
+3. Using incorrect field names will result in error messages that might be misleading (e.g., "received: string" when you're providing an array)
+4. To clear the `main_contact` attribute, send an empty array (`[]`)
+5. Do not use `null` to clear the field as it will cause a validation error
+
 ### Custom Fields
 
 Custom fields follow the same validation rules as their configured types in Attio.


### PR DESCRIPTION
## Description

This PR fixes the issue with updating the `main_contact` attribute in the Attio API.

### Problem

The API was returning errors when trying to update the `main_contact` attribute because:
1. The field names in the payload were incorrect (`record_id` instead of `target_record_id`)
2. The SDK wasn't properly formatting the value as an array

### Changes

1. **`src/objects/companies/basic.ts`**:
   - Added special handling for `main_contact` attributes
   - Properly formats values with correct field names (`target_record_id` and `target_object`)
   - Values are now wrapped in an array as required by the API
   - Added import for `searchPeople` function to handle name lookup

2. **`docs/api/company-write-operations.md`**:
   - Added detailed documentation about the `main_contact` attribute
   - Included specific API requirements and proper formatting
   - Added notes about common errors and how to avoid them
   - Documented clearing behavior (using `[]` instead of `null`)

### Testing Done

Confirmed the API accepts the correctly formatted payload with proper field names.

### API Payload Format

The correct format for setting a `main_contact` attribute is:
```json
{
  "data": {
    "values": {
      "main_contact": [
        {
          "target_record_id": "person_id",
          "target_object": "people"
        }
      ]
    }
  }
}
```

Fixes #278