### PR TITLE
Fix: Remove duplicate company basic info tool definition (#284)

### DIFF
--- a/src/handlers/tool-configs/companies/crud.ts
+++ b/src/handlers/tool-configs/companies/crud.ts
@@ -6,8 +6,7 @@ import {
   createCompany,
   updateCompany,
   updateCompanyAttribute,
-  deleteCompany,
-  getCompanyBasicInfo
+  deleteCompany
 } from "../../../objects/companies/index.js";
 import { ToolConfig } from "../../tool-types.js";
 import { formatterConfigs } from "./formatters.js";
@@ -39,11 +38,14 @@ function extractCompanyDisplayInfo(company: Company): { name: string; id: string
 
 // Company CRUD tool configurations
 export const crudToolConfigs = {
+  // Removed duplicate basicInfo configuration - already defined in formatterConfigs
+  /* Removed to prevent duplicate tool name conflict:
   basicInfo: {
     name: "get-company-basic-info",
     handler: getCompanyBasicInfo,
     formatResult: formatterConfigs.basicInfo.formatResult
   } as ToolConfig,
+  */
   
   create: {
     name: "create-company",
@@ -81,6 +83,8 @@ export const crudToolConfigs = {
 
 // CRUD tool definitions
 export const crudToolDefinitions = [
+  // Removed duplicate definition - already defined in formatterToolDefinitions
+  /* Removed to prevent duplicate tool name conflict:
   {
     name: "get-company-basic-info",
     description: "Get basic information about a company in Attio",
@@ -95,6 +99,7 @@ export const crudToolDefinitions = [
       required: ["companyId"]
     }
   },
+  */
   {
     name: "create-company",
     description: "Create a new company in Attio",

--- a/test/handlers/tools/company-tool-configs.test.ts
+++ b/test/handlers/tools/company-tool-configs.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for company tool configurations
+ * 
+ * This test verifies that there are no duplicate tool names in the company tool configs
+ */
+import { describe, it, expect } from 'vitest';
+import { formatterConfigs } from '../../../src/handlers/tool-configs/companies/formatters.js';
+import { crudToolConfigs } from '../../../src/handlers/tool-configs/companies/crud.js';
+
+describe('Company Tool Configurations', () => {
+  it('should have unique tool names across all config modules', () => {
+    // Get all tool names
+    const toolNames = new Set<string>();
+    const duplicates = new Set<string>();
+    
+    // Process formatters config
+    Object.values(formatterConfigs).forEach(config => {
+      const name = config.name;
+      if (toolNames.has(name)) {
+        duplicates.add(name);
+      } else {
+        toolNames.add(name);
+      }
+    });
+    
+    // Process CRUD config
+    Object.values(crudToolConfigs).forEach(config => {
+      const name = config.name;
+      if (toolNames.has(name)) {
+        duplicates.add(name);
+      } else {
+        toolNames.add(name);
+      }
+    });
+    
+    // There should be no duplicates
+    expect(duplicates.size).toBe(0);
+    
+    // Check specific tool name that was causing the issue
+    const basicInfoToolName = 'get-company-basic-info';
+    
+    // This tool should only be in the formatter configs, not in CRUD configs
+    expect(Object.values(formatterConfigs).some(config => config.name === basicInfoToolName)).toBe(true);
+    expect(Object.values(crudToolConfigs).some(config => config.name === basicInfoToolName)).toBe(false);
+  });
+});

--- a/test/handlers/tools/config-verifier.test.ts
+++ b/test/handlers/tools/config-verifier.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for tool configuration verification utilities
+ */
+import { verifyToolConfigsWithRequiredTools } from '../../../src/handlers/tools/config-verifier.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('Tool Config Verifier', () => {
+  let originalNodeEnv: string | undefined;
+  let originalDebug: string | undefined;
+  let originalStrictValidation: string | undefined;
+  let consoleWarnSpy: any;
+  let consoleErrorSpy: any;
+  let consoleLogSpy: any;
+
+  beforeEach(() => {
+    // Save original environment variables
+    originalNodeEnv = process.env.NODE_ENV;
+    originalDebug = process.env.DEBUG;
+    originalStrictValidation = process.env.STRICT_TOOL_VALIDATION;
+    
+    // Enable debug mode for testing
+    process.env.NODE_ENV = 'development';
+    
+    // Spy on console methods
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore original environment variables
+    process.env.NODE_ENV = originalNodeEnv;
+    process.env.DEBUG = originalDebug;
+    process.env.STRICT_TOOL_VALIDATION = originalStrictValidation;
+    
+    // Restore console methods
+    vi.restoreAllMocks();
+  });
+
+  it('should verify required tool types are present', () => {
+    const mockConfigs = {
+      search: {
+        name: 'search-test',
+        handler: () => {},
+        formatResult: () => {}
+      },
+      update: {
+        name: 'update-test',
+        handler: () => {},
+        formatResult: () => {}
+      }
+    };
+
+    const result = verifyToolConfigsWithRequiredTools('test', mockConfigs, ['search', 'update']);
+    
+    expect(result).toBe(true);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should identify missing required tool types', () => {
+    const mockConfigs = {
+      search: {
+        name: 'search-test',
+        handler: () => {},
+        formatResult: () => {}
+      }
+    };
+
+    const result = verifyToolConfigsWithRequiredTools('test', mockConfigs, ['search', 'update']);
+    
+    expect(result).toBe(false);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("MISSING: Required tool type 'update' not found!"));
+  });
+
+  it('should warn if handler function is missing', () => {
+    const mockConfigs = {
+      search: {
+        name: 'search-test',
+        // Missing handler
+        formatResult: () => {}
+      }
+    };
+
+    const result = verifyToolConfigsWithRequiredTools('test', mockConfigs, ['search']);
+    
+    expect(result).toBe(false);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("WARNING: search has no handler function!"));
+  });
+
+  it('should detect duplicate tool names', () => {
+    const mockConfigs = {
+      search: {
+        name: 'duplicate-name',
+        handler: () => {},
+        formatResult: () => {}
+      },
+      update: {
+        name: 'duplicate-name',
+        handler: () => {},
+        formatResult: () => {}
+      }
+    };
+
+    const result = verifyToolConfigsWithRequiredTools('test', mockConfigs, ['search', 'update']);
+    
+    // By default, it doesn't fail the validation without strict mode
+    expect(result).toBe(true);
+    
+    // But it does warn about duplicates
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("DUPLICATE TOOL NAMES DETECTED:"));
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Tool name "duplicate-name" is defined in multiple configs: search, update'));
+  });
+
+  it('should fail validation in strict mode for duplicate tool names', () => {
+    // Enable strict validation
+    process.env.STRICT_TOOL_VALIDATION = 'true';
+    
+    const mockConfigs = {
+      search: {
+        name: 'duplicate-name',
+        handler: () => {},
+        formatResult: () => {}
+      },
+      update: {
+        name: 'duplicate-name',
+        handler: () => {},
+        formatResult: () => {}
+      }
+    };
+
+    const result = verifyToolConfigsWithRequiredTools('test', mockConfigs, ['search', 'update']);
+    
+    // In strict mode, it should fail validation
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("ERROR: Duplicate tool names will cause MCP tool initialization failures."));
+  });
+
+  it('should skip validation when not in debug mode', () => {
+    // Disable debug mode
+    process.env.NODE_ENV = 'production';
+    process.env.DEBUG = undefined;
+    
+    const mockConfigs = {
+      // This would normally cause validation failures
+      incomplete: {
+        name: 'test',
+        // Missing handler
+      }
+    };
+
+    const result = verifyToolConfigsWithRequiredTools('test', mockConfigs, ['incomplete']);
+    
+    // In production mode, validation is skipped and returns true
+    expect(result).toBe(true);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed issue with duplicate tool name 'mcp__attio__get-company-basic-info' causing Claude API conflicts
- Removed duplicate definition from crudToolConfigs in companies/crud.ts
- Added duplicate tool name detection in the config verification utility

## Implementation Details
1. Identified duplicate tool definitions in both formatters.ts and crud.ts modules
2. Removed the duplicate definition in crud.ts which was redundant
3. Enhanced the config verifier utility to detect duplicate tool names during initialization
4. Added STRICT_TOOL_VALIDATION environment variable to optionally fail initialization with duplicates
5. Added comprehensive tests for the verification utility
6. Added specific test to verify no duplicate tool names exist in company configs

## Test Plan
- Created unit tests that specifically verify duplicate tool name detection
- Created a test that specifically checks that the company basic info tool is not duplicated
- Ran all handler-related tests to ensure no regressions
- Verified build succeeds with TypeScript compilation

Fixes #284