### PR TITLE
Fix: Normalize record metadata result #648

### DIFF
--- a/src/services/metadata/types.ts
+++ b/src/services/metadata/types.ts
@@ -5,6 +5,7 @@ export interface MetadataResult extends Record<string, unknown> {
   mappings?: Record<string, string>;
   count?: number;
   resource_type?: UniversalResourceType | string;
+  objectSlug?: string;
 }
 
 export interface DiscoverTypeOptions {

--- a/test/services/metadata/MetadataDiscoveryService.test.ts
+++ b/test/services/metadata/MetadataDiscoveryService.test.ts
@@ -81,6 +81,42 @@ describe('DefaultMetadataDiscoveryService', () => {
     expect(mockGet).not.toHaveBeenCalled();
   });
 
+  it('returns normalized record metadata with mappings and counts', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: [
+          {
+            title: 'Name',
+            api_slug: 'name',
+            category: 'basic',
+            type: 'text',
+          },
+          {
+            title: 'Notes',
+            api_slug: 'notes',
+            category: 'extended',
+            type: 'text',
+          },
+        ],
+      },
+    });
+
+    const result = await service.discoverObject({
+      objectSlug: 'companies',
+      categories: ['basic'],
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/objects/companies/attributes?categories=basic'
+    );
+    expect(result.count).toBe(1);
+    expect(result.mappings).toEqual({ Name: 'name' });
+    expect(result.resource_type).toBe(UniversalResourceType.RECORDS);
+    expect(result.objectSlug).toBe('companies');
+    expect(Array.isArray(result.attributes)).toBe(true);
+    expect((result.attributes as unknown[]).length).toBe(1);
+  });
+
   it('propagates structured errors from API failures', async () => {
     mockGet.mockRejectedValue(new Error('boom'));
 


### PR DESCRIPTION
## Summary
- ensure record-specific metadata discovery returns filtered attributes, mappings, counts, and object slug for parity with type-based discovery
- expose optional objectSlug on MetadataResult for downstream consumers
- add unit coverage locking in the normalized shape and category filtering behaviour

## Testing
- npm test -- MetadataDiscoveryService.test