### PR TITLE
CRITICAL: Fix delta.text extraction from Claude stream JSON #42

### DIFF
--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -158,7 +158,7 @@ jobs:
         run: exit 0
 
       - name: Checkout PR HEAD
-        if: steps.decide.outputs.internal == 'true' && steps.haslabel.outputs.has == 'true'
+        if: steps.decide.outputs.internal == 'true' && (steps.haslabel.outputs.has == 'true' || github.event_name == 'workflow_dispatch')
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.decide.outputs.sha }}
@@ -166,7 +166,7 @@ jobs:
           persist-credentials: false # defensive; we're not pushing
 
       - name: Claude Review (Sonnet)
-        if: steps.decide.outputs.internal == 'true' && steps.haslabel.outputs.has_review == 'true'
+        if: steps.decide.outputs.internal == 'true' && (steps.haslabel.outputs.has_review == 'true' || (github.event_name == 'workflow_dispatch' && steps.resolve.outputs.label == 'claude:review'))
         id: claude_sonnet
         timeout-minutes: 12
         uses: anthropics/claude-code-action@v1
@@ -216,7 +216,7 @@ jobs:
             - **Risk Level** with rationale
 
       - name: Claude Review (Opus)
-        if: steps.decide.outputs.internal == 'true' && steps.haslabel.outputs.has_ultra == 'true'
+        if: steps.decide.outputs.internal == 'true' && (steps.haslabel.outputs.has_ultra == 'true' || (github.event_name == 'workflow_dispatch' && steps.resolve.outputs.label == 'claude:ultra'))
         id: claude_opus
         timeout-minutes: 15
         uses: anthropics/claude-code-action@v1
@@ -271,40 +271,47 @@ jobs:
         if: steps.claude_sonnet.outcome == 'success' && steps.claude_sonnet.outputs.execution_file != ''
         shell: bash
         run: |
+          set -euo pipefail
           EXEC_FILE="${{ steps.claude_sonnet.outputs.execution_file }}"
           if [ -f "$EXEC_FILE" ]; then
             echo "📄 Processing execution file: $EXEC_FILE"
-            # Extract text content from the execution file and capture in env var
+
+            # 1) Try to pull ALL 'text' occurrences (covers delta.text too)
+            REVIEW_CONTENT=""
             if command -v jq >/dev/null 2>&1; then
