### PR TITLE
HOTFIX: Fix people search phone field regression (P0)

### DIFF
--- a/src/api/operations/search.ts
+++ b/src/api/operations/search.ts
@@ -39,7 +39,7 @@ export async function searchObject<T extends AttioRecord>(
       $or: [
         { name: { $contains: query } },
         { email_addresses: { $contains: query } },
-        { phone: { $contains: query } },
+        { phone_numbers: { $contains: query } },
       ],
     };
   } else {

--- a/test/api/people-search-phone-field-fix.test.ts
+++ b/test/api/people-search-phone-field-fix.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Test for the phone field fix in people search
+ * Verifies that searchObject uses correct 'phone_numbers' field instead of 'phone'
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { searchObject } from '../../src/api/operations/search.js';
+import { ResourceType } from '../../src/types/attio.js';
+
+// Mock the Attio client
+const mockPost = vi.fn();
+vi.mock('../../src/api/attio-client.js', () => ({
+  getAttioClient: () => ({
+    post: mockPost,
+  }),
+}));
+
+describe('People Search Phone Field Fix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ data: { data: [] } });
+  });
+
+  it('should use phone_numbers field instead of phone for people search', async () => {
+    const query = 'test@example.com';
+    
+    await searchObject(ResourceType.PEOPLE, query);
+    
+    expect(mockPost).toHaveBeenCalledWith('/objects/people/records/query', {
+      filter: {
+        $or: [
+          { name: { $contains: query } },
+          { email_addresses: { $contains: query } },
+          { phone_numbers: { $contains: query } }, // This should be phone_numbers, not phone
+        ],
+      },
+    });
+  });
+
+  it('should use name field only for company search (not affected)', async () => {
+    const query = 'test company';
+    
+    await searchObject(ResourceType.COMPANIES, query);
+    
+    expect(mockPost).toHaveBeenCalledWith('/objects/companies/records/query', {
+      filter: {
+        name: { $contains: query },
+      },
+    });
+  });
+
+  it('should not contain the incorrect phone field in people search', async () => {
+    const query = 'john@example.com';
+    
+    await searchObject(ResourceType.PEOPLE, query);
+    
+    const callArgs = mockPost.mock.calls[0];
+    const filterObject = callArgs[1].filter;
+    
+    // Verify phone_numbers is used
+    const phoneNumbersFilter = filterObject.$or.find((f: any) => f.phone_numbers);
+    expect(phoneNumbersFilter).toBeDefined();
+    expect(phoneNumbersFilter.phone_numbers).toEqual({ $contains: query });
+    
+    // Verify the incorrect 'phone' field is NOT used
+    const incorrectPhoneFilter = filterObject.$or.find((f: any) => f.phone);
+    expect(incorrectPhoneFilter).toBeUndefined();
+  });
+}); 

--- a/test/manual/test-domain-search-issue.js
+++ b/test/manual/test-domain-search-issue.js
@@ -1,0 +1,43 @@
+/**
+ * Manual test to verify domain search functionality
+ * This tests the specific issue reported where domain search returns 0 results
+ */
+
+import { searchCompaniesByDomain } from '../../dist/objects/companies/search.js';
+
+async function testDomainSearchIssue() {
+  console.log('=== Testing Domain Search Issue ===');
+  
+  const testDomains = [
+    'glomedspact.com',
+    'example.com',
+    'google.com',
+    'microsoft.com'
+  ];
+
+  for (const domain of testDomains) {
+    try {
+      console.log(`\nTesting domain: ${domain}`);
+      const results = await searchCompaniesByDomain(domain);
+      console.log(`Results: ${results.length} companies found`);
+      
+      if (results.length > 0) {
+        console.log('First result:', {
+          id: results[0].id?.record_id,
+          name: results[0].values?.name?.[0]?.value,
+          domains: results[0].values?.domains,
+          website: results[0].values?.website?.[0]?.value
+        });
+      }
+    } catch (error) {
+      console.error(`Error searching for ${domain}:`, error.message);
+    }
+  }
+}
+
+// Set up environment if API key exists
+if (process.env.ATTIO_API_KEY) {
+  testDomainSearchIssue().catch(console.error);
+} else {
+  console.log('ATTIO_API_KEY not set, skipping domain search test');
+}

--- a/test/manual/test-phone-search-fix.js
+++ b/test/manual/test-phone-search-fix.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify the phone number field fix
+ * Tests that searchPeopleByEmail no longer fails with "Unknown attribute slug: phone"
+ */
+
+import { searchPeopleByEmail } from '../../dist/objects/people/search.js';
+
+async function testPhoneFieldFix() {
+  console.log('Testing phone field fix for people search...');
+  
+  try {
+    // Test with a specific email
+    const testEmail = 'michel.camposbr@gmail.com';
+    console.log(`\nSearching for people with email: ${testEmail}`);
+    
+    const results = await searchPeopleByEmail(testEmail);
+    
+    console.log(`✅ Search completed successfully!`);
+    console.log(`Found ${results.length} people matching the email`);
+    
+    if (results.length > 0) {
+      console.log('\nFirst result:');
+      const person = results[0];
+      console.log(`- Name: ${person.values?.name?.[0]?.value || 'Unknown'}`);
+      console.log(`- ID: ${person.id?.record_id || 'Unknown'}`);
+      
+      // Show available fields to verify structure
+      const fields = Object.keys(person.values || {});
+      console.log(`- Available fields: ${fields.join(', ')}`);
+    }
+    
+  } catch (error) {
+    console.error('❌ Error occurred:');
+    console.error(error.message);
+    
+    // Check if it's the specific phone field error
+    if (error.message.includes('Unknown attribute slug: phone')) {
+      console.error('\n🚨 The phone field error still exists! Fix not working.');
+      process.exit(1);
+    } else {
+      console.log('\n✅ The phone field error is fixed (different error type)');
+    }
+  }
+}
+
+testPhoneFieldFix().catch(console.error); 


### PR DESCRIPTION
Fixes critical regression in people search functionality where incorrect field name 'phone' was used instead of 'phone_numbers', causing all people searches to fail with 'Bad Request: Unknown attribute slug: phone' error. Resolves #336. Includes comprehensive test coverage to prevent similar regressions.