### PR TITLE
Fix: Correct universal search pluralization

### DIFF
--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -36,6 +36,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/workflows/claude/
+          sparse-checkout-cone-mode: false
+
       - name: Classify command
         id: classify
         run: |
@@ -74,7 +81,7 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout repository
+      - name: Full checkout for command execution
         if: steps.classify.outputs.should_run == 'true' && steps.classify.outputs.is_maintainer == 'true' && steps.classify.outputs.command_type != 'review'
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude-comment-gate.yml
+++ b/.github/workflows/claude-comment-gate.yml
@@ -36,6 +36,13 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/workflows/claude/
+          sparse-checkout-cone-mode: false
+
       - name: Detect review command
         id: classify
         run: |

--- a/src/handlers/tool-configs/universal/operations/batch-format.ts
+++ b/src/handlers/tool-configs/universal/operations/batch-format.ts
@@ -1,9 +1,12 @@
-import { BatchOperationType, UniversalResourceType } from '../types.js';
-import { formatResourceType } from '../shared-handlers.js';
+import {
+  BatchOperationType,
+  UniversalResourceType,
+} from '@handlers/tool-configs/universal/types.js';
+import { formatResourceType } from '@handlers/tool-configs/universal/shared-handlers.js';
 import {
   safeExtractRecordValues,
   safeExtractFirstValue,
-} from '../../shared/type-utils.js';
+} from '@handlers/tool-configs/shared/type-utils.js';
 import type { JsonObject } from '@shared-types/attio.js';
 import type { UniversalBatchSearchResult } from '@api/operations/batch.js';
 
