### PR TITLE
Redact API key logging in E2E test setup

### DIFF
--- a/test/e2e/run-e2e-tests.js
+++ b/test/e2e/run-e2e-tests.js
@@ -226,13 +226,7 @@ async function runVitest(pattern = 'all', options = {}) {
 
   // Debug: Verify API key is loaded
   if (process.env.ATTIO_API_KEY) {
-    const apiKeyLength = process.env.ATTIO_API_KEY.length;
-    console.error(
-      colorize(
-        `✓ API key detected (length: ${apiKeyLength}, value redacted)`,
-        'green'
-      )
-    );
+    console.error(colorize('✓ API key detected (value redacted)', 'green'));
   } else {
     console.error(colorize('⚠️  API key not found in environment!', 'yellow'));
   }

--- a/test/e2e/run-e2e-tests.js
+++ b/test/e2e/run-e2e-tests.js
@@ -226,9 +226,10 @@ async function runVitest(pattern = 'all', options = {}) {
 
   // Debug: Verify API key is loaded
   if (process.env.ATTIO_API_KEY) {
+    const apiKeyLength = process.env.ATTIO_API_KEY.length;
     console.error(
       colorize(
-        `✓ API key loaded (${process.env.ATTIO_API_KEY.slice(0, 10)}...)`,
+        `✓ API key detected (length: ${apiKeyLength}, value redacted)`,
         'green'
       )
     );

--- a/test/e2e/setup/env-loader.ts
+++ b/test/e2e/setup/env-loader.ts
@@ -58,10 +58,12 @@ if (missingVars.length > 0) {
   console.warn('[E2E Setup] Tests will be skipped unless these are set.');
 } else {
   console.error('[E2E Setup] ✅ All required environment variables loaded');
-  // Log partial API key for verification (safely)
+  // Log API key metadata without exposing the raw value
   const apiKey = process.env.ATTIO_API_KEY;
   if (apiKey) {
-    console.error(`[E2E Setup] API Key loaded: ${apiKey.substring(0, 10)}...`);
+    console.error(
+      `[E2E Setup] API key detected (length: ${apiKey.length}, value redacted)`
+    );
   }
 }
 

--- a/test/e2e/setup/env-loader.ts
+++ b/test/e2e/setup/env-loader.ts
@@ -61,9 +61,7 @@ if (missingVars.length > 0) {
   // Log API key metadata without exposing the raw value
   const apiKey = process.env.ATTIO_API_KEY;
   if (apiKey) {
-    console.error(
-      `[E2E Setup] API key detected (length: ${apiKey.length}, value redacted)`
-    );
+    console.error('[E2E Setup] API key detected (value redacted)');
   }
 }
 

--- a/test/e2e/setupEnv.ts
+++ b/test/e2e/setupEnv.ts
@@ -54,9 +54,9 @@ function validateEnvironment(): void {
   }
 
   // Log loaded API key (redacted)
-  const apiKey = process.env.ATTIO_API_KEY!;
-  const lengthInfo = `length: ${apiKey.length}`;
-  console.log(`🔑 API key loaded (${lengthInfo}, value redacted)`);
+  if (process.env.ATTIO_API_KEY) {
+    console.log('🔑 API key loaded (value redacted)');
+  }
 }
 
 /**

--- a/test/e2e/setupEnv.ts
+++ b/test/e2e/setupEnv.ts
@@ -55,9 +55,8 @@ function validateEnvironment(): void {
 
   // Log loaded API key (redacted)
   const apiKey = process.env.ATTIO_API_KEY!;
-  const redactedKey =
-    apiKey.substring(0, 8) + '...' + apiKey.substring(apiKey.length - 4);
-  console.log(`🔑 API key loaded: ${redactedKey}`);
+  const lengthInfo = `length: ${apiKey.length}`;
+  console.log(`🔑 API key loaded (${lengthInfo}, value redacted)`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- stop logging partial Attio API keys in the E2E environment loader
- redact the API key output in the environment bootstrap script
- update the E2E test runner to report API key presence without exposing characters

## Testing
- not run (test changes only)


------
https://chatgpt.com/codex/tasks/task_b_68d817155c6083258eeb9db4b4d87adf