### PR TITLE
Fix: Harden secure error handler typings

### DIFF
--- a/src/utils/secure-error-handler.ts
+++ b/src/utils/secure-error-handler.ts
@@ -26,6 +26,9 @@ const resolveStatusCode = (
   error: unknown,
   fallback: number | undefined = DEFAULT_STATUS_CODE
 ): number | undefined => {
+  // Utilities know how to extract statuses from Axios, Attio API, and our wrapped
+  // StructuredHttpError instances. Always check them first to respect that
+  // centralised logic before falling back to heuristic property inspection.
   const statusFromUtilities = getErrorStatus(error);
   if (typeof statusFromUtilities === 'number') {
     return statusFromUtilities;


### PR DESCRIPTION
## Summary
- harden secure error handler status/type derivation without 
- tighten error response utilities to accept unknown inputs and reuse helpers
- make batch/retry/circuit breaker flows leverage shared helpers for message/status

## Testing
- npm run lint:src -- --max-warnings=50 (touched file only via lint-staged)
- npm run test:offline