### PR TITLE
Fix: JSON parsing in PR review script

### DIFF
--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -158,7 +158,16 @@ EOF
 fi
 
 # Run claude with the prompt and data using the allowed-tools flag
-claude --verbose --output-format json -p /tmp/pr_review_prompt_${PR_NUMBER}.md --allowedTools "mcp__mcp-sequentialthinking-tools__sequentialthinking_tools" < /tmp/pr_data_${PR_NUMBER}.md > /tmp/review_output_${PR_NUMBER}.md
+claude --verbose --output-format json -p /tmp/pr_review_prompt_${PR_NUMBER}.md --allowedTools "mcp__mcp-sequentialthinking-tools__sequentialthinking_tools" < /tmp/pr_data_${PR_NUMBER}.md > /tmp/review_output_json_${PR_NUMBER}.md
+
+# Extract the actual review content from the JSON output
+cat /tmp/review_output_json_${PR_NUMBER}.md | jq -r '.result' > /tmp/review_output_${PR_NUMBER}.md
+
+# If extraction fails, provide a fallback
+if [ ! -s /tmp/review_output_${PR_NUMBER}.md ]; then
+    echo "⚠️ Failed to extract review content from JSON. Using raw output."
+    cp /tmp/review_output_json_${PR_NUMBER}.md /tmp/review_output_${PR_NUMBER}.md
+fi
 
 echo "📝 Posting review to PR..."
 
@@ -172,7 +181,7 @@ echo "✅ Review completed and posted to PR #$PR_NUMBER"
 echo "🔗 View at: $(gh pr view $PR_NUMBER --json url -q .url)"
 
 # Cleanup
-rm /tmp/pr_review_prompt_${PR_NUMBER}.md /tmp/pr_data_${PR_NUMBER}.md /tmp/review_output_${PR_NUMBER}.md
+rm /tmp/pr_review_prompt_${PR_NUMBER}.md /tmp/pr_data_${PR_NUMBER}.md /tmp/review_output_${PR_NUMBER}.md /tmp/review_output_json_${PR_NUMBER}.md
 
 echo ""
 echo "💡 Full detailed analysis completed using claude -p"

--- a/scripts/test-pr-review.sh
+++ b/scripts/test-pr-review.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Test script for PR review functionality
+# This script tests the JSON parsing functionality of review-pr.sh without actually posting to GitHub
+
+set -e
+
+echo "🧪 Testing PR review JSON extraction..."
+
+# Create a sample JSON output similar to what Claude would produce
+cat > /tmp/sample_claude_json.md << EOF
+{
+  "type": "result",
+  "subtype": "success",
+  "cost_usd": 0.12345,
+  "is_error": false,
+  "duration_ms": 12345,
+  "duration_api_ms": 12345,
+  "num_turns": 3,
+  "result": "## Test PR Review\n\nThis is a test review to verify JSON extraction is working properly.\n\n### ✅ Strengths\n- Properly extracts content\n- Handles JSON format\n- Provides fallback\n\n**Recommendation: APPROVE**",
+  "total_cost": 0.12345,
+  "session_id": "test-session-id"
+}
+EOF
+
+# Test the extraction with jq
+echo "Testing JSON extraction..."
+cat /tmp/sample_claude_json.md | jq -r '.result' > /tmp/extracted_review.md
+
+# Verify the result
+if grep -q "Test PR Review" /tmp/extracted_review.md && grep -q "Recommendation: APPROVE" /tmp/extracted_review.md; then
+    echo "✅ Test passed: JSON extraction working properly"
+    cat /tmp/extracted_review.md
+else
+    echo "❌ Test failed: JSON extraction did not produce expected output"
+    echo "Expected content about PR Review and recommendation"
+    echo "Actual content:"
+    cat /tmp/extracted_review.md
+fi
+
+# Test fallback with malformed JSON
+echo "Testing fallback with malformed JSON..."
+echo "{malformed json" > /tmp/malformed_json.md
+cat /tmp/malformed_json.md | jq -r '.result' 2>/dev/null > /tmp/extracted_malformed.md || true
+
+if [ ! -s /tmp/extracted_malformed.md ]; then
+    echo "✅ Test passed: Empty file detection works for fallback"
+else
+    echo "❌ Test failed: Expected empty file for malformed JSON"
+fi
+
+# Cleanup
+echo "Cleaning up test files..."
+rm /tmp/sample_claude_json.md /tmp/extracted_review.md /tmp/malformed_json.md /tmp/extracted_malformed.md
+
+echo "✅ All tests completed"


### PR DESCRIPTION
## Fix: JSON parsing in PR review script

### Problem
The PR review script (`review-pr.sh`) was using `--output-format json` but not properly extracting the review content from the JSON output. This resulted in raw JSON being posted to PR comments, including message metadata instead of just the formatted markdown review.

### Solution
- Modified `review-pr.sh` to extract the actual review content from Claude's JSON output using `jq`
- Added a fallback mechanism in case the JSON parsing fails
- Created a test script (`test-pr-review.sh`) to verify the JSON extraction works properly

### Changes
1. Output JSON to a temporary file then extract the `.result` field using `jq`
2. Handle edge cases when extraction fails
3. Update cleanup to remove all temporary files
4. Add testing script to verify functionality

### Testing
- Added `test-pr-review.sh` to simulate Claude's JSON output and verify extraction
- Tested both successful extraction and fallback for malformed JSON