### PR TITLE
Fix: Replace console logging with scoped logger

### DIFF
--- a/src/objects/companies/basic.ts
+++ b/src/objects/companies/basic.ts
@@ -366,9 +366,12 @@ export async function createCompany(
               process.env.NODE_ENV === 'development' ||
               process.env.E2E_MODE === 'true'
             ) {
-              console.error(
-                '[createCompany] Created mock company result for testing:',
-                result
+              const { createScopedLogger } = await import(
+                '../../utils/logger.js'
+              );
+              createScopedLogger('companies.basic', 'createCompany').debug(
+                'Created mock company result for testing',
+                { result }
               );
             }
           }
@@ -377,7 +380,13 @@ export async function createCompany(
             process.env.NODE_ENV === 'development' ||
             process.env.E2E_MODE === 'true'
           ) {
-            console.error('[createCompany] Query fallback failed:', queryError);
+            const { createScopedLogger } = await import(
+              '../../utils/logger.js'
+            );
+            createScopedLogger('companies.basic', 'createCompany').error(
+              'Query fallback failed during company creation',
+              queryError instanceof Error ? queryError : undefined
+            );
           }
           // Try creating mock even if query fails in test environments
           if (
@@ -408,7 +417,9 @@ export async function createCompany(
               process.env.NODE_ENV === 'development' ||
               process.env.E2E_MODE === 'true'
             ) {
-              const { createScopedLogger } = await import('../../utils/logger.js');
+              const { createScopedLogger } = await import(
+                '../../utils/logger.js'
+              );
               createScopedLogger('companies.basic', 'createCompany').warn(
                 'Created emergency mock company result after query failure',
                 { result }

--- a/src/objects/lists.ts
+++ b/src/objects/lists.ts
@@ -36,6 +36,7 @@ import {
   hasErrorResponse,
 } from '../types/list-types.js';
 import { isValidUUID } from '../utils/validation/uuid-validation.js';
+import { createScopedLogger, OperationType } from '../utils/logger.js';
 
 // Re-export for backward compatibility
 export type { ListMembership } from '../types/list-types.js';
@@ -1170,6 +1171,11 @@ export async function searchLists(
  * @returns List attributes schema
  */
 export async function getListAttributes(): Promise<Record<string, unknown>> {
+  const log = createScopedLogger(
+    'objects.lists',
+    'getListAttributes',
+    OperationType.API_CALL
+  );
   const api = getLazyAttioClient();
   const path = '/lists/attributes';
 
@@ -1178,9 +1184,9 @@ export async function getListAttributes(): Promise<Record<string, unknown>> {
     return extract<Record<string, unknown>>(response);
   } catch (error) {
     if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `[getListAttributes] Error:`,
-        error instanceof Error ? error.message : 'Unknown error'
+      log.error(
+        'Failed to fetch list attributes, returning default schema',
+        error instanceof Error ? error : undefined
       );
     }
 

--- a/src/utils/AttioFieldMapper.ts
+++ b/src/utils/AttioFieldMapper.ts
@@ -5,6 +5,14 @@
  * Provides deprecation warnings for unsupported aliases
  */
 
+import { createScopedLogger, OperationType } from './logger.js';
+
+const log = createScopedLogger(
+  'utils.AttioFieldMapper',
+  undefined,
+  OperationType.TRANSFORMATION
+);
+
 export const FIELD_MAPPINGS = {
   timestamp: {
     created: 'created_at',
@@ -36,9 +44,10 @@ export function mapFieldName(genericField: string): string {
   // Check for deprecated mappings
   const deprecated = DEPRECATED_FIELDS[genericField];
   if (deprecated) {
-    console.warn(
-      `[AttioFieldMapper] Deprecated field '${genericField}' used. Use '${deprecated}' instead. Attio API uses '${deprecated}' for timestamp fields.`
-    );
+    log.warn('Deprecated field alias used', {
+      field: genericField,
+      replacement: deprecated,
+    });
     return deprecated;
   }
 

--- a/src/utils/axios-error-mapper.ts
+++ b/src/utils/axios-error-mapper.ts
@@ -8,6 +8,7 @@
 import { ErrorService } from '../services/ErrorService.js';
 import { getAttributeSchema, getSelectOptions } from '../api/attio-client.js';
 import type { AxiosErrorLike } from '../types/service-types.js';
+import { createScopedLogger, OperationType } from './logger.js';
 
 // Type definitions for better type safety
 interface WrappedError extends Error {
@@ -153,6 +154,11 @@ export const handleSelectOptionError = async (
   recordData: Record<string, unknown>,
   resourceType: string
 ): Promise<StructuredHttpError> => {
+  const log = createScopedLogger(
+    'utils.axios-error-mapper',
+    'handleSelectOptionError',
+    OperationType.DATA_PROCESSING
+  );
   const mapped = ErrorService.fromAxios(error);
 
   // Single-pass options cache to avoid multiple API calls for the same field
@@ -222,9 +228,12 @@ export const handleSelectOptionError = async (
               };
             }
           } catch (e) {
-            console.error(
-              `Failed to fetch select options for attribute ${attributeSlug}:`,
-              e
+            log.error(
+              `Failed to fetch select options for attribute ${attributeSlug}`,
+              e instanceof Error ? e : undefined,
+              {
+                attributeSlug,
+              }
             );
           }
         }
@@ -315,7 +324,10 @@ export const handleSelectOptionError = async (
         };
       }
     } catch (e) {
-      console.error('Failed to analyze select fields:', e);
+      log.error(
+        'Failed to analyze select field options while enhancing error message',
+        e instanceof Error ? e : undefined
+      );
     }
   }
 

--- a/src/utils/resource-mapping.ts
+++ b/src/utils/resource-mapping.ts
@@ -6,6 +6,13 @@
  */
 
 import { UniversalResourceType } from '../handlers/tool-configs/universal/types.js';
+import { createScopedLogger, OperationType } from './logger.js';
+
+const log = createScopedLogger(
+  'utils.resource-mapping',
+  undefined,
+  OperationType.SYSTEM
+);
 
 /**
  * Resource path configuration
@@ -97,9 +104,9 @@ export class ResourceMapper {
       }
 
       // Default fallback for completely unknown types
-      console.warn(
-        `Unknown resource type: ${resourceType}, using generic records path`
-      );
+      log.warn('Unknown resource type, using generic records path', {
+        resourceType,
+      });
       return '/records';
     }
 


### PR DESCRIPTION
## Summary
- replace remaining console.* in Batch A/B/C modules with scoped logging
- keep dev diagnostics but route through createScopedLogger with module metadata
- prepare follow-up work to ratchet lint baseline once warning debt is addressed

## Testing
- npm run lint:guard
- npm run test:offline

## Known gaps
- npm run lint:src -- --max-warnings=50 still reports 661 warnings (pre-existing); follow-up sub-issues will address this