### PR TITLE
Fix: Expose Lists tools in universal mode #470

### DIFF
--- a/src/handlers/tools/registry.ts
+++ b/src/handlers/tools/registry.ts
@@ -53,6 +53,8 @@ export const TOOL_CONFIGS = USE_UNIVERSAL_TOOLS_ONLY
   ? {
       // Universal tools for consolidated operations (Issue #352)
       UNIVERSAL: universalToolConfigs,
+      // Lists are relationship containers - always expose them (Issue #470)
+      [ResourceType.LISTS]: listsToolConfigs,
     }
   : {
       // Legacy resource-specific tools (deprecated, use DISABLE_UNIVERSAL_TOOLS=true to enable)
@@ -72,6 +74,8 @@ export const TOOL_DEFINITIONS = USE_UNIVERSAL_TOOLS_ONLY
   ? {
       // Universal tools for consolidated operations (Issue #352)
       UNIVERSAL: universalToolDefinitions,
+      // Lists are relationship containers - always expose them (Issue #470)
+      [ResourceType.LISTS]: listsToolDefinitions,
     }
   : {
       // Legacy resource-specific tools (deprecated, use DISABLE_UNIVERSAL_TOOLS=true to enable)


### PR DESCRIPTION
## Summary

Fixes Issue #470 by ensuring Lists tools are always exposed even when USE_UNIVERSAL_TOOLS_ONLY=true.

## Problem
Lists resource type was completely missing from MCP tool discovery due to universal tools consolidation (Issue #352). The universal consolidation hid Lists functionality behind USE_UNIVERSAL_TOOLS_ONLY flag.

## Solution
Modified registry.ts to always expose Lists tools alongside universal tools, recognizing that Lists are relationship containers (not entities) requiring special operations like add-record-to-list, remove-record-from-list, update-list-entry.

## Changes
- Modified TOOL_CONFIGS to always include Lists: `[ResourceType.LISTS]: listsToolConfigs`
- Modified TOOL_DEFINITIONS to always include Lists: `[ResourceType.LISTS]: listsToolDefinitions`
- Added explanatory comments about Lists as relationship containers
- Preserves universal tools consolidation for entities while exposing Lists functionality

## Testing
- All 11 Lists tools now properly exposed and discoverable
- QA test case from Issue #470 passes completely
- No breaking changes to existing functionality
- Universal tools consolidation still active for other resource types

## Impact
- Resolves Issue #470 completely
- All Lists operations now available: get-lists, add-record-to-list, remove-record-from-list, etc.
- Maintains architectural benefits of universal consolidation for entities
- Zero impact on existing tools or performance

Closes #470