-              # Try to extract content using jq if available
-              REVIEW_CONTENT=$(jq -r '
-                def extract_text:
-                  if type == "object" then
-                    if .type == "text" and .text then .text
-                    elif .content then .content | map(extract_text) | join("\n")
-                    elif .messages then .messages | map(extract_text) | join("\n")
-                    elif .turns then .turns | map(extract_text) | join("\n")
-                    else empty
-                    end
-                  elif type == "array" then map(extract_text) | join("\n")
-                  else empty
-                  end;
-                extract_text' "$EXEC_FILE" 2>/dev/null || cat "$EXEC_FILE")
-            else
-              # Fallback to reading the file directly
-              REVIEW_CONTENT=$(cat "$EXEC_FILE")
+              # Grab any .delta.text, then any plain .text, join in order
+              REVIEW_CONTENT="$(jq -r '
+                (.. | .delta?.text? // empty),
+                (.. | .text? // empty)
+              ' "$EXEC_FILE" 2>/dev/null | tr -d "\r")" || true
             fi
 
-            # Remove END-OF-REPORT marker and trim
-            REVIEW_CONTENT=$(echo "$REVIEW_CONTENT" | sed 's/END-OF-REPORT.*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            # 2) Fallback: quick-and-dirty extractor for "text":"..." pairs (NDJSON safe)
+            if [ -z "$REVIEW_CONTENT" ]; then
+              REVIEW_CONTENT="$(awk '
+                {
+                  while (match($0, /\"text\"\s*:\s*\"((\\.|[^\"])*)\"/, m)) {
+                    s=m[1]; gsub(/\\n/, "\n", s); gsub(/\\"/, "\"", s); gsub(/\\\\/, "\\", s);
+                    printf "%s", s;
+                    $0=substr($0, RSTART+RLENGTH);
+                  }
+                }
+              ' "$EXEC_FILE")"
+            fi
+
+            # Trim and cut at END-OF-REPORT if present
+            REVIEW_CONTENT="$(printf "%s" "$REVIEW_CONTENT" | sed 's/END-OF-REPORT.*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 
             if [ -n "$REVIEW_CONTENT" ]; then
               echo "✅ Captured Sonnet review content (${#REVIEW_CONTENT} chars)"
-              echo "RESULT_SONNET<<'EOF'" >> "$GITHUB_ENV"
-              echo "$REVIEW_CONTENT" >> "$GITHUB_ENV"
-              echo "EOF" >> "$GITHUB_ENV"
+              {
+                echo "RESULT_SONNET<<'EOF'"
+                echo "$REVIEW_CONTENT"
+                echo "EOF"
+              } >> "$GITHUB_ENV"
             else
-              echo "❌ No review content found in execution file"
+              echo "❌ No review content found in execution file (after jq/awk). Showing tail:"
+              tail -n 20 "$EXEC_FILE" || true
             fi
           else
             echo "❌ Execution file not found: $EXEC_FILE"
@@ -314,40 +321,47 @@ jobs:
         if: steps.claude_opus.outcome == 'success' && steps.claude_opus.outputs.execution_file != ''
         shell: bash
         run: |
+          set -euo pipefail
           EXEC_FILE="${{ steps.claude_opus.outputs.execution_file }}"
           if [ -f "$EXEC_FILE" ]; then
             echo "📄 Processing execution file: $EXEC_FILE"
-            # Extract text content from the execution file and capture in env var
+
+            # 1) Try to pull ALL 'text' occurrences (covers delta.text too)
+            REVIEW_CONTENT=""
             if command -v jq >/dev/null 2>&1; then
-              # Try to extract content using jq if available
-              REVIEW_CONTENT=$(jq -r '
-                def extract_text:
-                  if type == "object" then
-                    if .type == "text" and .text then .text
-                    elif .content then .content | map(extract_text) | join("\n")
-                    elif .messages then .messages | map(extract_text) | join("\n")
-                    elif .turns then .turns | map(extract_text) | join("\n")
-                    else empty
-                    end
-                  elif type == "array" then map(extract_text) | join("\n")
-                  else empty
-                  end;
-                extract_text' "$EXEC_FILE" 2>/dev/null || cat "$EXEC_FILE")
-            else
-              # Fallback to reading the file directly
-              REVIEW_CONTENT=$(cat "$EXEC_FILE")
+              # Grab any .delta.text, then any plain .text, join in order
+              REVIEW_CONTENT="$(jq -r '
+                (.. | .delta?.text? // empty),
+                (.. | .text? // empty)
+              ' "$EXEC_FILE" 2>/dev/null | tr -d "\r")" || true
             fi
 
-            # Remove END-OF-REPORT marker and trim
-            REVIEW_CONTENT=$(echo "$REVIEW_CONTENT" | sed 's/END-OF-REPORT.*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            # 2) Fallback: quick-and-dirty extractor for "text":"..." pairs (NDJSON safe)
+            if [ -z "$REVIEW_CONTENT" ]; then
+              REVIEW_CONTENT="$(awk '
+                {
+                  while (match($0, /\"text\"\s*:\s*\"((\\.|[^\"])*)\"/, m)) {
+                    s=m[1]; gsub(/\\n/, "\n", s); gsub(/\\"/, "\"", s); gsub(/\\\\/, "\\", s);
+                    printf "%s", s;
+                    $0=substr($0, RSTART+RLENGTH);
+                  }
+                }
+              ' "$EXEC_FILE")"
+            fi
+
+            # Trim and cut at END-OF-REPORT if present
+            REVIEW_CONTENT="$(printf "%s" "$REVIEW_CONTENT" | sed 's/END-OF-REPORT.*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 
             if [ -n "$REVIEW_CONTENT" ]; then
               echo "✅ Captured Opus review content (${#REVIEW_CONTENT} chars)"
-              echo "RESULT_OPUS<<'EOF'" >> "$GITHUB_ENV"
-              echo "$REVIEW_CONTENT" >> "$GITHUB_ENV"
-              echo "EOF" >> "$GITHUB_ENV"
+              {
+                echo "RESULT_OPUS<<'EOF'"
+                echo "$REVIEW_CONTENT"
+                echo "EOF"
+              } >> "$GITHUB_ENV"
             else
-              echo "❌ No review content found in execution file"
+              echo "❌ No review content found in execution file (after jq/awk). Showing tail:"
+              tail -n 20 "$EXEC_FILE" || true
             fi
           else
             echo "❌ Execution file not found: $EXEC_FILE"
@@ -361,7 +375,7 @@ jobs:
           ls -l "${{ steps.claude_opus.outputs.execution_file }}" 2>/dev/null || true
 
       - name: Post PR review (robust)
-        if: always() && steps.decide.outputs.internal == 'true' && steps.haslabel.outputs.has == 'true'
+        if: always() && steps.decide.outputs.internal == 'true' && (steps.haslabel.outputs.has == 'true' || github.event_name == 'workflow_dispatch')
         uses: actions/github-script@v7
         env:
           EXEC_FILE_SONNET: ${{ steps.claude_sonnet.outputs.execution_file }}
@@ -397,13 +411,24 @@ jobs:
             // Prefer the deeper Opus pass if both exist
             let body = (process.env.RESULT_OPUS || process.env.RESULT_SONNET || '').trim();
 
+            // Robust extractor: handles delta.text, text nodes, arrays, messages, etc.
             function extractText(node, out) {
               if (!node) return;
-              if (Array.isArray(node)) return node.forEach(n => extractText(n, out));
+              if (Array.isArray(node)) { node.forEach(n => extractText(n, out)); return; }
               if (typeof node === 'object') {
-                if (node.type === 'message' && node.role === 'assistant') extractText(node.content, out);
+                // Anthropic stream deltas
+                if (node.delta && typeof node.delta.text === 'string') out.push(node.delta.text);
+
+                // Plain text nodes
                 if (node.type === 'text' && typeof node.text === 'string') out.push(node.text);
-                extractText(node.content, out); extractText(node.turns, out); extractText(node.messages, out);
+
+                // Generic: capture any string-valued "text"
+                if (Object.prototype.hasOwnProperty.call(node, 'text') && typeof node.text === 'string') out.push(node.text);
+
+                // Recurse
+                for (const k of ['content','turns','messages','delta','data','message']) {
+                  if (node[k] !== undefined) extractText(node[k], out);
+                }
               }
             }
 
@@ -412,18 +437,28 @@ jobs:
               if (execFile && fs.existsSync(execFile)) {
                 try {
                   const raw = fs.readFileSync(execFile, 'utf8').trim();
-                  const lines = raw.split(/\r?\n/);
                   const chunks = [];
-                  for (const line of lines) {
+
+                  // First try NDJSON (stream JSON)
+                  for (const line of raw.split(/\r?\n/)) {
+                    const s = line.trim();
+                    if (!s) continue;
                     try {
-                      extractText(JSON.parse(line), chunks);
-                    } catch (e) {
-                      // Skip invalid JSON lines
-                    }
+                      extractText(JSON.parse(s), chunks);
+                    } catch {}
                   }
-                  body = chunks.join('\n\n').trim();
+
+                  // Fallback: single JSON blob
+                  if (!chunks.length) {
+                    try { extractText(JSON.parse(raw), chunks); } catch {}
+                  }
+
+                  // Join deltas without injecting extra newlines
+                  body = chunks.join('').trim();
+
+                  // Cut at the sentinel if present
                   const end = body.indexOf('END-OF-REPORT');
-                  if (end !== -1) body = body.slice(0, end + 'END-OF-REPORT'.length);
+                  if (end !== -1) body = body.slice(0, end);
                 } catch (e) {
                   core.warning(`Failed to parse execution file: ${e.message}`);
                 }

--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -359,18 +359,13 @@ jobs:
         env:
           EXEC_FILE_SONNET: ${{ steps.claude_sonnet.outputs.execution_file }}
           EXEC_FILE_OPUS: ${{ steps.claude_opus.outputs.execution_file }}
-          RESULT_SONNET: ${{ steps.claude_sonnet.outputs.result }}
-          RESULT_OPUS: ${{ steps.claude_opus.outputs.result }}
         with:
           script: |
             const fs = require('fs');
             const LIMIT = 65000;
 
             // Event-agnostic PR number detection
-            const prNumber =
-              Number('${{ github.event.pull_request.number || '' }}') ||
-              Number('${{ github.event.issue.number || '' }}') ||
-              Number('${{ steps.decide.outputs.pr || '' }}');
+            const prNumber = Number('${{ steps.resolve.outputs.pr }}');
 
             if (!prNumber) {
               core.info('No PR number found; skipping comment posting.');
@@ -448,7 +443,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = Number('${{ steps.decide.outputs.pr }}');
+            const prNumber = Number('${{ steps.resolve.outputs.pr }}');
 
             // Check which label was applied by looking at completed steps
             const sonnetRan = '${{ steps.claude_sonnet.outcome }}' !== '';

--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -279,10 +279,9 @@ jobs:
             # 1) Try to pull ALL 'text' occurrences (covers delta.text too)
             REVIEW_CONTENT=""
             if command -v jq >/dev/null 2>&1; then
-              # Grab any .delta.text, then any plain .text, join in order
+              # Process line-by-line to preserve stream order, prefer delta.text over text
               REVIEW_CONTENT="$(jq -r '
-                (.. | .delta?.text? // empty),
-                (.. | .text? // empty)
+                if type=="object" then (.delta?.text? // .text // empty) else empty end
               ' "$EXEC_FILE" 2>/dev/null | tr -d "\r")" || true
             fi
 
@@ -305,7 +304,7 @@ jobs:
             if [ -n "$REVIEW_CONTENT" ]; then
               echo "✅ Captured Sonnet review content (${#REVIEW_CONTENT} chars)"
               {
-                echo "RESULT_SONNET<<'EOF'"
+                echo "RESULT_SONNET<<EOF"
                 echo "$REVIEW_CONTENT"
                 echo "EOF"
               } >> "$GITHUB_ENV"
@@ -329,10 +328,9 @@ jobs:
             # 1) Try to pull ALL 'text' occurrences (covers delta.text too)
             REVIEW_CONTENT=""
             if command -v jq >/dev/null 2>&1; then
-              # Grab any .delta.text, then any plain .text, join in order
+              # Process line-by-line to preserve stream order, prefer delta.text over text
               REVIEW_CONTENT="$(jq -r '
-                (.. | .delta?.text? // empty),
-                (.. | .text? // empty)
+                if type=="object" then (.delta?.text? // .text // empty) else empty end
               ' "$EXEC_FILE" 2>/dev/null | tr -d "\r")" || true
             fi
 
@@ -355,7 +353,7 @@ jobs:
             if [ -n "$REVIEW_CONTENT" ]; then
               echo "✅ Captured Opus review content (${#REVIEW_CONTENT} chars)"
               {
-                echo "RESULT_OPUS<<'EOF'"
+                echo "RESULT_OPUS<<EOF"
                 echo "$REVIEW_CONTENT"
                 echo "EOF"
               } >> "$GITHUB_ENV"
@@ -416,19 +414,23 @@ jobs:
               if (!node) return;
               if (Array.isArray(node)) { node.forEach(n => extractText(n, out)); return; }
               if (typeof node === 'object') {
-                // Anthropic stream deltas
-                if (node.delta && typeof node.delta.text === 'string') out.push(node.delta.text);
+                // Anthropic stream deltas - prefer this over plain text
+                if (node.delta && typeof node.delta.text === 'string') {
+                  out.push(node.delta.text);
+                  // Don't process plain text if we found delta.text to avoid duplication
+                } else {
+                  // Plain text nodes (only if no delta.text was found)
+                  if (node.type === 'text' && typeof node.text === 'string') out.push(node.text);
+                  // Generic: capture any string-valued "text" (only if no delta)
+                  else if (Object.prototype.hasOwnProperty.call(node, 'text') && typeof node.text === 'string') out.push(node.text);
+                }
 
-                // Plain text nodes
-                if (node.type === 'text' && typeof node.text === 'string') out.push(node.text);
-
-                // Generic: capture any string-valued "text"
-                if (Object.prototype.hasOwnProperty.call(node, 'text') && typeof node.text === 'string') out.push(node.text);
-
-                // Recurse
-                for (const k of ['content','turns','messages','delta','data','message']) {
+                // Recurse into nested structures (but skip delta to avoid double-processing)
+                for (const k of ['content','turns','messages','data','message']) {
                   if (node[k] !== undefined) extractText(node[k], out);
                 }
+                // Only recurse into delta if it doesn't have text (to avoid reprocessing delta.text)
+                if (node.delta && !node.delta.text) extractText(node.delta, out);
               }
             }
 

--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -268,7 +268,7 @@ jobs:
             If mode is **ultra**, go deeper on security, performance, concurrency, error-handling, and propose minimal diffs.
 
       - name: Capture Sonnet Review Output
-        if: steps.claude_sonnet.conclusion == 'success' && steps.claude_sonnet.outputs.execution_file
+        if: steps.claude_sonnet.outcome == 'success' && steps.claude_sonnet.outputs.execution_file != ''
         shell: bash
         run: |
           EXEC_FILE="${{ steps.claude_sonnet.outputs.execution_file }}"
@@ -311,7 +311,7 @@ jobs:
           fi
 
       - name: Capture Opus Review Output
-        if: steps.claude_opus.conclusion == 'success' && steps.claude_opus.outputs.execution_file
+        if: steps.claude_opus.outcome == 'success' && steps.claude_opus.outputs.execution_file != ''
         shell: bash
         run: |
           EXEC_FILE="${{ steps.claude_opus.outputs.execution_file }}"
@@ -352,6 +352,13 @@ jobs:
           else
             echo "❌ Execution file not found: $EXEC_FILE"
           fi
+
+      - name: Debug review env
+        run: |
+          echo "RESULT_SONNET chars:" $(printf %s "$RESULT_SONNET" | wc -c)
+          echo "RESULT_OPUS chars:" $(printf %s "$RESULT_OPUS" | wc -c)
+          ls -l "${{ steps.claude_sonnet.outputs.execution_file }}" 2>/dev/null || true
+          ls -l "${{ steps.claude_opus.outputs.execution_file }}" 2>/dev/null || true
 
       - name: Post PR review (robust)
         if: always() && steps.decide.outputs.internal == 'true' && steps.haslabel.outputs.has == 'true'
@@ -404,8 +411,16 @@ jobs:
               const execFile = process.env.EXEC_FILE_SONNET || process.env.EXEC_FILE_OPUS;
               if (execFile && fs.existsSync(execFile)) {
                 try {
-                  const data = JSON.parse(fs.readFileSync(execFile, 'utf8'));
-                  const chunks = []; extractText(data, chunks);
+                  const raw = fs.readFileSync(execFile, 'utf8').trim();
+                  const lines = raw.split(/\r?\n/);
+                  const chunks = [];
+                  for (const line of lines) {
+                    try {
+                      extractText(JSON.parse(line), chunks);
+                    } catch (e) {
+                      // Skip invalid JSON lines
+                    }
+                  }
                   body = chunks.join('\n\n').trim();
                   const end = body.indexOf('END-OF-REPORT');
                   if (end !== -1) body = body.slice(0, end + 'END-OF-REPORT'.length);

--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -267,6 +267,92 @@ jobs:
 
             If mode is **ultra**, go deeper on security, performance, concurrency, error-handling, and propose minimal diffs.
 
+      - name: Capture Sonnet Review Output
+        if: steps.claude_sonnet.conclusion == 'success' && steps.claude_sonnet.outputs.execution_file
+        shell: bash
+        run: |
+          EXEC_FILE="${{ steps.claude_sonnet.outputs.execution_file }}"
+          if [ -f "$EXEC_FILE" ]; then
+            echo "📄 Processing execution file: $EXEC_FILE"
+            # Extract text content from the execution file and capture in env var
+            if command -v jq >/dev/null 2>&1; then
+              # Try to extract content using jq if available
+              REVIEW_CONTENT=$(jq -r '
+                def extract_text:
+                  if type == "object" then
+                    if .type == "text" and .text then .text
+                    elif .content then .content | map(extract_text) | join("\n")
+                    elif .messages then .messages | map(extract_text) | join("\n")
+                    elif .turns then .turns | map(extract_text) | join("\n")
+                    else empty
+                    end
+                  elif type == "array" then map(extract_text) | join("\n")
+                  else empty
+                  end;
+                extract_text' "$EXEC_FILE" 2>/dev/null || cat "$EXEC_FILE")
+            else
+              # Fallback to reading the file directly
+              REVIEW_CONTENT=$(cat "$EXEC_FILE")
+            fi
+
+            # Remove END-OF-REPORT marker and trim
+            REVIEW_CONTENT=$(echo "$REVIEW_CONTENT" | sed 's/END-OF-REPORT.*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+            if [ -n "$REVIEW_CONTENT" ]; then
+              echo "✅ Captured Sonnet review content (${#REVIEW_CONTENT} chars)"
+              echo "RESULT_SONNET<<'EOF'" >> "$GITHUB_ENV"
+              echo "$REVIEW_CONTENT" >> "$GITHUB_ENV"
+              echo "EOF" >> "$GITHUB_ENV"
+            else
+              echo "❌ No review content found in execution file"
+            fi
+          else
+            echo "❌ Execution file not found: $EXEC_FILE"
+          fi
+
+      - name: Capture Opus Review Output
+        if: steps.claude_opus.conclusion == 'success' && steps.claude_opus.outputs.execution_file
+        shell: bash
+        run: |
+          EXEC_FILE="${{ steps.claude_opus.outputs.execution_file }}"
+          if [ -f "$EXEC_FILE" ]; then
+            echo "📄 Processing execution file: $EXEC_FILE"
+            # Extract text content from the execution file and capture in env var
+            if command -v jq >/dev/null 2>&1; then
+              # Try to extract content using jq if available
+              REVIEW_CONTENT=$(jq -r '
+                def extract_text:
+                  if type == "object" then
+                    if .type == "text" and .text then .text
+                    elif .content then .content | map(extract_text) | join("\n")
+                    elif .messages then .messages | map(extract_text) | join("\n")
+                    elif .turns then .turns | map(extract_text) | join("\n")
+                    else empty
+                    end
+                  elif type == "array" then map(extract_text) | join("\n")
+                  else empty
+                  end;
+                extract_text' "$EXEC_FILE" 2>/dev/null || cat "$EXEC_FILE")
+            else
+              # Fallback to reading the file directly
+              REVIEW_CONTENT=$(cat "$EXEC_FILE")
+            fi
+
+            # Remove END-OF-REPORT marker and trim
+            REVIEW_CONTENT=$(echo "$REVIEW_CONTENT" | sed 's/END-OF-REPORT.*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+            if [ -n "$REVIEW_CONTENT" ]; then
+              echo "✅ Captured Opus review content (${#REVIEW_CONTENT} chars)"
+              echo "RESULT_OPUS<<'EOF'" >> "$GITHUB_ENV"
+              echo "$REVIEW_CONTENT" >> "$GITHUB_ENV"
+              echo "EOF" >> "$GITHUB_ENV"
+            else
+              echo "❌ No review content found in execution file"
+            fi
+          else
+            echo "❌ Execution file not found: $EXEC_FILE"
+          fi
+
       - name: Post PR review (robust)
         if: always() && steps.decide.outputs.internal == 'true' && steps.haslabel.outputs.has == 'true'
         uses: actions/github-script@v7


### PR DESCRIPTION
## 🚨 CRITICAL FIX: Extract delta.text from stream JSON

**Root Cause Identified**: Capture steps were extracting the wrong field from stream JSON output.

The  with  writes **NDJSON streaming events** where the human-readable text lands in  fields:


Previous jq only looked for  blocks → returned nothing →  stayed empty → no comments posted.

## 🔧 Robust Fixes Applied

### **Capture Steps (Sonnet + Opus)**
- ✅ Extract  to capture stream deltas  
- ✅ Fallback awk extractor for  pairs (NDJSON safe)
- ✅ Join with empty string (not ) to avoid fragmenting content
- ✅ Enhanced error logging with tail output on failure

### **Poster Step**
- ✅ Handle  for Anthropic stream deltas
- ✅ Process NDJSON line-by-line + fallback to single JSON blob
- ✅ Join chunks with  to preserve continuous text flow
- ✅ Robust extraction covering all text fields

### **Workflow Guards**
- ✅ Allow workflow_dispatch runs even without labels
- ✅ Ensure checkout/review/poster steps run on manual dispatch

## 🎯 Expected Results

The workflow chain should now work completely:
- Gate triggers dispatch ✅
- Review executes ✅  
- **Capture steps extract delta.text** (was missing, now fixed) ✅
- Environment vars populated with review content ✅
- Comments post successfully ✅

## 📋 Validation Checklist

Next run should show:
- ✅ **Claude Review** step runs (not skipped)
- ✅ **Capture … Output** prints 
- ✅ **Debug review env** shows 
- ✅ **Post PR review** creates comment successfully

**This is the final missing piece for Claude reviews to work.**