### PR TITLE
Fix: Prevent console.log from breaking MCP protocol (#286)

### DIFF
--- a/docs/mcp-protocol-communication.md
+++ b/docs/mcp-protocol-communication.md
@@ -1,0 +1,102 @@
+# MCP Protocol Communication Guidelines
+
+This document provides important guidelines for ensuring reliable communication between your MCP server and clients like Claude Desktop.
+
+## Critical Rule: NEVER Use console.log()
+
+**The most important rule when working with MCP servers: NEVER use `console.log()` directly.**
+
+### Why This Is Critical
+
+The Model Context Protocol (MCP) uses **standard output (stdout)** for communication between the server and client:
+
+1. Your MCP server receives requests on stdin
+2. Your MCP server sends responses on stdout
+3. Any debugging/logging information should go to stderr
+
+If you use `console.log()`, it writes to stdout, which:
+- Corrupts the JSON-RPC protocol
+- Causes "Unexpected token in JSON" errors in the client
+- Makes the MCP client (Claude Desktop) unable to parse your responses
+
+## Safe Logging Practices
+
+### 1. Use safeMcpLog (Preferred)
+
+```typescript
+import { safeMcpLog } from '../utils/logger.js';
+
+// Safe MCP logging - won't break protocol
+safeMcpLog('Processing tool request', { toolName, arguments });
+```
+
+### 2. Use console.error
+
+```typescript
+// Safe for MCP protocol - writes to stderr
+console.error('Processing tool request', toolName, arguments);
+```
+
+### 3. Use Structured Logging
+
+```typescript
+import { debug, info, warn, error } from '../utils/logger.js';
+
+// All these write to stderr now
+debug('module-name', 'Debug message', { context: 'data' });
+info('module-name', 'Info message', { context: 'data' });
+warn('module-name', 'Warning message', { context: 'data' });
+error('module-name', 'Error message', errorObject, { context: 'data' });
+```
+
+## Common MCP Protocol Errors
+
+### Client-Side Error Messages
+
+When protocol communication breaks, the client will show errors like:
+
+```
+SyntaxError: Unexpected token in JSON at position 12
+SyntaxError: Expected property name or '}' in JSON at position 1
+SyntaxError: Unexpected non-whitespace character after JSON at position 15
+```
+
+These errors usually indicate console.log output has contaminated the JSON response stream.
+
+### Debugging MCP Protocol Issues
+
+1. Search for `console.log` calls in your codebase
+2. Check if any middleware or third-party code writes to stdout
+3. Validate responses are proper JSON before sending
+4. Use `sanitizeMcpResponse` for all tool responses
+
+## Sanitizing MCP Responses
+
+Always sanitize responses before returning them to the client:
+
+```typescript
+import { sanitizeMcpResponse } from '../utils/json-serializer.js';
+
+// In your tool handler
+const result = await processToolRequest(request);
+return sanitizeMcpResponse(result);
+```
+
+## Common Pitfalls
+
+1. **Debug statements**: Even temporary `console.log` statements will break MCP
+2. **Third-party libraries**: Check if they write to stdout and redirect if needed
+3. **Error handling**: Make sure errors are not logged to stdout
+4. **Performance monitoring**: Use stderr for all performance logging
+
+## Testing MCP Communication
+
+To verify your MCP server doesn't contaminate stdout:
+
+```bash
+# Capture stdout separately and verify it's pure JSON
+node src/index.js > stdout.log 2> stderr.log
+cat stdout.log | jq . # Should parse cleanly as JSON
+```
+
+Always follow these guidelines to ensure reliable communication between your MCP server and clients.

--- a/src/utils/json-serializer.ts
+++ b/src/utils/json-serializer.ts
@@ -3,6 +3,12 @@
  * Handles circular references, non-serializable values, and large objects
  *
  * Uses fast-safe-stringify for improved performance and reliability
+ * 
+ * IMPORTANT MCP PROTOCOL WARNING:
+ * Never use console.log() in this file or any MCP-related code. 
+ * Always use console.error() or logger.safeMcpLog() instead.
+ * Using console.log will break the MCP protocol, as it writes to stdout
+ * which is used for client-server communication.
  */
 // @ts-ignore - Fast-safe-stringify has CommonJS exports
 import fastSafeStringify from 'fast-safe-stringify';
@@ -104,7 +110,7 @@ export function safeJsonStringify(
     // Performance monitoring and logging
     const duration = performance.now() - startTime;
     if (duration > 100) {
-      console.debug(
+      console.error(
         `[safeJsonStringify] Slow serialization detected: ${duration.toFixed(
           2
         )}ms for ${typeof obj} (${result.length} chars)`

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -176,7 +176,7 @@ export function debug(
       metadata: createLogMetadata('DEBUG', module, operation, operationType),
       ...(data && { data }),
     };
-    outputLog(entry, console.log);
+    outputLog(entry, console.error); // Use stderr instead of stdout to avoid interfering with MCP protocol
   }
 }
 
@@ -202,7 +202,7 @@ export function info(
       metadata: createLogMetadata('INFO', module, operation, operationType),
       ...(data && { data }),
     };
-    outputLog(entry, console.log);
+    outputLog(entry, console.error); // Use stderr instead of stdout to avoid interfering with MCP protocol
   }
 }
 
@@ -507,6 +507,18 @@ export async function withLogging<T>(
   }
 }
 
+/**
+ * Safe logging function that never interferes with MCP protocol
+ * Always use this for any direct console logging that might occur during MCP operations
+ *
+ * @param message - Message to log
+ * @param args - Additional arguments to log
+ */
+export function safeMcpLog(message: string, ...args: any[]): void {
+  // Always use console.error to avoid interfering with MCP protocol
+  console.error(`[MCP_SAFE_LOG] ${message}`, ...args);
+}
+
 export default {
   debug,
   info,
@@ -522,6 +534,7 @@ export default {
   generateCorrelationId,
   createScopedLogger,
   withLogging,
+  safeMcpLog,
   PerformanceTimer,
   LogLevel,
   OperationType,


### PR DESCRIPTION
## Summary
- Fixes JSON parsing errors in Claude Desktop by ensuring console logs don't interfere with MCP protocol
- Redirects all logging to stderr instead of stdout to maintain clean JSON-RPC communication
- Adds documentation and warning comments about MCP protocol communication requirements

## Problem
Claude Desktop was showing JSON parsing errors like:
- "Expected property name or '}' in JSON at position 1"
- "Unexpected non-whitespace character after JSON at position 11"

These errors occur when console.log statements write to stdout, which is used by the MCP protocol for communication.

## Changes
1. Changed  to  in all logger functions
2. Added new  utility to ensure all logging is done safely
3. Added warning comments in json-serializer.ts about console.log usage
4. Created documentation explaining MCP protocol communication guidelines

## Technical Details
- The Model Context Protocol uses stdout for client-server communication
- Any console.log statements contaminate the protocol's JSON stream
- All logging should be redirected to stderr to avoid protocol corruption
- Added detailed documentation in docs/mcp-protocol-communication.md

Fixes #286