### PR TITLE
Fix: Preserve enhanced core operation errors

### DIFF
--- a/src/handlers/tool-configs/universal/core-operations.ts
+++ b/src/handlers/tool-configs/universal/core-operations.ts
@@ -96,18 +96,11 @@ export const searchRecordsConfig: UniversalToolConfig = {
       );
       return await handleUniversalSearch(sanitizedParams);
     } catch (error: unknown) {
-      try {
-        await handleCoreOperationError(error, 'search', params.resource_type);
-        throw error; // not reached
-      } catch (e: any) {
-        if (e && typeof e.status === 'number' && e.body?.message) {
-          // For backward compatibility with tests, throw an Error with the enhanced message
-          const enhancedError = new Error(e.body.message);
-          enhancedError.name = e.body.code ?? 'ValidationError';
-          throw enhancedError;
-        }
-        throw e;
-      }
+      return await handleCoreOperationError(
+        error,
+        'search',
+        params.resource_type
+      );
     }
   },
   formatResult: (
@@ -245,22 +238,11 @@ export const getRecordDetailsConfig: UniversalToolConfig = {
       );
       return await handleUniversalGetDetails(sanitizedParams);
     } catch (error: unknown) {
-      try {
-        await handleCoreOperationError(
-          error,
-          'get details',
-          params.resource_type
-        );
-        throw error; // not reached
-      } catch (e: any) {
-        if (e && typeof e.status === 'number' && e.body?.message) {
-          // For backward compatibility with tests, throw an Error with the enhanced message
-          const enhancedError = new Error(e.body.message);
-          enhancedError.name = e.body.code ?? 'ValidationError';
-          throw enhancedError;
-        }
-        throw e;
-      }
+      return await handleCoreOperationError(
+        error,
+        'get details',
+        params.resource_type
+      );
     }
   },
   formatResult: (
@@ -509,23 +491,12 @@ export const updateRecordConfig: UniversalToolConfig = {
       }
       return result;
     } catch (error: unknown) {
-      try {
-        await handleCoreOperationError(
-          error,
-          'update',
-          params.resource_type,
-          params.record_data as Record<string, unknown>
-        );
-        throw error; // not reached
-      } catch (e: any) {
-        if (e && typeof e.status === 'number' && e.body?.message) {
-          // For backward compatibility with tests, throw an Error with the enhanced message
-          const enhancedError = new Error(e.body.message);
-          enhancedError.name = e.body.code ?? 'ValidationError';
-          throw enhancedError;
-        }
-        throw e;
-      }
+      return await handleCoreOperationError(
+        error,
+        'update',
+        params.resource_type,
+        params.record_data as Record<string, unknown>
+      );
     }
   },
   formatResult: (

--- a/test/handlers/tool-configs/universal/core-operations-search.test.ts
+++ b/test/handlers/tool-configs/universal/core-operations-search.test.ts
@@ -107,9 +107,13 @@ describe('Universal Core Operations Search Tests', () => {
         query: 'test',
       };
 
-      await expect(searchRecordsConfig.handler(params)).rejects.toThrow(
-        'Universal search failed for resource type companies: API error'
-      );
+      await expect(searchRecordsConfig.handler(params)).rejects.toMatchObject({
+        status: expect.any(Number),
+        body: expect.objectContaining({
+          message:
+            'Universal search failed for resource type companies: API error',
+        }),
+      });
       expect(vi.mocked(ErrorService.createUniversalError)).toHaveBeenCalledWith(
         'search',
         UniversalResourceType.COMPANIES,

--- a/test/performance/regression.test.ts
+++ b/test/performance/regression.test.ts
@@ -319,7 +319,13 @@ describe('Performance Regression Tests', () => {
         const duration = performance.now() - startTime;
 
         // Verify it's a validation error (enhanced error message format)
-        expect(error.message).toContain('Invalid record identifier format');
+        expect(error).toMatchObject({
+          body: expect.objectContaining({
+            message: expect.stringContaining(
+              'Invalid record identifier format'
+            ),
+          }),
+        });
 
         // Check performance budget
         expect(duration).toBeLessThan(PERFORMANCE_BUDGETS.notFound);
@@ -459,7 +465,13 @@ describe('Performance Regression Tests', () => {
         // Validation should be very fast (under 100ms)
         expect(duration).toBeLessThan(100);
         // Schema validation returns specific error message
-        expect(error.message).toMatch(/must be at least 1|positive integer/i);
+        expect(error).toMatchObject({
+          body: expect.objectContaining({
+            message: expect.stringMatching(
+              /must be at least 1|positive integer/i
+            ),
+          }),
+        });
 
         console.log(`Parameter validation time: ${duration.toFixed(0)}ms`);
       }


### PR DESCRIPTION
## Summary
- ensure universal core operations bubble axios-enhanced errors directly
- update search & performance tests to assert structured error payloads

## Testing
- npm run test:offline
- tsc --noEmit (pre-push hook)
