### PR TITLE
Fix: Implement missing generic record operation handlers #343

### DIFF
--- a/src/handlers/tools/dispatcher/core.ts
+++ b/src/handlers/tools/dispatcher/core.ts
@@ -65,6 +65,12 @@ import {
   handleBatchGetDetailsOperation,
 } from './operations/batch.js';
 
+// Import Record operation handlers
+import {
+  handleListOperation,
+  handleGetOperation,
+} from './operations/records.js';
+
 // Import tool type definitions
 import {
   ToolConfig,
@@ -292,6 +298,18 @@ export async function executeToolRequest(request: CallToolRequest) {
         request,
         toolConfig as SearchToolConfig,
         resourceType
+      );
+
+      // Handle generic record operations
+    } else if (toolType === 'list') {
+      result = await handleListOperation(
+        request,
+        toolConfig as ToolConfig
+      );
+    } else if (toolType === 'get') {
+      result = await handleGetOperation(
+        request,
+        toolConfig as ToolConfig
       );
     
     // Handle General tools (relationship helpers, etc.)

--- a/src/handlers/tools/dispatcher/operations/records.ts
+++ b/src/handlers/tools/dispatcher/operations/records.ts
@@ -1,0 +1,115 @@
+/**
+ * Generic record operation handlers for tool execution
+ *
+ * Handles generic record operations like list-records and get-record
+ * that work across all object types (companies, people, deals, etc.)
+ */
+
+import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createErrorResult } from '../../../../utils/error-handler.js';
+import { ToolConfig } from '../../../tool-types.js';
+import { formatResponse } from '../../formatters.js';
+import { hasResponseData } from '../../error-types.js';
+
+/**
+ * Handle list-records operations
+ * 
+ * Executes generic record listing for any object type
+ */
+export async function handleListOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig
+) {
+  try {
+    const { objectSlug, objectId, ...options } = request.params.arguments || {};
+
+    if (!objectSlug) {
+      return createErrorResult(
+        new Error('objectSlug parameter is required for list operation'),
+        `/objects/${objectSlug || 'unknown'}/records`,
+        'GET',
+        { status: 400, message: 'Missing required parameter: objectSlug' }
+      );
+    }
+
+    // Extract the list options, excluding objectSlug and objectId
+    const listOptions = {
+      page: options.page,
+      pageSize: options.pageSize,
+      query: options.query,
+      attributes: options.attributes,
+      sort: options.sort,
+      direction: options.direction,
+    };
+
+    // Remove undefined properties to keep the options clean
+    Object.keys(listOptions).forEach(key => {
+      if (listOptions[key as keyof typeof listOptions] === undefined) {
+        delete listOptions[key as keyof typeof listOptions];
+      }
+    });
+
+    const result = await toolConfig.handler(objectSlug, listOptions, objectId);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(result)
+      : `Found ${Array.isArray(result) ? result.length : 0} records`;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    const objectSlug = request.params.arguments?.objectSlug || 'unknown';
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/objects/${objectSlug}/records`,
+      'GET',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
+ * Handle get-record operations
+ * 
+ * Executes generic record retrieval for any object type
+ */
+export async function handleGetOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig
+) {
+  try {
+    const { objectSlug, recordId, attributes, objectId } = request.params.arguments || {};
+
+    if (!objectSlug) {
+      return createErrorResult(
+        new Error('objectSlug parameter is required for get operation'),
+        `/objects/${objectSlug || 'unknown'}/records/${recordId || 'unknown'}`,
+        'GET',
+        { status: 400, message: 'Missing required parameter: objectSlug' }
+      );
+    }
+
+    if (!recordId) {
+      return createErrorResult(
+        new Error('recordId parameter is required for get operation'),
+        `/objects/${objectSlug}/records/${recordId || 'unknown'}`,
+        'GET',
+        { status: 400, message: 'Missing required parameter: recordId' }
+      );
+    }
+
+    const result = await toolConfig.handler(objectSlug, recordId, attributes, objectId);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(result)
+      : `Record retrieved successfully`;
+
+    return formatResponse(formattedResult);
+  } catch (error) {
+    const objectSlug = request.params.arguments?.objectSlug || 'unknown';
+    const recordId = request.params.arguments?.recordId || 'unknown';
+    return createErrorResult(
+      error instanceof Error ? error : new Error('Unknown error'),
+      `/objects/${objectSlug}/records/${recordId}`,
+      'GET',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Fixes issue #343 where generic record operations (`list-records`, `get-record`) were failing with "Tool handler not implemented" errors, preventing users from interacting with deal objects and other generic record types.

## Problem
- `list-records` tool failing with: "Tool handler not implemented for tool type: list"
- `get-record` tool failing with: "Tool handler not implemented for tool type: get"  
- Users working with deal objects couldn't interact with them through generic record operations
- This was the final gap in dispatcher implementation after previous fixes for CRUD/batch/list operations

## Root Cause
The dispatcher was missing handlers for `'list'` and `'get'` tool types after modularization work. Similar issues were resolved in #275/#276 for other tool types, but generic record operations were missed.

## Solution
1. **Created records operation module**: `src/handlers/tools/dispatcher/operations/records.ts`
   - `handleListOperation()` for list-records tool execution
   - `handleGetOperation()` for get-record tool execution
   - Follows established error handling and response formatting patterns

2. **Updated dispatcher core**: Added missing handler cases in `core.ts`
   - `toolType === 'list'` now handled by `handleListOperation`
   - `toolType === 'get'` now handled by `handleGetOperation`
   - Added proper imports for new record operations

## Testing
✅ **Verification Complete**:
- Both tools now execute without "Tool handler not implemented" errors
- Tools show expected API-related errors (normal without API key) instead of implementation errors
- Build and type checking pass
- All offline tests pass (521 passed, 36 skipped)
- No regressions in existing functionality

## Test Plan
- [x] Verify `list-records` executes for people objects
- [x] Verify `list-records` executes for deals objects  
- [x] Verify `get-record` executes with test record ID
- [x] Confirm no "Tool handler not implemented" errors
- [x] Run build and type checking
- [x] Run test suite

## Impact
- ✅ Users can now use `list-records` with any object type (companies, people, deals, etc.)
- ✅ Users can now use `get-record` to retrieve specific records from any object type
- ✅ Resolves the final gap in dispatcher implementation for generic operations
- ✅ Completes the systematic tool handler implementation that was partially addressed in #275/#276

## Related Issues
- Closes #343
- Related to #275/#276 (systematic tool handler gaps - this completes the fix)
- Related to #316 (CI/CD test stabilization - mentioned missing tool handlers)

Fixes #343