### PR TITLE
Feature: Add path-based filtering for list entries (#303)

### DIFF
--- a/docs/path-based-filtering.md
+++ b/docs/path-based-filtering.md
@@ -1,0 +1,177 @@
+# Path-Based Filtering for List Entries
+
+This document explains how to use path-based filtering to find list entries based on properties of their parent records.
+
+## Overview
+
+Path-based filtering allows you to filter list entries by traversing relationships between objects. Specifically, you can filter list entries based on attributes of their parent records (the companies or people that the list entries are associated with).
+
+This is particularly useful when you want to find all entries in a list where the parent record matches certain criteria. For example:
+- Find all entries in a "Prospects" list where the parent company is in the "Technology" industry
+- Find all entries in a "Contacts" list where the parent person has an email from a specific domain
+- Find all entries in a "Deals" list where the parent company has more than 100 employees
+
+## API Reference
+
+### Filter List Entries by Parent Record Properties
+
+```
+filter-list-entries-by-parent
+```
+
+This tool allows you to filter list entries based on any attribute of their parent records.
+
+#### Parameters
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| listId | string | ID of the list to filter entries from | Yes |
+| parentObjectType | string | Type of the parent record (e.g., 'companies', 'people') | Yes |
+| parentAttributeSlug | string | Attribute of the parent record to filter by | Yes |
+| condition | string | Filter condition (e.g., 'equals', 'contains', 'greater_than') | Yes |
+| value | any | Value to filter by | Yes |
+| limit | number | Maximum number of entries to fetch (default: 20) | No |
+| offset | number | Number of entries to skip for pagination (default: 0) | No |
+
+#### Example Usage
+
+```javascript
+// Find entries in a list where the parent company is in the Technology industry
+const results = await filterListEntriesByParent(
+  'list_12345',    // listId
+  'companies',     // parentObjectType
+  'industry',      // parentAttributeSlug
+  'contains',      // condition
+  'Technology',    // value
+  10               // limit
+);
+
+// Find entries in a list where the parent person has an email from a specific domain
+const results = await filterListEntriesByParent(
+  'list_67890',    // listId
+  'people',        // parentObjectType
+  'email_addresses', // parentAttributeSlug
+  'contains',      // condition
+  '@example.com',  // value
+  20               // limit
+);
+```
+
+### Filter List Entries by Parent Record ID
+
+```
+filter-list-entries-by-parent-id
+```
+
+This is a simplified version of the above tool for the common case of filtering by record ID.
+
+#### Parameters
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| listId | string | ID of the list to filter entries from | Yes |
+| recordId | string | ID of the parent record to filter by | Yes |
+| limit | number | Maximum number of entries to fetch (default: 20) | No |
+| offset | number | Number of entries to skip for pagination (default: 0) | No |
+
+#### Example Usage
+
+```javascript
+// Find all entries in a list associated with a specific company
+const results = await filterListEntriesByParentId(
+  'list_12345',     // listId
+  'company_abcdef', // recordId
+  10                // limit
+);
+```
+
+## Supported Filter Conditions
+
+The following filter conditions are supported for path-based filtering:
+
+| Condition | Description | Example |
+|-----------|-------------|---------|
+| equals, eq | Exact match | industry equals "Technology" |
+| contains | Contains the string | email_addresses contains "@example.com" |
+| starts_with | Starts with the string | name starts_with "Acme" |
+| ends_with | Ends with the string | domain ends_with ".com" |
+| greater_than, gt | Greater than the value | employee_count greater_than 100 |
+| less_than, lt | Less than the value | revenue less_than 1000000 |
+| greater_than_or_equals, gte | Greater than or equal | age greater_than_or_equals 18 |
+| less_than_or_equals, lte | Less than or equal | date less_than_or_equals "2023-12-31" |
+| not_equals, ne | Not an exact match | status not_equals "Inactive" |
+| is_empty, is_not_set | Value is empty | description is_empty |
+| is_not_empty, is_set | Value is not empty | phone_numbers is_not_empty |
+| in | Value is in the array | industry in ["Technology", "SaaS"] |
+
+## Special Attribute Handling
+
+Some attributes receive special handling:
+
+### Record ID Filtering
+
+When filtering by `id` or `record_id`, the filter is optimized to use a direct record ID lookup:
+
+```javascript
+// These are equivalent
+await filterListEntriesByParent('list_12345', 'companies', 'id', 'equals', 'company_abc123');
+await filterListEntriesByParentId('list_12345', 'company_abc123');
+```
+
+### Name Filtering
+
+When filtering by `name`, the filter uses `full_name` in the query:
+
+```javascript
+// This uses full_name in the query
+await filterListEntriesByParent('list_12345', 'companies', 'name', 'contains', 'Acme');
+```
+
+### Email Address Filtering
+
+When filtering by `email_addresses`, the filter uses `email_address` in the query:
+
+```javascript
+// This uses email_address in the query
+await filterListEntriesByParent('list_12345', 'people', 'email_addresses', 'contains', '@example.com');
+```
+
+## Implementation Details
+
+Path-based filtering is implemented using the Attio API's path filter feature, which allows for filtering by following paths through related objects. This is accomplished by constructing a filter with:
+
+1. A `path` array that specifies the path to follow from the list entry to the parent record attribute
+2. A `constraints` object that specifies the filter condition and value
+
+For example, to filter list entries where the parent company's industry contains "Technology":
+
+```javascript
+{
+  path: [
+    ['my_list', 'parent_record'],
+    ['companies', 'industry']
+  ],
+  constraints: { contains: 'Technology' }
+}
+```
+
+The path array consists of tuples where:
+- The first element is the object slug/ID
+- The second element is the attribute or relationship to traverse
+
+## Error Handling
+
+The path-based filtering tools handle common errors including:
+
+- Invalid list IDs
+- Invalid parent object types
+- Invalid attribute slugs
+- Invalid filter conditions
+
+All errors include descriptive messages to help troubleshoot issues.
+
+## Performance Considerations
+
+- Path-based filters may be slower than direct attribute filters, especially for large lists
+- Consider using pagination (limit and offset) for large result sets
+- For best performance when filtering by record ID, use the specialized `filterListEntriesByParentId` function

--- a/src/handlers/tools/dispatcher/core.ts
+++ b/src/handlers/tools/dispatcher/core.ts
@@ -48,7 +48,9 @@ import {
   handleGetListDetailsOperation,
   handleGetListEntriesOperation,
   handleFilterListEntriesOperation,
-  handleAdvancedFilterListEntriesOperation
+  handleAdvancedFilterListEntriesOperation,
+  handleFilterListEntriesByParentOperation,
+  handleFilterListEntriesByParentIdOperation
 } from './operations/lists.js';
 
 // Import Batch operation handlers
@@ -158,6 +160,10 @@ export async function executeToolRequest(request: CallToolRequest) {
       result = await handleFilterListEntriesOperation(request, toolConfig);
     } else if (toolType === 'advancedFilterListEntries') {
       result = await handleAdvancedFilterListEntriesOperation(request, toolConfig);
+    } else if (toolType === 'filterListEntriesByParent') {
+      result = await handleFilterListEntriesByParentOperation(request, toolConfig);
+    } else if (toolType === 'filterListEntriesByParentId') {
+      result = await handleFilterListEntriesByParentIdOperation(request, toolConfig);
 
     // Handle Batch operations (from emergency fix)
     } else if (toolType === 'batchUpdate') {

--- a/src/handlers/tools/dispatcher/operations/lists.ts
+++ b/src/handlers/tools/dispatcher/operations/lists.ts
@@ -187,6 +187,153 @@ export async function handleUpdateListEntryOperation(
 }
 
 /**
+ * Handle filterListEntriesByParent operations
+ * 
+ * This handler extracts the required parameters from the tool request and passes them
+ * to the handler function for filtering list entries based on parent record properties.
+ */
+export async function handleFilterListEntriesByParentOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig
+) {
+  const listId = request.params.arguments?.listId as string;
+  const parentObjectType = request.params.arguments?.parentObjectType as string;
+  const parentAttributeSlug = request.params.arguments?.parentAttributeSlug as string;
+  const condition = request.params.arguments?.condition as string;
+  const value = request.params.arguments?.value;
+  const limit = request.params.arguments?.limit as number;
+  const offset = request.params.arguments?.offset as number;
+
+  // Validate required parameters
+  if (!listId) {
+    return createErrorResult(
+      new Error('listId parameter is required'),
+      '/lists',
+      'GET',
+      { status: 400, message: 'Missing required parameter: listId' }
+    );
+  }
+
+  if (!parentObjectType) {
+    return createErrorResult(
+      new Error('parentObjectType parameter is required'),
+      `/lists/${listId}/entries`,
+      'GET',
+      { status: 400, message: 'Missing required parameter: parentObjectType' }
+    );
+  }
+
+  if (!parentAttributeSlug) {
+    return createErrorResult(
+      new Error('parentAttributeSlug parameter is required'),
+      `/lists/${listId}/entries`,
+      'GET',
+      { status: 400, message: 'Missing required parameter: parentAttributeSlug' }
+    );
+  }
+
+  if (!condition) {
+    return createErrorResult(
+      new Error('condition parameter is required'),
+      `/lists/${listId}/entries`,
+      'GET',
+      { status: 400, message: 'Missing required parameter: condition' }
+    );
+  }
+
+  if (value === undefined) {
+    return createErrorResult(
+      new Error('value parameter is required'),
+      `/lists/${listId}/entries`,
+      'GET',
+      { status: 400, message: 'Missing required parameter: value' }
+    );
+  }
+
+  try {
+    // Call the handler function with all parameters
+    const result = await toolConfig.handler(
+      listId,
+      parentObjectType,
+      parentAttributeSlug,
+      condition,
+      value,
+      limit,
+      offset
+    );
+    
+    // Format the result using the configured formatter
+    const formattedResult = toolConfig.formatResult ? toolConfig.formatResult(result) : result;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/lists/${listId}/entries`,
+      'GET',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
+ * Handle filterListEntriesByParentId operations
+ * 
+ * This handler extracts the required parameters from the tool request and passes them
+ * to the handler function for filtering list entries by parent record ID.
+ */
+export async function handleFilterListEntriesByParentIdOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig
+) {
+  const listId = request.params.arguments?.listId as string;
+  const recordId = request.params.arguments?.recordId as string;
+  const limit = request.params.arguments?.limit as number;
+  const offset = request.params.arguments?.offset as number;
+
+  // Validate required parameters
+  if (!listId) {
+    return createErrorResult(
+      new Error('listId parameter is required'),
+      '/lists',
+      'GET',
+      { status: 400, message: 'Missing required parameter: listId' }
+    );
+  }
+
+  if (!recordId) {
+    return createErrorResult(
+      new Error('recordId parameter is required'),
+      `/lists/${listId}/entries`,
+      'GET',
+      { status: 400, message: 'Missing required parameter: recordId' }
+    );
+  }
+
+  try {
+    // Call the handler function with all parameters
+    const result = await toolConfig.handler(
+      listId,
+      recordId,
+      limit,
+      offset
+    );
+    
+    // Format the result using the configured formatter
+    const formattedResult = toolConfig.formatResult ? toolConfig.formatResult(result) : result;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/lists/${listId}/entries`,
+      'GET',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
  * Handle getListDetails operations
  */
 export async function handleGetListDetailsOperation(

--- a/src/handlers/tools/dispatcher/operations/lists.ts
+++ b/src/handlers/tools/dispatcher/operations/lists.ts
@@ -41,6 +41,8 @@ export async function handleAddRecordToListOperation(
 ) {
   const listId = request.params.arguments?.listId as string;
   const recordId = request.params.arguments?.recordId as string;
+  const objectType = request.params.arguments?.objectType as string;
+  const initialValues = request.params.arguments?.initialValues as Record<string, any>;
 
   if (!listId) {
     return createErrorResult(
@@ -61,7 +63,8 @@ export async function handleAddRecordToListOperation(
   }
 
   try {
-    const result = await toolConfig.handler(listId, recordId);
+    // Pass objectType and initialValues to the handler function
+    const result = await toolConfig.handler(listId, recordId, objectType, initialValues);
     const formattedResult = toolConfig.formatResult 
       ? toolConfig.formatResult(result) 
       : `Successfully added record ${recordId} to list ${listId}`;

--- a/src/handlers/tools/dispatcher/operations/lists.ts
+++ b/src/handlers/tools/dispatcher/operations/lists.ts
@@ -34,6 +34,14 @@ export async function handleGetListsOperation(
 
 /**
  * Handle addRecordToList operations
+ * 
+ * This function extracts parameters from the tool request and passes them to the handler.
+ * It supports both required parameters (listId, recordId) and optional parameters 
+ * (objectType, initialValues) needed for proper API payload construction.
+ * 
+ * @param request - The tool request containing parameters
+ * @param toolConfig - The tool configuration with handler function
+ * @returns Formatted response with success or error information
  */
 export async function handleAddRecordToListOperation(
   request: CallToolRequest,
@@ -41,8 +49,8 @@ export async function handleAddRecordToListOperation(
 ) {
   const listId = request.params.arguments?.listId as string;
   const recordId = request.params.arguments?.recordId as string;
-  const objectType = request.params.arguments?.objectType as string;
-  const initialValues = request.params.arguments?.initialValues as Record<string, any>;
+  const objectType = request.params.arguments?.objectType as string | undefined;
+  const initialValues = request.params.arguments?.initialValues as Record<string, any> | undefined;
 
   if (!listId) {
     return createErrorResult(

--- a/src/handlers/tools/formatters.ts
+++ b/src/handlers/tools/formatters.ts
@@ -7,12 +7,31 @@ import { safeJsonStringify, sanitizeMcpResponse } from "../../utils/json-seriali
 
 /**
  * Safely extract value from record attributes
+ * 
+ * @param record - The record to extract the value from, which might be an AttioRecord or a similar structure
+ * @param fieldName - The name of the field to extract
+ * @returns The extracted value as a string, or 'Unknown' if not found
  */
-function getAttributeValue(record: AttioRecord | undefined, fieldName: string): string {
+function getAttributeValue(record: any | undefined, fieldName: string): string {
   if (!record?.values) return 'Unknown';
   
-  const fieldValue = record.values[fieldName] as AttioValue<string>[] | undefined;
-  return fieldValue?.[0]?.value || 'Unknown';
+  const fieldValue = record.values[fieldName];
+  
+  if (!fieldValue) return 'Unknown';
+  
+  // Handle different value formats
+  if (Array.isArray(fieldValue) && fieldValue.length > 0) {
+    const firstValue = fieldValue[0];
+    if (typeof firstValue === 'object' && firstValue !== null && 'value' in firstValue) {
+      return firstValue.value as string || 'Unknown';
+    }
+    return String(firstValue) || 'Unknown';
+  } else if (typeof fieldValue === 'object' && fieldValue !== null && 'value' in fieldValue) {
+    return fieldValue.value as string || 'Unknown';
+  }
+  
+  // Fallback for any other format
+  return String(fieldValue) || 'Unknown';
 }
 
 /**

--- a/src/handlers/tools/formatters.ts
+++ b/src/handlers/tools/formatters.ts
@@ -8,11 +8,21 @@ import { safeJsonStringify, sanitizeMcpResponse } from "../../utils/json-seriali
 /**
  * Safely extract value from record attributes
  * 
+ * This function handles various record formats and extracts values from them,
+ * including standard AttioRecord objects and similar record-like structures
+ * that may come from different API responses or transformations.
+ * 
  * @param record - The record to extract the value from, which might be an AttioRecord or a similar structure
  * @param fieldName - The name of the field to extract
  * @returns The extracted value as a string, or 'Unknown' if not found
  */
-function getAttributeValue(record: any | undefined, fieldName: string): string {
+function getAttributeValue(
+  record: { 
+    values?: Record<string, any> | undefined;
+    [key: string]: any;
+  } | undefined, 
+  fieldName: string
+): string {
   if (!record?.values) return 'Unknown';
   
   const fieldValue = record.values[fieldName];

--- a/src/objects/lists.ts
+++ b/src/objects/lists.ts
@@ -591,7 +591,7 @@ export async function getRecordListMemberships(
     
     // For each list, check entries in parallel using batch operation
     const listConfigs = lists.map(list => ({
-      listId: list.id?.list_id || list.id,
+      listId: list.id?.list_id || (typeof list.id === 'string' ? list.id : ''),
       // Use the list name from the list object for later reference
       listName: list.name || list.title || 'Unnamed List',
       // Set a higher limit to ensure we catch the record if it exists

--- a/src/objects/lists.ts
+++ b/src/objects/lists.ts
@@ -665,3 +665,151 @@ export async function getRecordListMemberships(
     throw error;
   }
 }
+
+/**
+ * Filters list entries based on parent record properties using path-based filtering
+ * 
+ * This function allows filtering list entries based on properties of their parent records,
+ * such as company name, email domain, or any other attribute of the parent record.
+ * 
+ * @param listId - The ID of the list to filter entries from
+ * @param parentObjectType - The type of parent record (e.g., 'companies', 'people')
+ * @param parentAttributeSlug - The attribute of the parent record to filter by
+ * @param condition - The filter condition to apply
+ * @param value - The value to filter by
+ * @param limit - Maximum number of entries to fetch (default: 20)
+ * @param offset - Number of entries to skip (default: 0)
+ * @returns Array of filtered list entries
+ * 
+ * @example
+ * // Get list entries for companies that have "Tech" in their industry
+ * const entries = await filterListEntriesByParent(
+ *   'list_12345',
+ *   'companies',
+ *   'industry',
+ *   'contains',
+ *   'Tech'
+ * );
+ */
+export async function filterListEntriesByParent(
+  listId: string,
+  parentObjectType: string,
+  parentAttributeSlug: string,
+  condition: string,
+  value: any,
+  limit: number = 20,
+  offset: number = 0
+): Promise<AttioListEntry[]> {
+  // Input validation
+  if (!listId || typeof listId !== 'string') {
+    throw new Error('Invalid list ID: Must be a non-empty string');
+  }
+
+  if (!parentObjectType || typeof parentObjectType !== 'string') {
+    throw new Error('Invalid parent object type: Must be a non-empty string');
+  }
+
+  if (!parentAttributeSlug || typeof parentAttributeSlug !== 'string') {
+    throw new Error('Invalid parent attribute slug: Must be a non-empty string');
+  }
+
+  if (!condition || typeof condition !== 'string') {
+    throw new Error('Invalid condition: Must be a non-empty string');
+  }
+
+  // Use direct API interaction to perform path-based filtering
+  try {
+    // Get API client
+    const api = getAttioClient();
+    
+    // Create path-based filter using our utility function
+    const { path, constraints } = createPathBasedFilter(
+      listId,
+      parentObjectType,
+      parentAttributeSlug,
+      condition,
+      value
+    );
+    
+    // Construct the request payload
+    const payload = {
+      limit: limit,
+      offset: offset,
+      expand: ['record'],
+      path,
+      constraints
+    };
+
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`[filterListEntriesByParent] Filtering list ${listId} with path-based filter:`);
+      console.log(`- Parent Object Type: ${parentObjectType}`);
+      console.log(`- Parent Attribute: ${parentAttributeSlug}`);
+      console.log(`- Condition: ${condition}`);
+      console.log(`- Value: ${JSON.stringify(value)}`);
+      console.log(`- Request payload: ${JSON.stringify(payload)}`);
+    }
+    
+    // Create API URL endpoint
+    const endpoint = `/lists/${listId}/entries/query`;
+    
+    // Make the API request
+    const response = await api.post(endpoint, payload);
+    
+    // Process the entries to ensure record_id is properly set
+    const entries = processListEntries(response.data.data || []);
+    
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`[filterListEntriesByParent] Found ${entries.length} matching entries`);
+    }
+    
+    return entries;
+  } catch (error: any) {
+    // Enhanced error logging
+    if (process.env.NODE_ENV === 'development') {
+      console.error(`[filterListEntriesByParent] Error filtering list entries: ${error.message || 'Unknown error'}`);
+      
+      if (error.response) {
+        console.error('Status:', error.response.status);
+        console.error('Response data:', JSON.stringify(error.response.data || {}));
+      }
+    }
+    
+    // Add context to error message
+    if (error.response?.status === 400) {
+      throw new Error(`Invalid filter parameters: ${error.message || 'Bad request'}`);
+    } else if (error.response?.status === 404) {
+      throw new Error(`List ${listId} not found`);
+    }
+    
+    throw error;
+  }
+}
+
+/**
+ * Filters list entries by parent record ID
+ * 
+ * This is a specialized version of filterListEntriesByParent that specifically
+ * filters by the record ID of the parent record, which is a common use case.
+ * 
+ * @param listId - The ID of the list to filter entries from
+ * @param recordId - The ID of the parent record to filter by
+ * @param limit - Maximum number of entries to fetch (default: 20)
+ * @param offset - Number of entries to skip (default: 0)
+ * @returns Array of filtered list entries
+ */
+export async function filterListEntriesByParentId(
+  listId: string,
+  recordId: string,
+  limit: number = 20,
+  offset: number = 0
+): Promise<AttioListEntry[]> {
+  return filterListEntriesByParent(
+    listId,
+    'record', // This is a special case that will use just the parent_record path
+    'record_id',
+    'equals',
+    recordId,
+    limit,
+    offset
+  );
+}

--- a/src/utils/record-utils.ts
+++ b/src/utils/record-utils.ts
@@ -142,9 +142,9 @@ export function processListEntries(
           recordId = idObj;
         } else if (idObj.record_id) {
           recordId = idObj.record_id;
-        } else if (idObj.id) {
+        } else if (idObj.id && typeof idObj.id === 'string') {
           recordId = idObj.id;
-        } else if (idObj.reference_id) {
+        } else if (idObj.reference_id && typeof idObj.reference_id === 'string') {
           recordId = idObj.reference_id;
         }
       }

--- a/src/utils/record-utils.ts
+++ b/src/utils/record-utils.ts
@@ -13,6 +13,7 @@ import {
   createActivityFilter,
   createNumericFilter,
   FILTER_ATTRIBUTES,
+  FilterConditionType,
 } from './filters/index.js';
 
 // Re-export filter utilities for backwards compatibility
@@ -245,4 +246,112 @@ export function getRecordNameFromEntry(entry: AttioListEntry): {
     name: recordName,
     type: recordType,
   };
+}
+
+/**
+ * Creates a path-based filter for filtering list entries by parent record properties
+ * 
+ * This function constructs a filter that follows paths through related objects,
+ * which is necessary for filtering list entries based on properties of their parent records.
+ * 
+ * @param listSlug - The slug of the list (either the API slug or list ID)
+ * @param parentObjectType - The type of the parent record (e.g., 'companies', 'people')
+ * @param parentAttributeSlug - The attribute of the parent record to filter by
+ * @param condition - The filter condition to apply
+ * @param value - The value to filter by
+ * @returns A filter object compatible with the Attio API for path-based filtering
+ * 
+ * @example
+ * // Filter for companies in a list named "prospects" that have "Tech" in their industry
+ * const filter = createPathBasedFilter('prospects', 'companies', 'industry', 'contains', 'Tech');
+ * 
+ * @example
+ * // Filter for people in a list with ID "list_12345" who have an email from apple.com
+ * const filter = createPathBasedFilter('list_12345', 'people', 'email_addresses', 'contains', '@apple.com');
+ */
+export function createPathBasedFilter(
+  listSlug: string,
+  parentObjectType: string,
+  parentAttributeSlug: string,
+  condition: string,
+  value: any
+): { path: string[][]; constraints: Record<string, any> } {
+  // Create path array for drilling down through objects
+  // First path element is [listSlug, "parent_record"] to navigate from list entry to its parent record
+  // Second path element is [parentObjectType, parentAttributeSlug] to navigate to specific attribute
+  const path = [
+    [listSlug, 'parent_record'],
+    [parentObjectType, parentAttributeSlug]
+  ];
+  
+  // Create constraints object based on condition and value
+  let constraints: Record<string, any> = {};
+  
+  // Handle different condition types appropriately
+  if (condition === 'equals' || condition === 'eq') {
+    // For exact equality on simple attributes
+    constraints = { value };
+  } else if (condition === 'contains') {
+    // For partial text matching
+    constraints = { contains: value };
+  } else if (condition === 'starts_with') {
+    constraints = { starts_with: value };
+  } else if (condition === 'ends_with') {
+    constraints = { ends_with: value };
+  } else if (condition === 'greater_than' || condition === 'gt') {
+    constraints = { gt: value };
+  } else if (condition === 'less_than' || condition === 'lt') {
+    constraints = { lt: value };
+  } else if (condition === 'greater_than_or_equals' || condition === 'gte') {
+    constraints = { gte: value };
+  } else if (condition === 'less_than_or_equals' || condition === 'lte') {
+    constraints = { lte: value };
+  } else if (condition === 'not_equals' || condition === 'ne') {
+    constraints = { ne: value };
+  } else if (condition === 'is_empty' || condition === 'is_not_set') {
+    constraints = { is_empty: true };
+  } else if (condition === 'is_not_empty' || condition === 'is_set') {
+    constraints = { is_not_empty: true };
+  } else if (condition === 'in') {
+    constraints = { in: Array.isArray(value) ? value : [value] };
+  } else {
+    // Default to exact match if condition is unknown
+    constraints = { value };
+  }
+  
+  // Special case for filtering by record ID
+  if (parentAttributeSlug === 'id' || parentAttributeSlug === 'record_id') {
+    return {
+      path: [[listSlug, 'parent_record']],
+      constraints: { record_id: value }
+    };
+  }
+  
+  // For filtering by name, we need to use full_name property
+  if (parentAttributeSlug === 'name') {
+    if (condition === 'equals') {
+      constraints = { full_name: value };
+    } else if (condition === 'contains') {
+      constraints = { full_name: { contains: value } };
+    } else if (condition === 'starts_with') {
+      constraints = { full_name: { starts_with: value } };
+    } else if (condition === 'ends_with') {
+      constraints = { full_name: { ends_with: value } };
+    }
+  }
+  
+  // For email addresses, we need to use email_address property
+  if (parentAttributeSlug === 'email_addresses') {
+    if (condition === 'equals') {
+      constraints = { email_address: value };
+    } else if (condition === 'contains') {
+      constraints = { email_address: { contains: value } };
+    } else if (condition === 'starts_with') {
+      constraints = { email_address: { starts_with: value } };
+    } else if (condition === 'ends_with') {
+      constraints = { email_address: { ends_with: value } };
+    }
+  }
+  
+  return { path, constraints };
 }

--- a/test/integration/lists/add-record-to-list.integration.test.ts
+++ b/test/integration/lists/add-record-to-list.integration.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Integration test for the add-record-to-list tool
+ * Tests the entire flow from tool invocation to API call with proper parameters
+ */
+
+import { getAttioClient } from '../../../src/api/attio-client';
+import { addRecordToList } from '../../../src/objects/lists';
+import { handleAddRecordToListOperation } from '../../../src/handlers/tools/dispatcher/operations/lists';
+import { listsToolConfigs } from '../../../src/handlers/tool-configs/lists';
+
+// Skip tests if no API key is available
+const apiKey = process.env.ATTIO_API_KEY;
+const skipTests = !apiKey || process.env.SKIP_INTEGRATION_TESTS === 'true';
+
+// Mock data for testing
+const TEST_LIST_ID = 'list_your_test_list_id_here'; // Replace with a real list ID for testing
+const TEST_RECORD_ID = 'company_your_test_company_id_here'; // Replace with a real company ID for testing
+
+// Mock axios for API client in case we're skipping real API tests
+jest.mock('axios', () => {
+  // Only mock if we're skipping tests
+  if (skipTests) {
+    return {
+      create: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({ data: { data: {} } }),
+        post: jest.fn().mockResolvedValue({ 
+          data: { 
+            data: {
+              id: { entry_id: 'mock-entry-id' },
+              record_id: TEST_RECORD_ID,
+              values: { stage: 'Mock Stage' }
+            } 
+          } 
+        }),
+        interceptors: {
+          request: { use: jest.fn() },
+          response: { use: jest.fn() }
+        }
+      }))
+    };
+  }
+  
+  // Otherwise use the real axios
+  return jest.requireActual('axios');
+});
+
+describe('Add Record To List Integration', () => {
+  // Longer timeout for API calls
+  jest.setTimeout(30000);
+  
+  // Skip all tests if no API key
+  const conditionalTest = skipTests ? test.skip : test;
+  
+  // Create a test company and list for testing if needed
+  let createdEntryId: string | undefined;
+  
+  // Clean up after tests
+  afterAll(async () => {
+    if (skipTests || !createdEntryId) return;
+    
+    try {
+      // Clean up any created test data
+      const api = getAttioClient();
+      await api.delete(`/lists/${TEST_LIST_ID}/entries/${createdEntryId}`);
+      console.log(`Cleaned up test entry ${createdEntryId}`);
+    } catch (error) {
+      console.error('Error during cleanup:', error);
+    }
+  });
+  
+  conditionalTest('should call API with correct payload - required params only', async () => {
+    // Create a mock tool request with required parameters only
+    const mockRequest = {
+      params: {
+        arguments: {
+          listId: TEST_LIST_ID,
+          recordId: TEST_RECORD_ID
+        }
+      }
+    };
+    
+    // Call the handler
+    const result = await handleAddRecordToListOperation(
+      mockRequest as any,
+      listsToolConfigs.addRecordToList
+    );
+    
+    // Verify the result
+    expect(result).toBeDefined();
+    expect(result.status).toBe('success');
+    
+    // Save the entry ID for cleanup
+    const resultData = JSON.parse(result.content);
+    const entryIdMatch = resultData.match(/Entry ID: ([a-zA-Z0-9_-]+)/);
+    if (entryIdMatch && entryIdMatch[1]) {
+      createdEntryId = entryIdMatch[1];
+    }
+  });
+  
+  conditionalTest('should call API with correct payload - including objectType', async () => {
+    // Create a mock tool request with objectType
+    const mockRequest = {
+      params: {
+        arguments: {
+          listId: TEST_LIST_ID,
+          recordId: TEST_RECORD_ID,
+          objectType: 'companies'
+        }
+      }
+    };
+    
+    // Direct API call to spy on the payload
+    let capturedPayload: any;
+    const originalPost = getAttioClient().post;
+    
+    // Replace post method to capture the payload
+    getAttioClient().post = async (url: string, data: any) => {
+      capturedPayload = data;
+      return originalPost(url, data);
+    };
+    
+    // Call the handler
+    const result = await handleAddRecordToListOperation(
+      mockRequest as any,
+      listsToolConfigs.addRecordToList
+    );
+    
+    // Restore original post method
+    getAttioClient().post = originalPost;
+    
+    // Verify the payload
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.data).toBeDefined();
+    expect(capturedPayload.data.parent_object).toBe('companies');
+    
+    // Verify the result
+    expect(result).toBeDefined();
+    expect(result.status).toBe('success');
+    
+    // Save the entry ID for cleanup
+    const resultData = JSON.parse(result.content);
+    const entryIdMatch = resultData.match(/Entry ID: ([a-zA-Z0-9_-]+)/);
+    if (entryIdMatch && entryIdMatch[1]) {
+      createdEntryId = entryIdMatch[1];
+    }
+  });
+  
+  conditionalTest('should call API with correct payload - including initialValues', async () => {
+    // Create a mock tool request with initialValues
+    const initialValues = {
+      stage: 'Test Stage',
+      priority: 'High',
+      test_field: 'Test Value'
+    };
+    
+    const mockRequest = {
+      params: {
+        arguments: {
+          listId: TEST_LIST_ID,
+          recordId: TEST_RECORD_ID,
+          initialValues
+        }
+      }
+    };
+    
+    // Direct API call to spy on the payload
+    let capturedPayload: any;
+    const originalPost = getAttioClient().post;
+    
+    // Replace post method to capture the payload
+    getAttioClient().post = async (url: string, data: any) => {
+      capturedPayload = data;
+      return originalPost(url, data);
+    };
+    
+    // Call the handler
+    const result = await handleAddRecordToListOperation(
+      mockRequest as any,
+      listsToolConfigs.addRecordToList
+    );
+    
+    // Restore original post method
+    getAttioClient().post = originalPost;
+    
+    // Verify the payload
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.data).toBeDefined();
+    expect(capturedPayload.data.entry_values).toBeDefined();
+    expect(capturedPayload.data.entry_values.stage).toBe(initialValues.stage);
+    expect(capturedPayload.data.entry_values.priority).toBe(initialValues.priority);
+    expect(capturedPayload.data.entry_values.test_field).toBe(initialValues.test_field);
+    
+    // Verify the result
+    expect(result).toBeDefined();
+    expect(result.status).toBe('success');
+    
+    // Save the entry ID for cleanup
+    const resultData = JSON.parse(result.content);
+    const entryIdMatch = resultData.match(/Entry ID: ([a-zA-Z0-9_-]+)/);
+    if (entryIdMatch && entryIdMatch[1]) {
+      createdEntryId = entryIdMatch[1];
+    }
+  });
+  
+  conditionalTest('should call API with correct payload - all parameters', async () => {
+    // Create a mock tool request with all parameters
+    const initialValues = {
+      stage: 'Complete Test',
+      priority: 'Critical',
+      notes: 'This is a test with all parameters'
+    };
+    
+    const mockRequest = {
+      params: {
+        arguments: {
+          listId: TEST_LIST_ID,
+          recordId: TEST_RECORD_ID,
+          objectType: 'companies',
+          initialValues
+        }
+      }
+    };
+    
+    // Direct API call to spy on the payload
+    let capturedPayload: any;
+    const originalPost = getAttioClient().post;
+    
+    // Replace post method to capture the payload
+    getAttioClient().post = async (url: string, data: any) => {
+      capturedPayload = data;
+      return originalPost(url, data);
+    };
+    
+    // Call the handler
+    const result = await handleAddRecordToListOperation(
+      mockRequest as any,
+      listsToolConfigs.addRecordToList
+    );
+    
+    // Restore original post method
+    getAttioClient().post = originalPost;
+    
+    // Verify the payload
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.data).toBeDefined();
+    expect(capturedPayload.data.parent_object).toBe('companies');
+    expect(capturedPayload.data.entry_values).toBeDefined();
+    expect(capturedPayload.data.entry_values.stage).toBe(initialValues.stage);
+    expect(capturedPayload.data.entry_values.priority).toBe(initialValues.priority);
+    expect(capturedPayload.data.entry_values.notes).toBe(initialValues.notes);
+    
+    // Verify the result
+    expect(result).toBeDefined();
+    expect(result.status).toBe('success');
+    
+    // Save the entry ID for cleanup
+    const resultData = JSON.parse(result.content);
+    const entryIdMatch = resultData.match(/Entry ID: ([a-zA-Z0-9_-]+)/);
+    if (entryIdMatch && entryIdMatch[1]) {
+      createdEntryId = entryIdMatch[1];
+    }
+  });
+  
+  // Test with non-API interactions (mock only)
+  test('should handle missing required parameters correctly', async () => {
+    // Test missing listId
+    const mockRequestNoListId = {
+      params: {
+        arguments: {
+          recordId: TEST_RECORD_ID
+        }
+      }
+    };
+    
+    const resultNoListId = await handleAddRecordToListOperation(
+      mockRequestNoListId as any,
+      listsToolConfigs.addRecordToList
+    );
+    
+    expect(resultNoListId).toBeDefined();
+    expect(resultNoListId.status).toBe('error');
+    expect(resultNoListId.content).toContain('listId parameter is required');
+    
+    // Test missing recordId
+    const mockRequestNoRecordId = {
+      params: {
+        arguments: {
+          listId: TEST_LIST_ID
+        }
+      }
+    };
+    
+    const resultNoRecordId = await handleAddRecordToListOperation(
+      mockRequestNoRecordId as any,
+      listsToolConfigs.addRecordToList
+    );
+    
+    expect(resultNoRecordId).toBeDefined();
+    expect(resultNoRecordId.status).toBe('error');
+    expect(resultNoRecordId.content).toContain('recordId parameter is required');
+  });
+});

--- a/test/integration/path-based-filtering.integration.test.ts
+++ b/test/integration/path-based-filtering.integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration tests for path-based filtering of list entries
+ */
+
+import { filterListEntriesByParent, filterListEntriesByParentId } from '../../src/objects/lists';
+
+// Skip tests if no API key is available
+const skipTests = !process.env.ATTIO_API_KEY;
+const itif = skipTests ? it.skip : it;
+
+describe('Path-based list entry filtering', () => {
+  // Use a known list ID - adjust this to a valid list ID in your test environment
+  const TEST_LIST_ID = process.env.TEST_LIST_ID || 'list_12345';
+  
+  describe('filterListEntriesByParent', () => {
+    itif('should filter list entries by parent company industry', async () => {
+      // Arrange - Use a condition that should match at least one company
+      const parentObjectType = 'companies';
+      const parentAttributeSlug = 'industry';
+      const condition = 'contains';
+      const value = 'Tech'; // Adjust this value based on your test data
+      
+      // Act
+      const results = await filterListEntriesByParent(
+        TEST_LIST_ID,
+        parentObjectType,
+        parentAttributeSlug,
+        condition,
+        value,
+        5 // Limit to 5 entries
+      );
+      
+      // Assert
+      expect(Array.isArray(results)).toBe(true);
+      // Should find at least one matching entry
+      expect(results.length).toBeGreaterThan(0);
+      // Each result should have basic list entry properties
+      results.forEach(entry => {
+        expect(entry.id).toBeDefined();
+        expect(entry.list_id).toBe(TEST_LIST_ID);
+      });
+    }, 30000); // 30s timeout for API call
+    
+    itif('should filter list entries by parent person email domain', async () => {
+      // Arrange
+      const parentObjectType = 'people';
+      const parentAttributeSlug = 'email_addresses';
+      const condition = 'contains';
+      const value = '@example.com'; // Adjust based on your test data
+      
+      // Act
+      const results = await filterListEntriesByParent(
+        TEST_LIST_ID,
+        parentObjectType,
+        parentAttributeSlug,
+        condition,
+        value,
+        5 // Limit to 5 entries
+      );
+      
+      // Assert
+      expect(Array.isArray(results)).toBe(true);
+      // Each result should have basic list entry properties
+      if (results.length > 0) {
+        results.forEach(entry => {
+          expect(entry.id).toBeDefined();
+          expect(entry.list_id).toBe(TEST_LIST_ID);
+        });
+      }
+    }, 30000); // 30s timeout for API call
+  });
+  
+  describe('filterListEntriesByParentId', () => {
+    itif('should filter list entries by parent record ID', async () => {
+      // Arrange - Use a record ID that should exist in the list
+      // This ID should be adjusted to match a real record in your test environment
+      const recordId = process.env.TEST_RECORD_ID || 'record_12345';
+      
+      // Act
+      const results = await filterListEntriesByParentId(
+        TEST_LIST_ID,
+        recordId,
+        5 // Limit to 5 entries
+      );
+      
+      // Assert
+      expect(Array.isArray(results)).toBe(true);
+      // Each result should have basic list entry properties
+      if (results.length > 0) {
+        results.forEach(entry => {
+          expect(entry.id).toBeDefined();
+          expect(entry.list_id).toBe(TEST_LIST_ID);
+          // For direct record ID filters, the parent_record_id should match
+          if (entry.parent_record_id) {
+            expect(entry.parent_record_id).toBe(recordId);
+          }
+        });
+      }
+    }, 30000); // 30s timeout for API call
+  });
+  
+  describe('error handling', () => {
+    itif('should handle invalid list ID gracefully', async () => {
+      // Arrange
+      const invalidListId = 'non_existent_list';
+      
+      // Act & Assert
+      await expect(
+        filterListEntriesByParent(
+          invalidListId,
+          'companies',
+          'industry',
+          'contains',
+          'Tech'
+        )
+      ).rejects.toThrow();
+    }, 30000); // 30s timeout for API call
+    
+    itif('should handle invalid attribute gracefully', async () => {
+      // Arrange
+      const invalidAttribute = 'non_existent_attribute';
+      
+      // Act & Assert
+      await expect(
+        filterListEntriesByParent(
+          TEST_LIST_ID,
+          'companies',
+          invalidAttribute,
+          'contains',
+          'Tech'
+        )
+      ).rejects.toThrow();
+    }, 30000); // 30s timeout for API call
+  });
+});

--- a/test/manual/test-add-record-to-list-fix.js
+++ b/test/manual/test-add-record-to-list-fix.js
@@ -1,0 +1,151 @@
+/**
+ * Manual test for the fixed add-record-to-list tool
+ * This test verifies that the API payload structure is correct when using objectType and initialValues
+ * 
+ * Run with: node test/manual/test-add-record-to-list-fix.js
+ */
+
+// Import the handler directly
+import { handleAddRecordToListOperation } from '../../dist/handlers/tools/dispatcher/operations/lists.js';
+import { listsToolConfigs } from '../../dist/handlers/tool-configs/lists.js';
+
+// Spy on the handler to see what parameters it receives
+const originalHandler = listsToolConfigs.addRecordToList.handler;
+let handlerCalled = false;
+let handlerParams = {};
+
+// Replace the handler with our spy function
+listsToolConfigs.addRecordToList.handler = function(listId, recordId, objectType, initialValues) {
+  console.log('\n[TEST SPY] addRecordToList handler called with:');
+  console.log('- listId:', listId);
+  console.log('- recordId:', recordId);
+  console.log('- objectType:', objectType);
+  console.log('- initialValues:', JSON.stringify(initialValues, null, 2));
+  
+  handlerCalled = true;
+  handlerParams = { listId, recordId, objectType, initialValues };
+  
+  // Return a mock response
+  return Promise.resolve({
+    id: { entry_id: 'test-entry-123' },
+    record_id: recordId,
+    parent_record_id: recordId,
+    values: initialValues || {}
+  });
+};
+
+// Create a mock request with various parameter combinations
+async function runTest(testName, requestArguments) {
+  console.log(`\n=== TEST: ${testName} ===`);
+  
+  handlerCalled = false;
+  handlerParams = {};
+  
+  // Create the mock request
+  const mockRequest = {
+    params: {
+      arguments: requestArguments
+    }
+  };
+  
+  // Call the handler
+  try {
+    const result = await handleAddRecordToListOperation(mockRequest, listsToolConfigs.addRecordToList);
+    console.log('Operation result:', result);
+    
+    // Verify parameters were passed correctly
+    if (!handlerCalled) {
+      console.error('❌ FAILED: Handler was not called');
+      return false;
+    }
+    
+    // For required parameters
+    if (requestArguments.listId !== handlerParams.listId) {
+      console.error(`❌ FAILED: listId not passed correctly. Expected ${requestArguments.listId}, got ${handlerParams.listId}`);
+      return false;
+    }
+    
+    if (requestArguments.recordId !== handlerParams.recordId) {
+      console.error(`❌ FAILED: recordId not passed correctly. Expected ${requestArguments.recordId}, got ${handlerParams.recordId}`);
+      return false;
+    }
+    
+    // For optional parameters
+    if (requestArguments.objectType && requestArguments.objectType !== handlerParams.objectType) {
+      console.error(`❌ FAILED: objectType not passed correctly. Expected ${requestArguments.objectType}, got ${handlerParams.objectType}`);
+      return false;
+    }
+    
+    if (requestArguments.initialValues && JSON.stringify(requestArguments.initialValues) !== JSON.stringify(handlerParams.initialValues)) {
+      console.error(`❌ FAILED: initialValues not passed correctly. Expected ${JSON.stringify(requestArguments.initialValues)}, got ${JSON.stringify(handlerParams.initialValues)}`);
+      return false;
+    }
+    
+    console.log('✅ PASSED: All parameters passed correctly to handler');
+    return true;
+  } catch (error) {
+    console.error('❌ ERROR:', error.message);
+    return false;
+  }
+}
+
+// Main test function
+async function runAllTests() {
+  let passCount = 0;
+  let failCount = 0;
+  
+  // Test 1: Required parameters only
+  const test1 = await runTest('Required parameters only', {
+    listId: 'list-123',
+    recordId: 'record-456'
+  });
+  test1 ? passCount++ : failCount++;
+  
+  // Test 2: With objectType
+  const test2 = await runTest('With objectType', {
+    listId: 'list-123',
+    recordId: 'record-456',
+    objectType: 'people'
+  });
+  test2 ? passCount++ : failCount++;
+  
+  // Test 3: With initialValues
+  const test3 = await runTest('With initialValues', {
+    listId: 'list-123',
+    recordId: 'record-456',
+    initialValues: {
+      stage: 'Prospect',
+      priority: 'High'
+    }
+  });
+  test3 ? passCount++ : failCount++;
+  
+  // Test 4: With both objectType and initialValues
+  const test4 = await runTest('With both objectType and initialValues', {
+    listId: 'list-123',
+    recordId: 'record-456',
+    objectType: 'companies',
+    initialValues: {
+      stage: 'Demo Scheduled',
+      priority: 'Medium',
+      notes: 'Demo scheduled for next week'
+    }
+  });
+  test4 ? passCount++ : failCount++;
+  
+  // Print summary
+  console.log('\n=== TEST SUMMARY ===');
+  console.log(`Tests passed: ${passCount}`);
+  console.log(`Tests failed: ${failCount}`);
+  
+  if (failCount === 0) {
+    console.log('\n✅ ALL TESTS PASSED: add-record-to-list bug fix is working correctly');
+  } else {
+    console.log('\n❌ SOME TESTS FAILED: Please check the output above for details');
+  }
+}
+
+// Run all tests
+runAllTests().catch(error => {
+  console.error('Unexpected error:', error);
+});

--- a/test/utils/path-based-filter.test.ts
+++ b/test/utils/path-based-filter.test.ts
@@ -1,0 +1,226 @@
+import { createPathBasedFilter } from '../../src/utils/record-utils';
+
+describe('createPathBasedFilter', () => {
+  const listId = 'my_list';
+  const companiesObjectType = 'companies';
+  const peopleObjectType = 'people';
+
+  describe('basic filter creation', () => {
+    it('should create a correct path-based filter structure', () => {
+      // Arrange
+      const parentAttributeSlug = 'industry';
+      const condition = 'contains';
+      const value = 'Tech';
+      
+      // Act
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        parentAttributeSlug,
+        condition,
+        value
+      );
+      
+      // Assert
+      expect(filter).toEqual({
+        path: [
+          [listId, 'parent_record'],
+          [companiesObjectType, parentAttributeSlug]
+        ],
+        constraints: { contains: 'Tech' }
+      });
+    });
+  });
+  
+  describe('condition mapping', () => {
+    it('should correctly map equals condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'industry',
+        'equals',
+        'Technology'
+      );
+      
+      expect(filter.constraints).toEqual({ value: 'Technology' });
+    });
+    
+    it('should correctly map contains condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'description',
+        'contains',
+        'software'
+      );
+      
+      expect(filter.constraints).toEqual({ contains: 'software' });
+    });
+    
+    it('should correctly map starts_with condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'description', // Using description instead of name to avoid special handling
+        'starts_with',
+        'Acme'
+      );
+      
+      expect(filter.constraints).toEqual({ starts_with: 'Acme' });
+    });
+    
+    it('should correctly map ends_with condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'domain',
+        'ends_with',
+        '.com'
+      );
+      
+      expect(filter.constraints).toEqual({ ends_with: '.com' });
+    });
+    
+    it('should correctly map greater_than condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'employee_count',
+        'greater_than',
+        100
+      );
+      
+      expect(filter.constraints).toEqual({ gt: 100 });
+    });
+    
+    it('should correctly map less_than condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'revenue',
+        'less_than',
+        1000000
+      );
+      
+      expect(filter.constraints).toEqual({ lt: 1000000 });
+    });
+    
+    it('should correctly map is_empty condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        peopleObjectType,
+        'phone_numbers',
+        'is_empty',
+        null
+      );
+      
+      expect(filter.constraints).toEqual({ is_empty: true });
+    });
+    
+    it('should correctly map is_not_empty condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        peopleObjectType,
+        'email_addresses',
+        'is_not_empty',
+        null
+      );
+      
+      expect(filter.constraints).toEqual({ is_not_empty: true });
+    });
+    
+    it('should correctly map in condition with array value', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'industry',
+        'in',
+        ['Technology', 'Software', 'SaaS']
+      );
+      
+      expect(filter.constraints).toEqual({ in: ['Technology', 'Software', 'SaaS'] });
+    });
+    
+    it('should correctly map in condition with single value (converted to array)', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'industry',
+        'in',
+        'Technology'
+      );
+      
+      expect(filter.constraints).toEqual({ in: ['Technology'] });
+    });
+  });
+  
+  describe('special attribute handling', () => {
+    it('should create special filter for record_id', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'record_id',
+        'equals',
+        'company_123'
+      );
+      
+      // Should have simplified path and direct record_id constraint
+      expect(filter).toEqual({
+        path: [[listId, 'parent_record']],
+        constraints: { record_id: 'company_123' }
+      });
+    });
+    
+    it('should create special filter for id attribute', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'id',
+        'equals',
+        'company_123'
+      );
+      
+      // Should have simplified path and direct record_id constraint
+      expect(filter).toEqual({
+        path: [[listId, 'parent_record']],
+        constraints: { record_id: 'company_123' }
+      });
+    });
+    
+    it('should handle name attribute with equals condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'name',
+        'equals',
+        'Acme Corp'
+      );
+      
+      expect(filter.constraints).toEqual({ full_name: 'Acme Corp' });
+    });
+    
+    it('should handle name attribute with contains condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        companiesObjectType,
+        'name',
+        'contains',
+        'Acme'
+      );
+      
+      expect(filter.constraints).toEqual({ full_name: { contains: 'Acme' } });
+    });
+    
+    it('should handle email_addresses attribute with contains condition', () => {
+      const filter = createPathBasedFilter(
+        listId,
+        peopleObjectType,
+        'email_addresses',
+        'contains',
+        '@example.com'
+      );
+      
+      expect(filter.constraints).toEqual({ email_address: { contains: '@example.com' } });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds the ability to filter list entries based on parent record properties, implementing issue #303.

Two new tools are introduced:
- `filter-list-entries-by-parent`: Filters by any parent record attribute (industry, name, etc.)
- `filter-list-entries-by-parent-id`: Simplified version for filtering by record ID

## Implementation Details
- Added `createPathBasedFilter` utility in record-utils.ts for constructing path-based filters
- Added list entry filtering functions to lists.ts module
- Updated dispatcher to handle the new tool types
- Added unit tests for path-based filter creation
- Added integration tests for the filtering functionality
- Added comprehensive documentation in docs/path-based-filtering.md

## Test Plan
- Run unit tests: `npm test test/utils/path-based-filter.test.ts`
- Run integration tests (requires API key): `npm test test/integration/path-based-filtering.integration.test.ts`
- Manual testing with example list queries