### PR TITLE
Fix: Prevent Claude PR review monologue dumps #999

### DIFF
--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -128,8 +128,8 @@ jobs:
           fi
 
           # Calculate cutoff turns (when to stop using tools)
-          sonnet_cutoff=$((sonnet_cap - 6))
-          opus_cutoff=$((opus_cap - 8))
+          sonnet_cutoff=$((sonnet_cap - 10))
+          opus_cutoff=$((opus_cap - 12))
 
           echo "sonnet_turns=$sonnet_cap" >> $GITHUB_OUTPUT
           echo "opus_turns=$opus_cap" >> $GITHUB_OUTPUT
@@ -197,6 +197,8 @@ jobs:
 
           ring0_json=$(jq -c '.' "$RING0_JSON_PATH")
           ring1_json=$(jq -c '.' "$RING1_JSON_PATH")
+          # Normalize .js -> .ts for source paths; keeps everything JSON-safe
+          ring1_json=$(jq -c 'map(if endswith(".js") then sub("\\.js$"; ".ts") else . end)' <<< "$ring1_json")
           fallback=$(jq -r '.fallback // false' "$SUMMARY_PATH")
 
           printf 'RING0_JSON=%s\n' "$ring0_json" >> "$GITHUB_ENV"
@@ -261,7 +263,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-20250514
             --max-turns ${{ steps.turns.outputs.sonnet_turns }}
-            --allowed-tools Read,Glob,Grep,NotebookEdit
+            --allowed-tools Read,Glob,Grep
             --output-format stream-json
           prompt: |
             IMPORTANT EXECUTION RULES
@@ -273,12 +275,22 @@ jobs:
             - Start the report with the heading `# PR Review Report`.
             - Respect the scope rules below. If you cannot remain in scope, say so explicitly.
 
+            TOOLS POLICY (hard rule)
+            - Use only: Read, Glob, Grep. Do NOT use Bash, Web*, NotebookEdit, or TodoWrite.
+            - If a command/build/test is needed, SKIP it and write the report instead.
+            - If you can't find a symbol after 3 tool calls, stop tool use and write the report.
+
             SCOPE RULES
             - Ring 0: Files changed in the PR (JSON supplied separately); findings must cite Ring 0 paths only.
             - Ring 1: Neighbor/test/import context only. Use Ring 1 to reason, never as independent findings.
             - Ignore absolute/tsconfig-path imports. Stay within the sparse checkout tree.
             - If Ring 1 is unavailable, work with Ring 0 alone rather than expanding scope.
             - Current fallback flag: ${{ env.RING_SCOPE_FALLBACK }}
+
+            PATH RESOLUTION RULES
+            - Source files use ESM imports like "../foo.js" but live on disk as "../foo.ts".
+            - When a Read(...) of a "*.js" path fails, immediately retry the same path with ".ts".
+            - Never treat missing "*.js" as missing code if a ".ts" twin exists.
 
             Changed files (Ring 0 JSON):
             ${{ env.RING0_JSON }}
@@ -326,7 +338,7 @@ jobs:
           claude_args: >-
             --model claude-opus-4-1-20250805
             --max-turns ${{ steps.turns.outputs.opus_turns }}
-            --allowed-tools Read,Glob,Grep,NotebookEdit
+            --allowed-tools Read,Glob,Grep
             --output-format stream-json
           prompt: |
             IMPORTANT EXECUTION RULES
@@ -338,12 +350,22 @@ jobs:
             - Start the report with the heading `# PR Review Report`.
             - Respect the scope rules below. If you cannot remain in scope, say so explicitly.
 
