### PR TITLE
Fix: reduce any type usage in src/objects/ from 17 to 1 warning #665

### DIFF
--- a/src/objects/batch-companies.ts
+++ b/src/objects/batch-companies.ts
@@ -7,6 +7,8 @@ import {
   BatchResponse,
   BatchConfig,
   RecordAttributes,
+  RecordBatchCreateParams,
+  RecordBatchUpdateParams,
 } from '../types/attio.js';
 import { CompanyFieldValue } from '../types/tool-types.js';
 import {
@@ -23,6 +25,18 @@ import {
 } from './companies/index.js';
 import { CompanyValidator } from '../validators/company-validator.js';
 import { validateBatchOperation } from '../utils/batch-validation.js';
+
+type CompanyUpdatePayload = {
+  id: string;
+  attributes: RecordAttributes;
+};
+
+type CompanyOperationInput =
+  | { type: 'create'; data: RecordAttributes }
+  | { type: 'update'; data: CompanyUpdatePayload }
+  | { type: 'delete'; data: string };
+
+type BatchFunctionParams = unknown;
 
 /**
  * Helper function to execute a batch operation with improved error handling
@@ -44,7 +58,7 @@ import { validateBatchOperation } from '../utils/batch-validation.js';
 async function executeBatchCompanyOperation<T, R>(
   operationType: 'create' | 'update' | 'delete' | 'search' | 'get',
   records: T[],
-  batchFunction: (params: any) => Promise<R[]>,
+  batchFunction: (params: BatchFunctionParams) => Promise<R[]>,
   singleFunction: (params: T) => Promise<R>,
   batchConfig?: Partial<BatchConfig>
 ): Promise<BatchResponse<R>> {
@@ -69,13 +83,17 @@ async function executeBatchCompanyOperation<T, R>(
 
   try {
     // Attempt to use the batch API
-    const results = await batchFunction({
-      objectSlug: ResourceType.COMPANIES, // Always explicitly set the resource type
-      records:
-        operationType === 'create'
-          ? records.map((r: any) => ({ attributes: r }))
-          : records,
-    });
+    const payload =
+      operationType === 'create'
+        ? {
+            objectSlug: ResourceType.COMPANIES,
+            records: records.map((record) => ({ attributes: record })),
+          }
+        : {
+            objectSlug: ResourceType.COMPANIES,
+            records,
+          };
+    const results = await batchFunction(payload);
 
     // Format the response
     return {
@@ -203,7 +221,8 @@ export async function batchCreateCompanies(params: {
     return executeBatchCompanyOperation<RecordAttributes, Company>(
       'create',
       validatedCompanies,
-      batchCreateRecords,
+      (params: unknown) =>
+        batchCreateRecords(params as RecordBatchCreateParams),
       createCompany,
       batchConfig
     );
@@ -297,7 +316,8 @@ export async function batchUpdateCompanies(params: {
     >(
       'update',
       updates,
-      batchUpdateRecords,
+      (params: unknown) =>
+        batchUpdateRecords(params as RecordBatchUpdateParams),
       (params) => updateCompany(params.id, params.attributes),
       batchConfig
     );
@@ -392,17 +412,14 @@ export async function batchGetCompanyDetails(
  * @returns Batch response with results for each operation
  */
 export async function batchCompanyOperations(
-  operations: Array<{
-    type: 'create' | 'update' | 'delete';
-    data: any;
-  }>,
+  operations: CompanyOperationInput[],
   batchConfig?: Partial<BatchConfig>
 ): Promise<BatchResponse<Company | boolean>> {
   const results: Array<{
     id: string;
     success: boolean;
     data?: Company | boolean;
-    error?: any;
+    error?: unknown;
   }> = [];
 
   let succeeded = 0;
@@ -415,7 +432,7 @@ export async function batchCompanyOperations(
     ...batchConfig,
   };
 
-  const chunks = [];
+  const chunks: CompanyOperationInput[][] = [];
   for (let i = 0; i < operations.length; i += config.maxBatchSize) {
     chunks.push(operations.slice(i, i + config.maxBatchSize));
   }
@@ -428,21 +445,19 @@ export async function batchCompanyOperations(
         try {
           let result: Company | boolean;
 
-          switch (operation.type) {
-            case 'create':
-              result = await createCompany(operation.data);
-              break;
-            case 'update':
-              result = await updateCompany(
-                operation.data.id,
-                operation.data.attributes
-              );
-              break;
-            case 'delete':
-              result = await deleteCompany(operation.data);
-              break;
-            default:
-              throw new Error(`Unknown operation type: ${operation.type}`);
+          if (operation.type === 'create') {
+            result = await createCompany(operation.data);
+          } else if (operation.type === 'update') {
+            result = await updateCompany(
+              operation.data.id,
+              operation.data.attributes
+            );
+          } else if (operation.type === 'delete') {
+            result = await deleteCompany(operation.data);
+          } else {
+            throw new Error(
+              `Unknown operation type: ${(operation as any).type}`
+            );
           }
 
           succeeded++;

--- a/src/objects/companies/attributes.ts
+++ b/src/objects/companies/attributes.ts
@@ -23,7 +23,7 @@ function logAttributeError(
   log.error('Error occurred', error, {
     errorType: error instanceof Error ? error.constructor.name : typeof error,
     message: getErrorMessage(error),
-    stack: (error as any)?.stack,
+    stack: error instanceof Error ? error.stack : undefined,
     ...(Object.keys(context).length > 0 ? { context } : {}),
   });
 }
@@ -272,9 +272,10 @@ export async function discoverCompanyAttributes(): Promise<{
 
   if (process.env.NODE_ENV === 'development') {
     const { createScopedLogger } = await import('../../utils/logger.js');
-    createScopedLogger('companies.attributes', 'discoverCompanyAttributes').debug(
-      'Starting attribute discovery'
-    );
+    createScopedLogger(
+      'companies.attributes',
+      'discoverCompanyAttributes'
+    ).debug('Starting attribute discovery');
   }
 
   try {
@@ -316,15 +317,15 @@ export async function discoverCompanyAttributes(): Promise<{
     const sampleCompanyId = sampleCompany?.id?.record_id;
     if (!sampleCompanyId) {
       const { createScopedLogger } = await import('../../utils/logger.js');
-      createScopedLogger('companies.attributes', 'discoverCompanyAttributes').warn(
-        'Sample company has no record ID',
-        {
-          hasId: !!sampleCompany?.id,
-          idType: typeof sampleCompany?.id,
-          idKeys: sampleCompany?.id ? Object.keys(sampleCompany.id) : null,
-          company: sampleCompany,
-        }
-      );
+      createScopedLogger(
+        'companies.attributes',
+        'discoverCompanyAttributes'
+      ).warn('Sample company has no record ID', {
+        hasId: !!sampleCompany?.id,
+        idType: typeof sampleCompany?.id,
+        idKeys: sampleCompany?.id ? Object.keys(sampleCompany.id) : null,
+        company: sampleCompany,
+      });
       return {
         standard: [],
         custom: [],
@@ -334,10 +335,10 @@ export async function discoverCompanyAttributes(): Promise<{
 
     if (process.env.NODE_ENV === 'development') {
       const { createScopedLogger } = await import('../../utils/logger.js');
-      createScopedLogger('companies.attributes', 'discoverCompanyAttributes').debug(
-        'Using sample company ID',
-        { sampleCompanyId }
-      );
+      createScopedLogger(
+        'companies.attributes',
+        'discoverCompanyAttributes'
+      ).debug('Using sample company ID', { sampleCompanyId });
     }
 
     const sampleCompanyDetails = await getCompanyDetails(sampleCompanyId);
@@ -345,10 +346,12 @@ export async function discoverCompanyAttributes(): Promise<{
 
     if (process.env.NODE_ENV === 'development') {
       const { createScopedLogger } = await import('../../utils/logger.js');
-      createScopedLogger('companies.attributes', 'discoverCompanyAttributes').debug(
-        'Retrieved fields from sample company',
-        { count: Object.keys(values).length }
-      );
+      createScopedLogger(
+        'companies.attributes',
+        'discoverCompanyAttributes'
+      ).debug('Retrieved fields from sample company', {
+        count: Object.keys(values).length,
+      });
     }
 
     const standardFields = new Set([

--- a/src/objects/companies/basic.ts
+++ b/src/objects/companies/basic.ts
@@ -3,7 +3,8 @@
  */
 import { getLazyAttioClient } from '../../api/lazy-client.js';
 import { getObjectDetails, listObjects } from '../../api/operations/index.js';
-import { ResourceType, Company } from '../../types/attio.js';
+import { ResourceType, Company, RecordAttributes } from '../../types/attio.js';
+import { CompanyUpdateInput } from '../../types/company-types.js';
 import { CompanyAttributes } from './types.js';
 import { CompanyValidator } from '../../validators/company-validator.js';
 import {
@@ -225,7 +226,7 @@ export async function createCompany(
 
   try {
     // Temporarily comment out validation to isolate the issue
-    let result = await createObjectWithDynamicFields<Company>(
+    let result = await createObjectWithDynamicFields<Company, RecordAttributes>(
       ResourceType.COMPANIES,
       attributes
       // CompanyValidator.validateCreate  // Temporarily disabled
@@ -594,11 +595,19 @@ export async function updateCompany(
   attributes: Partial<CompanyAttributes>
 ): Promise<Company> {
   try {
-    return await updateObjectWithDynamicFields<Company>(
+    return await updateObjectWithDynamicFields<
+      Company,
+      Partial<CompanyAttributes>,
+      CompanyUpdateInput
+    >(
       ResourceType.COMPANIES,
       companyId,
       attributes,
-      CompanyValidator.validateUpdate
+      async (id: string, attrs: Partial<CompanyAttributes>) =>
+        CompanyValidator.validateUpdate(
+          id,
+          attrs as Record<string, CompanyFieldValue>
+        )
     );
   } catch (error: unknown) {
     // Handle mock company updates in test environments using shared state

--- a/src/objects/companies/types.ts
+++ b/src/objects/companies/types.ts
@@ -29,7 +29,7 @@ export interface CompanyAttributes {
   twitter?: string;
   associated_deals?: string[]; // Record reference to deals
   associated_workspaces?: string[]; // Record reference to workspaces
-  [key: string]: any; // Allow for custom fields
+  [key: string]: unknown; // Allow for custom fields
 }
 
 export interface CompanyFieldUpdate {

--- a/src/objects/notes.ts
+++ b/src/objects/notes.ts
@@ -13,6 +13,38 @@ import {
 import { createRecordNotFoundError } from '../utils/validation/uuid-validation.js';
 import { debug } from '../utils/logger.js';
 
+interface HttpErrorLike {
+  response?: {
+    status?: number;
+    data?: {
+      message?: string;
+    };
+  };
+  message?: string;
+}
+
+function getStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+  const candidate = error as HttpErrorLike;
+  const status = candidate.response?.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'object' && error !== null) {
+    return (error as HttpErrorLike).message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return undefined;
+}
+
 /**
  * Create note body for Attio API
  */
@@ -101,22 +133,33 @@ export async function createNote(
 
   try {
     const response = await api.post('/notes', { data: body });
-    return response.data;
-  } catch (error: any) {
-    debug('notes', 'Create note failed', { error: error.message });
+    const data = response?.data as { data: AttioNote } | undefined;
+    if (!data) {
+      throw new UniversalValidationError(
+        'Note creation returned empty response',
+        ErrorType.SYSTEM_ERROR
+      );
+    }
+    return data;
+  } catch (error: unknown) {
+    debug('notes', 'Create note failed', {
+      error: getErrorMessage(error) || 'Unknown error',
+    });
 
     // Map HTTP errors to universal validation errors
-    if (error.response?.status === 422) {
+    if (getStatus(error) === 422) {
       throw new UniversalValidationError(
         `Validation failed: ${
-          error.response?.data?.message || 'Invalid note data'
+          (typeof error === 'object' && error !== null
+            ? (error as HttpErrorLike).response?.data?.message
+            : undefined) || 'Invalid note data'
         }`,
         ErrorType.USER_ERROR,
         { field: 'content' }
       );
     }
 
-    if (error.response?.status === 404) {
+    if (getStatus(error) === 404) {
       throw createRecordNotFoundError(
         body.parent_record_id,
         body.parent_object
@@ -145,16 +188,18 @@ export async function listNotes(query: ListNotesQuery = {}): Promise<{
     // The /notes endpoint accepts filters (parent_object, parent_record_id)
     // and returns an empty array when no notes exist.
     const response = await api.get('/notes', { params: query });
-    const res = response.data ?? { data: [] };
-    // Ensure shape consistency
-    if (!Array.isArray(res.data)) {
-      return { data: [], meta: undefined };
-    }
-    return res;
-  } catch (error: any) {
-    debug('notes', 'List notes failed', { error: error.message });
+    const res = (response?.data as {
+      data?: AttioNote[];
+      meta?: { next_cursor?: string };
+    }) ?? { data: [] };
+    const items = Array.isArray(res.data) ? res.data : [];
+    return { data: items, meta: res.meta };
+  } catch (error: unknown) {
+    debug('notes', 'List notes failed', {
+      error: getErrorMessage(error) || 'Unknown error',
+    });
     // Prefer returning an empty list on benign 404s for list operations
-    const status = error?.response?.status;
+    const status = getStatus(error);
     if (status === 404) {
       return { data: [], meta: undefined };
     }
@@ -180,11 +225,20 @@ export async function getNote(noteId: string): Promise<{ data: AttioNote }> {
 
   try {
     const response = await api.get(`/notes/${noteId}`);
-    return response.data;
-  } catch (error: any) {
-    debug('notes', 'Get note failed', { error: error.message });
+    const data = response?.data as { data: AttioNote } | undefined;
+    if (!data) {
+      throw new UniversalValidationError(
+        'Note lookup returned empty response',
+        ErrorType.SYSTEM_ERROR
+      );
+    }
+    return data;
+  } catch (error: unknown) {
+    debug('notes', 'Get note failed', {
+      error: getErrorMessage(error) || 'Unknown error',
+    });
 
-    if (error.response?.status === 404) {
+    if (getStatus(error) === 404) {
       throw createRecordNotFoundError(noteId, 'note');
     }
 
@@ -213,10 +267,12 @@ export async function deleteNote(
   try {
     await api.delete(`/notes/${noteId}`);
     return { success: true };
-  } catch (error: any) {
-    debug('notes', 'Delete note failed', { error: error.message });
+  } catch (error: unknown) {
+    debug('notes', 'Delete note failed', {
+      error: getErrorMessage(error) || 'Unknown error',
+    });
 
-    if (error.response?.status === 404) {
+    if (getStatus(error) === 404) {
       throw createRecordNotFoundError(noteId, 'note');
     }
 

--- a/src/objects/paginated-people.ts
+++ b/src/objects/paginated-people.ts
@@ -77,7 +77,7 @@ export async function paginatedSearchPeople(
  * @returns Paginated response with matching people
  */
 export async function paginatedSearchPeopleByCreationDate(
-  dateRange: DateRange | string | any,
+  dateRange: DateRange | string | Record<string, unknown> | undefined,
   page: number | string = 1,
   pageSize: number | string = 20
 ): Promise<PaginatedResponse<Person>> {
@@ -123,7 +123,7 @@ export async function paginatedSearchPeopleByCreationDate(
  * @returns Paginated response with matching people
  */
 export async function paginatedSearchPeopleByModificationDate(
-  dateRange: DateRange | string | any,
+  dateRange: DateRange | string | Record<string, unknown> | undefined,
   page: number | string = 1,
   pageSize: number | string = 20
 ): Promise<PaginatedResponse<Person>> {
@@ -169,7 +169,7 @@ export async function paginatedSearchPeopleByModificationDate(
  * @returns Paginated response with matching people
  */
 export async function paginatedSearchPeopleByLastInteraction(
-  dateRange: DateRange | string | any,
+  dateRange: DateRange | string | Record<string, unknown> | undefined,
   interactionType?: InteractionType | string,
   page: number | string = 1,
   pageSize: number | string = 20
@@ -236,7 +236,7 @@ export async function paginatedSearchPeopleByLastInteraction(
  * @returns Paginated response with matching people
  */
 export async function paginatedSearchPeopleByActivity(
-  activityFilter: ActivityFilter | string | any,
+  activityFilter: ActivityFilter | string | Record<string, unknown> | undefined,
   page: number | string = 1,
   pageSize: number | string = 20
 ): Promise<PaginatedResponse<Person>> {

--- a/src/objects/people-write.ts
+++ b/src/objects/people-write.ts
@@ -11,9 +11,7 @@ import {
 } from './base-operations.js';
 import { AttioApiError } from '../utils/error-handler.js';
 import { getAttributeSlugById } from '../api/attribute-types.js';
-import { searchPeopleByEmail } from './people/search.js';
 import { searchCompanies } from './companies/search.js';
-import { getLazyAttioClient } from '../api/lazy-client.js';
 import { isValidEmail } from '../utils/validation/email-validation.js';
 import { PersonAttributes } from './people/types.js';
 import {
@@ -21,16 +19,6 @@ import {
   InvalidPersonDataError,
 } from './people/errors.js';
 import { searchPeopleByEmails } from './people/email-validation.js';
-
-// Type definition for email input formats
-type EmailInput =
-  | string
-  | {
-      value?: string;
-      email?: string;
-      email_address?: string;
-      [key: string]: any;
-    };
 
 // Re-export error classes for backward compatibility
 export {
@@ -329,7 +317,11 @@ export async function updatePerson(
   attributes: PersonAttributes
 ): Promise<Person> {
   try {
-    return await updateObjectWithDynamicFields<Person>(
+    return await updateObjectWithDynamicFields<
+      Person,
+      PersonAttributes,
+      PersonAttributes
+    >(
       ResourceType.PEOPLE,
       personId,
       attributes,
@@ -370,7 +362,10 @@ export async function updatePersonAttribute(
       attributeValue
     );
 
-    return await updateObjectAttributeWithDynamicFields<Person>(
+    return await updateObjectAttributeWithDynamicFields<
+      Person,
+      PersonAttributes
+    >(
       ResourceType.PEOPLE,
       personId,
       attributeName,

--- a/src/objects/people/basic.ts
+++ b/src/objects/people/basic.ts
@@ -34,11 +34,11 @@ export async function createPerson(
   attributes: PersonAttributes
 ): Promise<Person> {
   try {
-    const result = await createObjectWithDynamicFields<Person>(
-      ResourceType.PEOPLE,
-      attributes,
-      PersonValidator.validateCreate
-    );
+    const result = await createObjectWithDynamicFields<
+      Person,
+      PersonAttributes,
+      PersonAttributes
+    >(ResourceType.PEOPLE, attributes, PersonValidator.validateCreate);
 
     // Defensive validation: Ensure we have a valid person record
     if (!result) {
@@ -97,7 +97,11 @@ export async function updatePerson(
   attributes: PersonAttributes
 ): Promise<Person> {
   try {
-    return await updateObjectWithDynamicFields<Person>(
+    return await updateObjectWithDynamicFields<
+      Person,
+      PersonAttributes,
+      PersonAttributes
+    >(
       ResourceType.PEOPLE,
       personId,
       attributes,
@@ -135,17 +139,20 @@ export async function updatePerson(
 export async function updatePersonAttribute(
   personId: string,
   attributeName: string,
-  attributeValue: any
+  attributeValue: unknown
 ): Promise<Person> {
   try {
     // Validate attribute update
     await PersonValidator.validateAttributeUpdate(
       personId,
       attributeName,
-      attributeValue
+      attributeValue as string | string[] | { record_id: string } | undefined
     );
 
-    return await updateObjectAttributeWithDynamicFields<Person>(
+    return await updateObjectAttributeWithDynamicFields<
+      Person,
+      PersonAttributes
+    >(
       ResourceType.PEOPLE,
       personId,
       attributeName,

--- a/src/objects/people/batch.ts
+++ b/src/objects/people/batch.ts
@@ -46,7 +46,7 @@ export async function batchSearchPeople(
         queries,
         config
       );
-    } catch (batchError) {
+    } catch {
       // Fallback to individual searches
       const results = [];
       let succeeded = 0;
@@ -124,7 +124,7 @@ export async function batchGetPeopleDetails(
         personIds,
         config
       );
-    } catch (batchError) {
+    } catch {
       // Fallback to individual detail retrieval
       const results = [];
       let succeeded = 0;

--- a/src/objects/records/formatters.ts
+++ b/src/objects/records/formatters.ts
@@ -10,7 +10,7 @@ import { RecordAttributes } from '../../types/attio.js';
  * @param value - Attribute value to format
  * @returns Properly formatted attribute value for the API
  */
-export function formatRecordAttribute(key: string, value: any): any {
+export function formatRecordAttribute(key: string, value: unknown): unknown {
   if (value === null || value === undefined) {
     return value;
   }
@@ -32,8 +32,13 @@ export function formatRecordAttribute(key: string, value: any): any {
     !Array.isArray(value) &&
     (key.includes('address') || key.includes('location'))
   ) {
-    if ('street' in value || 'city' in value || 'country' in value) {
-      return value;
+    const addressCandidate = value as Record<string, unknown>;
+    if (
+      'street' in addressCandidate ||
+      'city' in addressCandidate ||
+      'country' in addressCandidate
+    ) {
+      return addressCandidate;
     }
   }
 


### PR DESCRIPTION
## Summary

Successfully reduced `any` type usage in `src/objects/` from **17 ESLint warnings down to just 1 warning** (94% reduction), resolving Issue #665.

## Key Changes

### Type Safety Improvements
- Replace `any` with `unknown` in catch blocks across all files 
- Add type-safe error helpers (`getStatus`, `getErrorMessage`, `getCode`)
- Enhance response handling with proper type guards
- Strengthen parameter types from `any` to `Record<string, unknown> | undefined`

### TypeScript Compilation Fixes
- ✅ Add missing `RecordAttributes` import in `companies/basic.ts:6`
- ✅ Resolve batch operations typing issues with type-safe adapters
- ✅ Fix `AttributeMap` vs `PersonAttributes` conflicts using proper generics
- ✅ Add proper union types for validator functions

### Files Updated
- `src/objects/base-operations.ts` - Enhanced generic type system for validators
- `src/objects/batch-companies.ts` - Fixed batch operation type flows with adapters  
- `src/objects/lists.ts` - Type-safe list handling and response extraction
- `src/objects/notes.ts` - Improved error handling with type guards
- `src/objects/tasks.ts` - Enhanced error helper functions
- `src/objects/companies/{basic,attributes,notes,relationships,types}` - Type safety across company modules
- `src/objects/people/{basic,batch}` - Fixed validator parameter types  
- `src/objects/records/{formatters,index}` - Safe record handling
- Plus updates to `paginated-people.ts`, `people-write.ts` and others

## Validation Results

- ✅ **TypeScript compilation**: `npm run typecheck` - 0 errors
- ✅ **Offline tests**: `npm run test:offline` - All 1947 tests passing  
- ✅ **ESLint warnings**: Reduced from 17 to 1 (94% improvement)
- ✅ **Actual `any` types**: Only 1 remaining in error edge case

## Impact

This enhancement significantly improves type safety across the entire objects layer:
- Better IDE autocompletion and error detection
- Improved refactoring safety and maintainability  
- More precise error handling with type guards
- Protection against runtime type errors
- Enhanced developer experience

The one remaining `any` type is in an error message template (`batch-companies.ts:456`) and is acceptable for this context.

## Test Plan

- [x] TypeScript compilation passes without errors
- [x] All existing offline tests continue to pass (1947 tests)
- [x] ESLint warnings reduced significantly
- [x] No regressions in functionality