### PR TITLE
Fix: Enable workflow cascading by using PAT in gate workflow

### DIFF
--- a/.github/workflows/claude-comment-gate.yml
+++ b/.github/workflows/claude-comment-gate.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Ensure label exists
         uses: actions/github-script@v7
+        env:
+          # Use PAT instead of GITHUB_TOKEN to trigger downstream workflows
+          GITHUB_TOKEN: ${{ secrets.CLAUDE_GATE_TOKEN || github.token }}
         with:
           script: |
             const name = '${{ steps.info.outputs.label }}';
@@ -80,6 +83,9 @@ jobs:
       - name: Add or toggle label (handles re-review)
         id: relabel
         uses: actions/github-script@v7
+        env:
+          # Use PAT instead of GITHUB_TOKEN to trigger downstream workflows
+          GITHUB_TOKEN: ${{ secrets.CLAUDE_GATE_TOKEN || github.token }}
         with:
           script: |
             const issue_number = Number('${{ steps.info.outputs.pr }}');
@@ -124,6 +130,9 @@ jobs:
 
       - name: Acknowledge
         uses: actions/github-script@v7
+        env:
+          # Use PAT instead of GITHUB_TOKEN to trigger downstream workflows
+          GITHUB_TOKEN: ${{ secrets.CLAUDE_GATE_TOKEN || github.token }}
         with:
           script: |
             const issue_number = Number('${{ steps.info.outputs.pr }}');


### PR DESCRIPTION
## Root Cause Identified

The Claude workflow chain was not working due to a fundamental GitHub Actions security feature:

> **GitHub blocks events triggered by GITHUB_TOKEN from cascading into new workflow runs** to prevent infinite loops.

### The Problem Chain
1. **Gate workflow** uses `github.token` (GITHUB_TOKEN) to add `claude:*` labels
2. **GitHub blocks** the resulting `labeled` events from triggering other workflows  
3. **Review workflow** never receives the event despite being correctly configured

This explains why the review workflow had `skipped` runs - it was firing but the events were blocked at the source.

## Solution: Personal Access Token (PAT)

Replace GITHUB_TOKEN with a Personal Access Token in the gate workflow to enable proper event cascading.

### Changes Made

**Gate Workflow Updates:**
- Added `CLAUDE_GATE_TOKEN` environment variable to all GitHub API steps
- Falls back to `github.token` if PAT is not configured
- Enables proper event chain: Gate (PAT) → labeled event → Review workflow fires

**Pattern Used:**
```yaml
env:
  GITHUB_TOKEN: ${{ secrets.CLAUDE_GATE_TOKEN || github.token }}
```

## Setup Instructions

### 1. Create Personal Access Token
1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
2. Generate new token with `repo` scope (for private repos) or `public_repo` (for public repos)
3. Copy the generated token

### 2. Add Repository Secret
1. Go to Repository Settings → Secrets and variables → Actions
2. Add new repository secret:
   - **Name:** `CLAUDE_GATE_TOKEN`
   - **Value:** [paste the PAT token]

### 3. Test the Fix
Once the secret is added, the workflow chain should work:
1. **Comment** `@claude ultra` on any PR
2. **Gate workflow** adds label using PAT → event cascades properly
3. **Review workflow** triggers and runs Claude review
4. **Review posted** back to the PR

## Technical Details

**Research Sources:**
- [GitHub Docs - GITHUB_TOKEN](https://docs.github.com/en/actions/concepts/security/github_token)
- [GitHub Docs - Triggering Workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow)
- [GitHub Changelog - Sept 8, 2022](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/)

**Affected Events:**
All events except `workflow_dispatch` and `repository_dispatch` are blocked when triggered by GITHUB_TOKEN, including:
- `pull_request:labeled` 
- `issues:labeled`
- `push`, `release`, etc.

**Security Rationale:**
This limitation prevents accidental infinite workflow loops and forces developers to be intentional about cross-workflow triggers.

## Backward Compatibility

The fix is backward compatible:
- **With PAT:** Workflow cascading works properly ✅
- **Without PAT:** Falls back to existing behavior (no cascading) ⚠️

Once `CLAUDE_GATE_TOKEN` is added, the Claude workflow chain will function as designed!