+            TOOLS POLICY (hard rule)
+            - Use only: Read, Glob, Grep. Do NOT use Bash, Web*, NotebookEdit, or TodoWrite.
+            - If a command/build/test is needed, SKIP it and write the report instead.
+            - If you can't find a symbol after 3 tool calls, stop tool use and write the report.
+
             SCOPE RULES
             - Ring 0: Files changed in the PR (JSON supplied separately); findings must cite Ring 0 paths only.
             - Ring 1: Neighbor/test/import context only. Use Ring 1 to reason, never as independent findings.
             - Ignore absolute/tsconfig-path imports. Stay within the sparse checkout tree.
             - If Ring 1 is unavailable, work with Ring 0 alone rather than expanding scope.
             - Current fallback flag: ${{ env.RING_SCOPE_FALLBACK }}
+
+            PATH RESOLUTION RULES
+            - Source files use ESM imports like "../foo.js" but live on disk as "../foo.ts".
+            - When a Read(...) of a "*.js" path fails, immediately retry the same path with ".ts".
+            - Never treat missing "*.js" as missing code if a ".ts" twin exists.
 
             Changed files (Ring 0 JSON):
             ${{ env.RING0_JSON }}
@@ -461,6 +483,11 @@ jobs:
               return;
             }
 
+            // Require a proper report header; otherwise don't export anything
+            if (!/^#\s*PR Review Report\b/m.test(review)) {
+              core.warning('No PR Review header detected; skipping RESULT_SONNET export.');
+              return;
+            }
             core.exportVariable('RESULT_SONNET', review);
             core.info(`Captured Sonnet review content (${review.length} chars).`);
 
@@ -543,6 +570,11 @@ jobs:
               return;
             }
 
+            // Require a proper report header; otherwise don't export anything
+            if (!/^#\s*PR Review Report\b/m.test(review)) {
+              core.warning('No PR Review header detected; skipping RESULT_OPUS export.');
+              return;
+            }
             core.exportVariable('RESULT_OPUS', review);
             core.info(`Captured Opus review content (${review.length} chars).`);
 
@@ -680,6 +712,12 @@ jobs:
             };
 
             body = trimReport(body);
+
+            // Don't post unless it's a real report
+            if (!/^#\s*PR Review Report\b/m.test(body)) {
+              core.info('No final report detected; skipping comment to avoid posting process narration.');
+              return;
+            }
 
             const ring0Set = new Set();
             try {


### PR DESCRIPTION
## Summary
Bulletproofs Claude PR review workflow to prevent raw model output/monologue from being posted as comments.

## Root Cause Analysis
- TS ESM imports use `../types.js` specifiers but files exist as `../types.ts` on disk
- Claude attempts `Read(...types.js)`, fails, burns turns with tool churn
- Models hit max-turns without generating proper `# PR Review Report` header
- Posting logic publishes raw stream buffer instead of structured report

## Changes Applied

### 1. Header Validation Guards
- **Capture steps**: Only export RESULT_* if proper `# PR Review Report` header exists
- **Posting step**: Skip comment if no valid report header found
- **Result**: No more "Now let me check..." monologue dumps

### 2. TS ESM Path Resolution Rules  
- Added PATH RESOLUTION RULES to both model prompts
- Instructs models to retry `.ts` when `.js` Read operations fail
- **Result**: Eliminates primary source of tool churn

### 3. Explicit Tools Policy
- Added TOOLS POLICY to both Sonnet and Opus prompts  
- Restricts to Read/Glob/Grep only, blocks Bash/Web*/NotebookEdit/TodoWrite
- Removed NotebookEdit from `--allowed-tools` to match policy
- **Result**: No wasted turns on blocked tool attempts

### 4. Earlier Report Writing Cutoff
- Sonnet: cutoff moved from -6 to -10 turns before max
- Opus: cutoff moved from -8 to -12 turns before max
- **Result**: More buffer time for actual report composition

### 5. Ring1 Path Normalization
- Proactively converts `.js` → `.ts` in RING1_JSON environment variable
- **Result**: Models never see problematic `.js` paths in the first place

## Expected Results
- ✅ No more raw monologue comments
- ✅ Either clean structured reports or no comment posted  
- ✅ Faster execution with less tool churn
- ✅ Higher success rate for report generation

## Testing
Ready for workflow_dispatch testing with `claude:ultra` label.

Resolves #999