### PR TITLE
Fix: Resolve workflow_dispatch ref parameter issue #42

### DIFF
--- a/.github/workflows/claude-comment-gate.yml
+++ b/.github/workflows/claude-comment-gate.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  actions: read
+  actions: write
 
 jobs:
   gate:
@@ -196,15 +196,23 @@ jobs:
         with:
           github-token: ${{ secrets.CLAUDE_GATE_TOKEN }}
           script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Resolve default branch dynamically
+            const { data: r } = await github.rest.repos.get({ owner, repo });
+            const ref = r.default_branch || 'main';
+
+            // Dispatch the workflow on the default branch
             await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner, repo,
               workflow_id: 'claude-pr-review-labeled.yml',
-              ref: context.repo.default_branch,
+              ref,
               inputs: {
                 pr: String('${{ steps.info.outputs.pr }}'),
                 label: '${{ steps.info.outputs.label }}',
                 source: 'gate'
               }
             });
-            core.info(`Dispatched review workflow for PR #${{ steps.info.outputs.pr }} with label ${{ steps.info.outputs.label }}`);
+
+            core.info(`Dispatched review workflow for PR #${{ steps.info.outputs.pr }} on ref "${ref}" with label ${{ steps.info.outputs.label }}`);


### PR DESCRIPTION
## Summary
Clean fix for HttpError in claude-comment-gate.yml workflow caused by invalid ref parameter.

## Problem
The workflow was failing with:
```
HttpError: Invalid request. "ref" wasn't supplied.
```

## Root Cause & Solution
1. **Invalid context property**: `context.repo.default_branch` doesn't exist
2. **Missing permissions**: `createWorkflowDispatch` requires actions: write
3. **Robust implementation**: Dynamic default branch resolution with fallback

## Key Changes
- ✅ Add `actions: write` permission for createWorkflowDispatch  
- ✅ Implement dynamic default branch resolution via repos.get() API
- ✅ Replace invalid `context.repo.default_branch` with proper resolution
- ✅ Add fallback to 'main' if default_branch unavailable
- ✅ Enhanced logging with resolved ref

## Technical Implementation
```javascript
// Resolve default branch dynamically
const { data: r } = await github.rest.repos.get({ owner, repo });
const ref = r.default_branch || 'main';
```

## Benefits
- 🚀 **Future-proof**: No hardcoded branch names
- 🔒 **Proper permissions**: Workflow dispatch works correctly
- 📊 **Better logging**: Shows which ref was used
- 🌐 **Repository-agnostic**: Works regardless of default branch name

Resolves HttpError: Invalid request. ref wasn't supplied