### PR TITLE
Refactor: eliminate any types in middleware layer #666

### DIFF
--- a/src/middleware/performance-compat.ts
+++ b/src/middleware/performance-compat.ts
@@ -65,9 +65,9 @@ class PerformanceMonitorInstance {
       startTime = storedStartTime;
       actualSuccess =
         typeof startTimeOrSuccess === 'boolean' ? startTimeOrSuccess : true;
-      actualError = typeof success === 'string' ? (success as any) : error;
+      actualError = typeof success === 'string' ? (success as unknown as string) : error;
       actualMetadata =
-        error && typeof error === 'object' ? (error as any) : metadata;
+        error && typeof error === 'object' ? (error as unknown as Record<string, unknown>) : metadata;
 
       // Clean up stored operation
       this.activeOperations.delete(toolName);

--- a/src/middleware/performance-enhanced.ts
+++ b/src/middleware/performance-enhanced.ts
@@ -102,7 +102,18 @@ export class EnhancedPerformanceTracker extends EventEmitter {
   private degradationThreshold: number = 0.2; // 20% degradation threshold
 
   // Timing context for current operation
-  private timingContext: Map<string, any> = new Map();
+  private timingContext: Map<string, {
+    toolName: string;
+    operationType: string;
+    startTime: number;
+    metadata?: Record<string, unknown>;
+    timings: {
+      validation: number;
+      attioApi: number;
+      serialization: number;
+      other: number;
+    };
+  }> = new Map();
 
   private constructor() {
     super();
@@ -201,7 +212,7 @@ export class EnhancedPerformanceTracker extends EventEmitter {
     success: boolean = true,
     error?: string,
     statusCode?: number,
-    additionalMetadata?: Record<string, any>
+    additionalMetadata?: Record<string, unknown>
   ): EnhancedPerformanceMetrics | null {
     if (!this.enabled || !operationId) return null;
 
@@ -222,7 +233,7 @@ export class EnhancedPerformanceTracker extends EventEmitter {
     const metrics: EnhancedPerformanceMetrics = {
       toolName: context.toolName,
       operationType: context.operationType,
-      resourceType: context.metadata?.resourceType,
+      resourceType: context.metadata?.resourceType as string | undefined,
       startTime: context.startTime,
       endTime,
       duration,
@@ -238,7 +249,7 @@ export class EnhancedPerformanceTracker extends EventEmitter {
       cached: false,
       error,
       statusCode,
-      recordCount: additionalMetadata?.recordCount,
+      recordCount: additionalMetadata?.recordCount as number | undefined,
       metadata: { ...context.metadata, ...additionalMetadata },
     };
 
@@ -540,26 +551,26 @@ export class EnhancedPerformanceTracker extends EventEmitter {
 Performance Report
 ==================
 Total Operations: ${stats.count}
-Success Rate: ${(stats.successRate as any).toFixed(1)}%
-Cache Hit Rate: ${(stats.cacheHitRate as any).toFixed(1)}%
+Success Rate: ${(stats.successRate as number).toFixed(1)}%
+Cache Hit Rate: ${(stats.cacheHitRate as number).toFixed(1)}%
 
 Timing Statistics (ms)
 ----------------------
-Average: ${(stats.timing as any).average.toFixed(0)}
-Min: ${(stats.timing as any).min.toFixed(0)}
-Max: ${(stats.timing as any).max.toFixed(0)}
-P50: ${(stats.timing as any).p50.toFixed(0)}
-P95: ${(stats.timing as any).p95.toFixed(0)}
-P99: ${(stats.timing as any).p99.toFixed(0)}
+Average: ${((stats.timing as Record<string, number>).average).toFixed(0)}
+Min: ${((stats.timing as Record<string, number>).min).toFixed(0)}
+Max: ${((stats.timing as Record<string, number>).max).toFixed(0)}
+P50: ${((stats.timing as Record<string, number>).p50).toFixed(0)}
+P95: ${((stats.timing as Record<string, number>).p95).toFixed(0)}
+P99: ${((stats.timing as Record<string, number>).p99).toFixed(0)}
 
 API vs MCP Overhead (ms)
 ------------------------
-API Average: ${(stats.apiTiming as any).average.toFixed(0)}
-API P95: ${(stats.apiTiming as any).p95.toFixed(0)}
-API P99: ${(stats.apiTiming as any).p99.toFixed(0)}
-MCP Average: ${(stats.overhead as any).average.toFixed(0)}
-MCP P95: ${(stats.overhead as any).p95.toFixed(0)}
-MCP P99: ${(stats.overhead as any).p99.toFixed(0)}
+API Average: ${((stats.apiTiming as Record<string, number>).average).toFixed(0)}
+API P95: ${((stats.apiTiming as Record<string, number>).p95).toFixed(0)}
+API P99: ${((stats.apiTiming as Record<string, number>).p99).toFixed(0)}
+MCP Average: ${((stats.overhead as Record<string, number>).average).toFixed(0)}
+MCP P95: ${((stats.overhead as Record<string, number>).p95).toFixed(0)}
+MCP P99: ${((stats.overhead as Record<string, number>).p99).toFixed(0)}
 
 Budget Violations: ${stats.budgetViolations}
 

--- a/src/middleware/performance.ts
+++ b/src/middleware/performance.ts
@@ -399,7 +399,7 @@ export function trackPerformance(toolName?: string) {
   ) {
     const originalMethod = descriptor.value;
     const name =
-      toolName || `${(target as any).constructor.name}.${propertyKey}`;
+      toolName || `${(target as Record<string, unknown>).constructor.name}.${propertyKey}`;
 
     descriptor.value = async function (...args: unknown[]) {
       const startTime = PerformanceTracker.startOperation(name);

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -486,7 +486,7 @@ export class ParameterValidationMiddleware {
  */
 export function createValidationErrorResponse(
   error: UniversalValidationError
-): any {
+): Record<string, unknown> {
   return {
     error: error.toErrorResponse().error,
     status: 'error',
@@ -497,12 +497,12 @@ export function createValidationErrorResponse(
 /**
  * Wrap a handler with validation middleware
  */
-export function withValidation<T extends (...args: any[]) => any>(
+export function withValidation<T extends (...args: unknown[]) => unknown>(
   handler: T,
   schema: SchemaDefinition,
   toolName: string
 ): T {
-  return (async (...args: any[]) => {
+  return (async (...args: unknown[]) => {
     try {
       // Validate parameters if provided
       if (args[0]) {


### PR DESCRIPTION
Closes #666

## Background
Follow-up to #650 lint warning reduction effort. The middleware directory contained 25+ lint warnings.

## Changes
- `performance-enhanced.ts`: Replaced `any` types in timing context Map, metadata parameters, and string template type assertions
- `validation.ts`: Fixed return type of `createValidationErrorResponse` and generic constraints in `withValidation`
- `performance.ts`: Replaced `any` cast with proper `Record<string, unknown>` type in decorator
- `performance-compat.ts`: Fixed type casts using proper `unknown` intermediary types

## Result
- Middleware directory now has 0 lint warnings (reduced from ~25)
- No behavioral changes - purely type safety improvements
- Follows project's ANY TYPE REDUCTION STRATEGY

Generated with [Claude Code](https://claude.ai/code)