### PR TITLE
Fix: Correct git sparse-checkout syntax in Claude workflow #42

### DIFF
--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -218,8 +218,8 @@ jobs:
           # Prepare sparse checkout patterns (include limited defaults for workflow internals)
           tmpfile=$(mktemp)
           {
-            echo '.github'
-            echo 'scripts/claude'
+            echo '/.github/**'
+            echo '/scripts/claude/**'
             jq -r '.[]' "$RING0_JSON_PATH"
             jq -r '.[]' "$RING1_JSON_PATH"
           } | sed '/^\s*$/d' | sort -u > "$tmpfile"
@@ -230,8 +230,21 @@ jobs:
             exit 0
           fi
 
-          git sparse-checkout init --cone=false
-          git sparse-checkout set --stdin < "$tmpfile"
+          # Init with sparse index for performance
+          git sparse-checkout init --sparse-index
+
+          # Use non-cone mode so individual file patterns are honored
+          if git sparse-checkout set -h 2>&1 | grep -q -- '--no-cone'; then
+            git sparse-checkout set --no-cone --stdin < "$tmpfile"
+          else
+            # Legacy fallback: disable cone via config, then set patterns
+            git config --local core.sparseCheckoutCone false
+            git sparse-checkout set --stdin < "$tmpfile"
+          fi
+
+          # Sanity check
+          echo "Sparse checkout patterns applied:"
+          git sparse-checkout list || true
           rm -f "$tmpfile"
 
       - name: Claude Review (Sonnet)


### PR DESCRIPTION
## Summary

Fix the git sparse-checkout syntax error in the Claude PR review workflow.

### Changes Made

- **Fixed invalid --cone=false flag**: Replace with proper --sparse-index init  
- **Use --no-cone flag on set command**: Required for file-level patterns
- **Add legacy fallback**: Support for older Git versions that don't support --no-cone
- **Update patterns**: Use leading slash and /** for directories
- **Add sanity check**: Verify sparse checkout patterns are applied correctly

### Technical Details

The original code had a Git syntax error where --cone was being passed a value when it's a boolean flag.

The fix ensures Ring 0/Ring 1 scoping works correctly with file-level precision while being compatible across Git versions.

Fixes #42