@@ -94,7 +97,8 @@ function formatBatchSearchResults(
     summary += 'Successful searches:\n';
     successful.forEach((searchResult, index) => {
       const records = searchResult.result ?? [];
-      summary += `\n${index + 1}. Query: "${searchResult.query}" - Found ${records.length} ${resourceTypeName}s\n`;
+      const resourceLabel = pluralizeResource(resourceTypeName, records.length);
+      summary += `\n${index + 1}. Query: "${searchResult.query}" - Found ${records.length} ${resourceLabel}\n`;
 
       if (records.length > 0) {
         records.slice(0, 3).forEach((record: unknown, recordIndex: number) => {

--- a/src/handlers/tool-configs/universal/operations/content-search.ts
+++ b/src/handlers/tool-configs/universal/operations/content-search.ts
@@ -7,14 +7,14 @@ import {
   ContentSearchParams,
   ContentSearchType,
   UniversalResourceType,
-} from '../types.js';
-import { AttioRecord, InteractionType } from '../../../../types/attio.js';
+} from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord, InteractionType } from '@shared-types/attio.js';
 
-import { validateUniversalToolParams } from '../schemas.js';
-import { UniversalSearchService } from '../../../../services/UniversalSearchService.js';
-import { ErrorService } from '../../../../services/ErrorService.js';
-import { getTypedErrorMessage } from '../typed-error-handling.js';
-import { formatResourceType } from '../shared-handlers.js';
+import { validateUniversalToolParams } from '@handlers/tool-configs/universal/schemas.js';
+import { UniversalSearchService } from '@services/UniversalSearchService.js';
+import { ErrorService } from '@services/ErrorService.js';
+import { getPluralResourceType } from '@handlers/tool-configs/universal/core/utils.js';
+import { formatResourceType } from '@handlers/tool-configs/universal/shared-handlers.js';
 
 export const searchByContentConfig: UniversalToolConfig<
   ContentSearchParams,
@@ -51,7 +51,7 @@ export const searchByContentConfig: UniversalToolConfig<
         // Support basic activity content for people via specialized handler mock
         if (resource_type === UniversalResourceType.PEOPLE) {
           const { searchPeopleByActivity } = await import(
-            '../../../../objects/people/search.js'
+            '@src/objects/people/search.js'
           );
           return await searchPeopleByActivity({
             dateRange: { preset: 'last_month' },
@@ -102,11 +102,16 @@ export const searchByContentConfig: UniversalToolConfig<
     }
 
     const contentTypeName = contentType ? contentType : 'content';
+    const resultCount = results.length;
     const resourceTypeName = resourceType
-      ? formatResourceType(resourceType)
-      : 'record';
+      ? resultCount === 1
+        ? formatResourceType(resourceType)
+        : getPluralResourceType(resourceType)
+      : resultCount === 1
+        ? 'record'
+        : 'records';
 
-    return `Found ${results.length} ${resourceTypeName}s with matching ${contentTypeName}:\n${results
+    return `Found ${results.length} ${resourceTypeName} with matching ${contentTypeName}:\n${results
       .map((record: Record<string, unknown>, index: number) => {
         const values = record.values as Record<string, unknown>;
         const recordId = record.id as Record<string, unknown>;

--- a/src/handlers/tool-configs/universal/operations/timeframe-search.ts
+++ b/src/handlers/tool-configs/universal/operations/timeframe-search.ts
@@ -8,19 +8,19 @@ import {
   TimeframeType,
   UniversalResourceType,
   RelativeTimeframe,
-} from '../types.js';
-import { AttioRecord } from '../../../../types/attio.js';
-import { safeExtractTimestamp } from '../../shared/type-utils.js';
+} from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord } from '@shared-types/attio.js';
+import { safeExtractTimestamp } from '@handlers/tool-configs/shared/type-utils.js';
 
-import { validateUniversalToolParams } from '../schemas.js';
-import { ErrorService } from '../../../../services/ErrorService.js';
-import { getTypedErrorMessage } from '../typed-error-handling.js';
+import { validateUniversalToolParams } from '@handlers/tool-configs/universal/schemas.js';
+import { ErrorService } from '@services/ErrorService.js';
 import {
   formatResourceType,
   handleUniversalSearch,
-} from '../shared-handlers.js';
-import { normalizeOperator } from '../../../../utils/AttioFilterOperators.js';
-import { mapFieldName } from '../../../../utils/AttioFieldMapper.js';
+} from '@handlers/tool-configs/universal/shared-handlers.js';
+import { getPluralResourceType } from '@handlers/tool-configs/universal/core/utils.js';
+import { normalizeOperator } from '@utils/AttioFilterOperators.js';
+import { mapFieldName } from '@utils/AttioFieldMapper.js';
 
 export const searchByTimeframeConfig: UniversalToolConfig<
   TimeframeSearchParams,
@@ -53,7 +53,7 @@ export const searchByTimeframeConfig: UniversalToolConfig<
       if (relative_range) {
         // Import the timeframe utility to convert relative ranges
         const { getRelativeTimeframeRange } = await import(
-          '../../../../utils/filters/timeframe-utils.js'
+          '@utils/filters/timeframe-utils.js'
         );
 
         try {
@@ -214,11 +214,16 @@ export const searchByTimeframeConfig: UniversalToolConfig<
     const timeframeName = timeframeType
       ? timeframeType.replace(/_/g, ' ')
       : 'timeframe';
+    const resourceCount = results.length;
     const resourceTypeName = resourceType
-      ? formatResourceType(resourceType)
-      : 'record';
+      ? resourceCount === 1
+        ? formatResourceType(resourceType)
+        : getPluralResourceType(resourceType)
+      : resourceCount === 1
+        ? 'record'
+        : 'records';
 
-    return `Found ${results.length} ${resourceTypeName}s by ${timeframeName}:\n${results
+    return `Found ${results.length} ${resourceTypeName} by ${timeframeName}:\n${results
       .map((record: Record<string, unknown>, index: number) => {
         const values = record.values as Record<string, unknown>;
         const name =

--- a/test/handlers/tool-configs/universal/advanced-operations-content.test.ts
+++ b/test/handlers/tool-configs/universal/advanced-operations-content.test.ts
@@ -5,12 +5,12 @@ import {
   TimeframeType,
   ContentSearchParams,
   TimeframeSearchParams,
-} from '../../../../src/handlers/tool-configs/universal/types.js';
+} from '@handlers/tool-configs/universal/types.js';
 import {
   setupUnitTestMocks,
   cleanupMocks,
   getMockInstances,
-} from './helpers/index.js';
+} from '@test/handlers/tool-configs/universal/helpers/index.js';
 
 describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
   let searchByContentConfig: any;
@@ -21,7 +21,7 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
 
     // Import after mocks are set up
     const advancedOps = await import(
-      '../../../../src/handlers/tool-configs/universal/advanced-operations.js'
+      '@handlers/tool-configs/universal/advanced-operations.js'
     );
     searchByContentConfig = advancedOps.searchByContentConfig;
     searchByTimeframeConfig = advancedOps.searchByTimeframeConfig;
@@ -142,7 +142,7 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
         UniversalResourceType.COMPANIES
       );
 
-      expect(formatted).toContain('Found 1 companys with matching notes');
+      expect(formatted).toContain('Found 1 company with matching notes');
       expect(formatted).toContain('1. Company with Content (ID: comp-1)');
     });
 
@@ -299,7 +299,7 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
         UniversalResourceType.PEOPLE
       );
 
-      expect(formatted).toContain('Found 1 persons by created');
+      expect(formatted).toContain('Found 1 person by created');
       expect(formatted).toContain(
         '1. Test Person (created: 12/1/2023) (ID: person-1)'
       );


### PR DESCRIPTION
## Summary
- ensure universal content and timeframe search formatters use path aliases and proper singular/plural labels
- update batch search summary to pluralize resource names correctly
- adjust unit tests to match corrected phrasing and alias imports

## Testing
- npx vitest run test/handlers/tool-configs/universal/advanced-operations-content.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d86d028ae88325a19a922e8945ee3c