### PR TITLE
Feature: Add Developer Mode MCP support

### DIFF
--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -36,6 +36,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/workflows/claude/
+          sparse-checkout-cone-mode: false
+
       - name: Classify command
         id: classify
         run: |
@@ -74,7 +81,7 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout repository
+      - name: Full checkout for command execution
         if: steps.classify.outputs.should_run == 'true' && steps.classify.outputs.is_maintainer == 'true' && steps.classify.outputs.command_type != 'review'
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude-comment-gate.yml
+++ b/.github/workflows/claude-comment-gate.yml
@@ -36,6 +36,13 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/workflows/claude/
+          sparse-checkout-cone-mode: false
+
       - name: Detect review command
         id: classify
         run: |

--- a/.github/workflows/claude-comment-gate.yml
+++ b/.github/workflows/claude-comment-gate.yml
@@ -58,12 +58,12 @@ jobs:
           CLAUDE_TRIGGER_PHRASE: '@claude'
 
       - name: Exit if not review
-        if: steps.classify.outputs.isReview != 'true'
+        if: steps.classify.outputs.isReview != 'ultra' && steps.classify.outputs.isReview != 'review'
         run: |
           echo 'Not a review trigger; leaving for command workflow.'
 
       - name: Validate CLAUDE_GATE_TOKEN
-        if: steps.classify.outputs.isReview == 'true'
+        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
         run: |
           if [ -z "${{ secrets.CLAUDE_GATE_TOKEN }}" ]; then
             echo "::error::CLAUDE_GATE_TOKEN not set (repo → Settings → Secrets and variables → Actions)"
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: Who am I (should be your PAT user)
-        if: steps.classify.outputs.isReview == 'true'
+        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.CLAUDE_GATE_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
             }
 
       - name: Extract PR number + intent
-        if: steps.classify.outputs.isReview == 'true'
+        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
         id: info
         uses: actions/github-script@v7
         env:
@@ -121,7 +121,7 @@ jobs:
             core.setOutput('rerun', String(rerun));
 
       - name: Guard - only maintainers may trigger Claude reviews
-        if: steps.classify.outputs.isReview == 'true'
+        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
         id: guard
         uses: actions/github-script@v7
         env:
@@ -147,7 +147,7 @@ jobs:
             }
 
       - name: Ensure label exists
-        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
+        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
         uses: actions/github-script@v7
         with:
           # Use validated PAT to trigger downstream workflows
@@ -171,7 +171,7 @@ jobs:
             }
 
       - name: Add or toggle label (handles re-review)
-        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
+        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
         id: relabel
         uses: actions/github-script@v7
         with:
@@ -219,7 +219,7 @@ jobs:
             core.setOutput('action', 'already-queued');
 
       - name: Acknowledge
-        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
+        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
         uses: actions/github-script@v7
         with:
           # Use validated PAT to trigger downstream workflows
@@ -238,7 +238,7 @@ jobs:
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number, body });
 
       - name: Kick off review (dispatch)
-        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
+        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.CLAUDE_GATE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Transform your CRM workflows with AI-powered automation. Instead of clicking thr
 - **Legacy Tools**: Available via `DISABLE_UNIVERSAL_TOOLS=true` environment variable (deprecated)
 - **Lists API**: Fully functional with complete CRUD operations (contrary to some outdated documentation)
 
+### 🤝 **OpenAI MCP Compatibility**
+
+- **Developer Mode Ready**: Every tool now publishes MCP safety annotations (`readOnlyHint`, `destructiveHint`) so OpenAI Developer Mode can auto-approve reads and request confirmation for writes.
+- **Search Compatibility Surface**: The `search` and `fetch` tools remain available for OpenAI’s baseline MCP support. Set `ATTIO_MCP_TOOL_MODE=search` to expose only these read-only endpoints (plus health checks) when Developer Mode is unavailable.
+- **Default Behaviour**: With `ATTIO_MCP_TOOL_MODE` unset, the full universal tool set is exposed—matching Claude’s experience—while OpenAI users still see the compatibility wrappers.
+- **User Documentation**: See the “ChatGPT Developer Mode” docs (coming soon) for a walkthrough of the approval flows and recommended tool descriptions.
+
 ### **Performance Considerations**
 
 - **Batch Operations**: Optimized with chunking, rate limiting, and error recovery

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Transform your CRM workflows with AI-powered automation. Instead of clicking thr
 - **Developer Mode Ready**: Every tool now publishes MCP safety annotations (`readOnlyHint`, `destructiveHint`) so OpenAI Developer Mode can auto-approve reads and request confirmation for writes.
 - **Search Compatibility Surface**: The `search` and `fetch` tools remain available for OpenAI’s baseline MCP support. Set `ATTIO_MCP_TOOL_MODE=search` to expose only these read-only endpoints (plus health checks) when Developer Mode is unavailable.
 - **Default Behaviour**: With `ATTIO_MCP_TOOL_MODE` unset, the full universal tool set is exposed—matching Claude’s experience—while OpenAI users still see the compatibility wrappers.
+- **Detailed Guide**: See [docs/chatgpt-developer-mode.md](./docs/chatgpt-developer-mode.md) for environment variables, approval flows, and validation tips.
 - **User Documentation**: See the “ChatGPT Developer Mode” docs (coming soon) for a walkthrough of the approval flows and recommended tool descriptions.
 
 ### **Performance Considerations**

--- a/docs/chatgpt-developer-mode.md
+++ b/docs/chatgpt-developer-mode.md
@@ -1,0 +1,94 @@
+# ChatGPT Developer Mode Integration
+
+This guide explains how to expose the Attio MCP server to ChatGPT users in two configurations:
+
+1. **Full Developer Mode** – Pro/Plus accounts with the Developer Mode beta enabled can access the entire Attio toolset, including write operations, with built-in approval flows.
+2. **Search-Only Compatibility** – For accounts without Developer Mode, expose a minimal `search`/`fetch` surface that mirrors OpenAI’s baseline MCP requirements.
+
+The server now publishes MCP safety annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) on every tool definition so ChatGPT can make informed approval decisions.
+
+---
+
+## 1. Requirements
+
+| Scenario       | Requirements                                                                                               |
+| -------------- | ---------------------------------------------------------------------------------------------------------- |
+| Developer Mode | ChatGPT Pro/Plus subscription, browser access, _Settings → Connectors → Advanced → Developer Mode_ enabled |
+| Search Only    | Any ChatGPT account that supports custom connectors                                                        |
+
+### Server prerequisites
+
+- Publicly accessible HTTPS endpoint (or a tunnel such as `smithery dev --public` during development).
+- Standard MCP transport (STDIO is fine locally, Smithery or your hosting provider for production).
+- Set `ATTIO_API_KEY`/`ATTIO_WORKSPACE_ID` for Attio API access.
+
+---
+
+## 2. Enabling Developer Mode Access
+
+1. **Expose the full tool catalogue** (do _not_ set `ATTIO_MCP_TOOL_MODE`).
+2. Deploy the server (see the main README for deployment options).
+3. In ChatGPT:
+   - Open **Settings → Connectors → Advanced**.
+   - Enable **Developer Mode**.
+   - Add the Attio MCP server URL.
+4. ChatGPT will automatically:
+   - Auto-approve tools with `readOnlyHint: true` (e.g. `search-records`, `get-record-details`).
+   - Prompt for approval on write tools (`create-record`, `update-record`) and destructive tools (`delete-record`).
+
+### Approval messaging tips
+
+- Tool descriptions should clearly explain the effect of the operation (e.g. “Create a new Attio contact”).
+- Validation errors should mention that approval may be required (we already surface this in handler responses).
+
+---
+
+## 3. Search-Only Compatibility Mode
+
+Set the environment variable:
+
+```bash
+export ATTIO_MCP_TOOL_MODE=search
+```
+
+When this flag is present the server will only advertise:
+
+| Tool                              | Behaviour                                                                                                |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `search`                          | Delegates to the universal search service and returns JSON-encoded results in a single text content item |
+| `fetch`                           | Retrieves the full record payload for a search result ID                                                 |
+| `health-check`/`aaa-health-check` | Simple readiness probes                                                                                  |
+
+All other tools are filtered out at registry time and ignored by the dispatcher. This is ideal for accounts without Developer Mode or for a constrained roll-out.
+
+Unset the variable (or set it to any value other than `search`) to restore the full tool catalogue.
+
+---
+
+## 4. Testing Matrix
+
+| Mode           | Suggested Tests                                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Developer Mode | `npm test -- --run test/services/openai-compatibility.service.test.ts`, plus manual validation in ChatGPT Developer Mode |
+| Search-only    | Same test suite plus a quick `list_tools` in ChatGPT to confirm only `search`/`fetch` are visible                        |
+
+> **Note:** Full MCP end-to-end suites still require Attio API credentials. Run them before production rollout (`npm test`) or rely on CI where the secrets are available.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom                                            | Likely Cause                                                                  | Fix                                                                |
+| -------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| ChatGPT requests consent for read-only tools       | `readOnlyHint` missing                                                        | Confirm you are running a version that includes safety annotations |
+| ChatGPT cannot see write tools                     | Running with `ATTIO_MCP_TOOL_MODE=search`                                     | Unset the variable for full access                                 |
+| `search` returns no results                        | Ensure Attio API credentials are set and universal search works in Claude/CLI |
+| PR validation fails with missing Attio credentials | Expected if secrets are not available locally; see `README.md` testing notes  |
+
+---
+
+## 6. Next Steps
+
+- Monitor approval logs to verify the safety flow.
+- Add targeted UI messaging in ChatGPT descriptions for high-risk tools (`delete-record`, `batch-operations`).
+- Expand the test suite with real Developer Mode integration tests once mocked approval APIs become available.

--- a/src/config/tool-mode.ts
+++ b/src/config/tool-mode.ts
@@ -1,0 +1,47 @@
+/**
+ * Determines which MCP tool set should be exposed to clients.
+ *
+ * By default we expose the complete universal tool catalogue. Setting
+ * `ATTIO_MCP_TOOL_MODE=search` limits the surface area to the lightweight
+ * search/fetch compatibility tools that match OpenAI's baseline MCP support.
+ */
+
+const SEARCH_ONLY_ENV_VALUE = 'search';
+
+const SEARCH_ONLY_TOOL_NAMES = new Set([
+  'search',
+  'fetch',
+  'aaa-health-check',
+  'health-check',
+]);
+
+/**
+ * Returns true when the server should run in search-only compatibility mode.
+ */
+export function isSearchOnlyMode(): boolean {
+  const mode = (process.env.ATTIO_MCP_TOOL_MODE ?? '').toLowerCase();
+  return mode === SEARCH_ONLY_ENV_VALUE;
+}
+
+/**
+ * Determines whether a given tool name may be exposed in the current mode.
+ */
+export function isToolAllowed(toolName: string): boolean {
+  if (!isSearchOnlyMode()) {
+    return true;
+  }
+  return SEARCH_ONLY_TOOL_NAMES.has(toolName);
+}
+
+/**
+ * Filters an array of tool definitions/configurations so only the allowed
+ * tools are returned for the active server mode.
+ */
+export function filterAllowedTools<T extends { name: string }>(
+  tools: T[]
+): T[] {
+  if (!isSearchOnlyMode()) {
+    return tools;
+  }
+  return tools.filter((tool) => isToolAllowed(tool.name));
+}

--- a/src/handlers/tool-configs/openai/index.ts
+++ b/src/handlers/tool-configs/openai/index.ts
@@ -1,0 +1,156 @@
+import { z } from 'zod';
+import { ToolConfig } from '../../tool-types.js';
+import {
+  OpenAiCompatibilityService,
+  OpenAiSearchParams,
+} from '../../../services/OpenAiCompatibilityService.js';
+
+const searchParamsValidator = z.object({
+  query: z.string().min(1, 'Query is required'),
+  type: z.enum(['companies', 'people', 'lists', 'tasks', 'all']).optional(),
+  limit: z.number().int().positive().max(25).optional(),
+});
+
+const fetchParamsValidator = z.object({
+  id: z.string().min(1, 'Identifier is required'),
+});
+
+const searchInputSchema = {
+  type: 'object' as const,
+  properties: {
+    query: {
+      type: 'string' as const,
+      description: 'Search query string (required).',
+    },
+    type: {
+      type: 'string' as const,
+      enum: ['companies', 'people', 'lists', 'tasks', 'all'] as const,
+      description: 'Optional resource filter (defaults to all).',
+    },
+    limit: {
+      type: 'integer' as const,
+      minimum: 1,
+      maximum: 25,
+      description: 'Maximum number of results to return (default 10).',
+    },
+  },
+  required: ['query'] as const,
+  additionalProperties: false,
+};
+
+const fetchInputSchema = {
+  type: 'object' as const,
+  properties: {
+    id: {
+      type: 'string' as const,
+      description: 'Identifier emitted by the search tool (<resource>:<id>).',
+    },
+  },
+  required: ['id'] as const,
+  additionalProperties: false,
+};
+
+async function handleSearch(params: unknown) {
+  try {
+    const validated = searchParamsValidator.parse(params) as OpenAiSearchParams;
+    const results = await OpenAiCompatibilityService.search(validated);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ results }),
+        },
+      ],
+      isError: false,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown search error';
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Search failed: ${message}`,
+        },
+      ],
+      isError: true,
+      error: {
+        code: 400,
+        message,
+        type: 'openai_search_error',
+      },
+    };
+  }
+}
+
+async function handleFetch(params: unknown) {
+  try {
+    const validated = fetchParamsValidator.parse(params);
+    const result = await OpenAiCompatibilityService.fetch(validated.id);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(result),
+        },
+      ],
+      isError: false,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown fetch error';
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Fetch failed: ${message}`,
+        },
+      ],
+      isError: true,
+      error: {
+        code: 400,
+        message,
+        type: 'openai_fetch_error',
+      },
+    };
+  }
+}
+
+const searchToolConfig: ToolConfig = {
+  name: 'search',
+  handler: handleSearch,
+  formatResult: (result: { results?: unknown }) =>
+    JSON.stringify(result ?? {}, null, 2),
+};
+
+const fetchToolConfig: ToolConfig = {
+  name: 'fetch',
+  handler: handleFetch,
+  formatResult: (result: unknown) => JSON.stringify(result ?? {}, null, 2),
+};
+
+export const openAiToolConfigs = {
+  'openai-search': searchToolConfig,
+  'openai-fetch': fetchToolConfig,
+} as const;
+
+export const openAiToolDefinitions = {
+  'openai-search': {
+    name: 'search',
+    description: 'Search Attio data by query for OpenAI MCP clients.',
+    inputSchema: searchInputSchema,
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+  },
+  'openai-fetch': {
+    name: 'fetch',
+    description: 'Retrieve the full record payload for a search result ID.',
+    inputSchema: fetchInputSchema,
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+  },
+} as const;

--- a/src/handlers/tool-configs/universal/batch-search.ts
+++ b/src/handlers/tool-configs/universal/batch-search.ts
@@ -202,4 +202,8 @@ export const batchSearchToolDefinition = {
   description:
     'Perform batch search operations with multiple queries in parallel',
   inputSchema: batchSearchSchema,
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
 };

--- a/src/handlers/tool-configs/universal/core/crud-operations.ts
+++ b/src/handlers/tool-configs/universal/core/crud-operations.ts
@@ -240,16 +240,28 @@ export const createRecordDefinition = {
   name: 'create-record',
   description: 'Create a new record of any supported type',
   inputSchema: createRecordSchema,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
 };
 
 export const updateRecordDefinition = {
   name: 'update-record',
   description: 'Update an existing record of any supported type',
   inputSchema: updateRecordSchema,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
 };
 
 export const deleteRecordDefinition = {
   name: 'delete-record',
   description: 'Delete a record of any supported type',
   inputSchema: deleteRecordSchema,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+  },
 };

--- a/src/handlers/tool-configs/universal/core/detailed-info-operations.ts
+++ b/src/handlers/tool-configs/universal/core/detailed-info-operations.ts
@@ -84,4 +84,8 @@ export const getDetailedInfoDefinition = {
   description:
     'Get specific types of detailed information (contact, business, social)',
   inputSchema: getDetailedInfoSchema,
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
 };

--- a/src/handlers/tool-configs/universal/core/metadata-operations.ts
+++ b/src/handlers/tool-configs/universal/core/metadata-operations.ts
@@ -241,10 +241,18 @@ export const getAttributesDefinition = {
   description:
     'Get attributes for any resource type (companies, people, lists, records, tasks, deals, notes)',
   inputSchema: getAttributesSchema,
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
 };
 
 export const discoverAttributesDefinition = {
   name: 'discover-attributes',
   description: 'Discover available attributes for any resource type',
   inputSchema: discoverAttributesSchema,
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
 };

--- a/src/handlers/tool-configs/universal/core/notes-operations.ts
+++ b/src/handlers/tool-configs/universal/core/notes-operations.ts
@@ -126,10 +126,18 @@ export const createNoteDefinition = {
   name: 'create-note',
   description: 'Create a note for any record type (companies, people, deals)',
   inputSchema: createNoteSchema,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
 };
 
 export const listNotesDefinition = {
   name: 'list-notes',
   description: 'Get notes for any record type (companies, people, deals)',
   inputSchema: listNotesSchema,
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
 };

--- a/src/handlers/tool-configs/universal/core/record-details-operations.ts
+++ b/src/handlers/tool-configs/universal/core/record-details-operations.ts
@@ -157,4 +157,8 @@ export const getRecordDetailsDefinition = {
   name: 'get-record-details',
   description: 'Get detailed information for any record type',
   inputSchema: getRecordDetailsSchema,
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
 };

--- a/src/handlers/tool-configs/universal/core/search-operations.ts
+++ b/src/handlers/tool-configs/universal/core/search-operations.ts
@@ -147,4 +147,8 @@ export const searchRecordsDefinition = {
   description:
     'Universal search across all resource types (companies, people, records, tasks)',
   inputSchema: searchRecordsSchema,
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
 };

--- a/src/handlers/tool-configs/universal/index.ts
+++ b/src/handlers/tool-configs/universal/index.ts
@@ -22,6 +22,7 @@ import {
   batchSearchConfig,
   batchSearchToolDefinition,
 } from './batch-search.js';
+import { openAiToolConfigs, openAiToolDefinitions } from '../openai/index.js';
 
 /**
  * Simple no-auth health-check tool to support unauthenticated capability scanning
@@ -34,6 +35,10 @@ export const healthCheckToolDefinition = {
     type: 'object',
     properties: {},
     additionalProperties: true,
+  },
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
   },
 };
 
@@ -48,6 +53,10 @@ export const healthCheckAliasToolDefinition = {
     type: 'object',
     properties: {},
     additionalProperties: true,
+  },
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
   },
 };
 
@@ -120,6 +129,7 @@ export const universalToolConfigs = {
   ...coreOperationsToolConfigs,
   ...advancedOperationsToolConfigs,
   'batch-search': batchSearchConfig,
+  ...openAiToolConfigs,
 };
 
 /**
@@ -133,6 +143,7 @@ export const universalToolDefinitions = {
   ...coreOperationsToolDefinitions,
   ...advancedOperationsToolDefinitions,
   'batch-search': batchSearchToolDefinition,
+  ...openAiToolDefinitions,
 };
 
 /**

--- a/src/handlers/tool-configs/universal/operations/index.ts
+++ b/src/handlers/tool-configs/universal/operations/index.ts
@@ -31,28 +31,48 @@ export const advancedOperationsToolDefinitions = {
     description:
       'Advanced search with complex filtering across all resource types',
     inputSchema: advancedSearchSchema,
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
   },
   'search-by-relationship': {
     name: 'search-by-relationship',
     description: 'Search records by their relationships to other entities',
     inputSchema: searchByRelationshipSchema,
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
   },
   'search-by-content': {
     name: 'search-by-content',
     description: 'Search within notes, activity, and interaction content',
     inputSchema: searchByContentSchema,
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
   },
   'search-by-timeframe': {
     name: 'search-by-timeframe',
     description:
       'Search records by temporal criteria (creation, modification, interaction dates)',
     inputSchema: searchByTimeframeSchema,
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
   },
   'batch-operations': {
     name: 'batch-operations',
     description:
       'Perform bulk operations (create, update, delete, get, search)',
     inputSchema: batchOperationsSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
   },
 };
 

--- a/src/handlers/tools/index.ts
+++ b/src/handlers/tools/index.ts
@@ -13,6 +13,7 @@ import { ServerContext } from '../../server/createServer.js';
 import { setGlobalContext } from '../../api/lazy-client.js';
 
 // Import from modular components
+import { filterAllowedTools } from '../../config/tool-mode.js';
 import { TOOL_DEFINITIONS } from './registry.js';
 import { executeToolRequest } from './dispatcher.js';
 
@@ -154,8 +155,9 @@ export function registerToolHandlers(
       }
     }
 
+    const tools = filterAllowedTools(allTools);
     return {
-      tools: allTools,
+      tools,
     };
   });
 

--- a/src/handlers/tools/registry.ts
+++ b/src/handlers/tools/registry.ts
@@ -4,6 +4,7 @@
 import { ResourceType } from '../../types/attio.js';
 import { ToolConfig } from '../tool-types.js';
 import { createScopedLogger } from '../../utils/logger.js';
+import { isToolAllowed } from '../../config/tool-mode.js';
 
 // Type for return values that can include special resource markers
 type ToolConfigResult = {
@@ -190,11 +191,14 @@ export function findToolConfig(toolName: string): ToolConfigResult | undefined {
           });
         }
 
-        return {
-          resourceType: resourceType as ResourceType,
-          toolConfig: config as ToolConfig,
-          toolType,
-        };
+        if (isToolAllowed(toolName)) {
+          return {
+            resourceType: resourceType as ResourceType,
+            toolConfig: config as ToolConfig,
+            toolType,
+          };
+        }
+        return undefined;
       }
     }
   }
@@ -208,11 +212,14 @@ export function findToolConfig(toolName: string): ToolConfigResult | undefined {
           log.info('Found universal tool', { toolName, toolType });
         }
 
-        return {
-          resourceType: 'UNIVERSAL' as const,
-          toolConfig: config as ToolConfig,
-          toolType,
-        };
+        if (isToolAllowed(toolName)) {
+          return {
+            resourceType: 'UNIVERSAL' as const,
+            toolConfig: config as ToolConfig,
+            toolType,
+          };
+        }
+        return undefined;
       }
     }
   }
@@ -226,11 +233,14 @@ export function findToolConfig(toolName: string): ToolConfigResult | undefined {
           log.info('Found general tool', { toolName, toolType });
         }
 
-        return {
-          resourceType: 'GENERAL' as const,
-          toolConfig: config as ToolConfig,
-          toolType,
-        };
+        if (isToolAllowed(toolName)) {
+          return {
+            resourceType: 'GENERAL' as const,
+            toolConfig: config as ToolConfig,
+            toolType,
+          };
+        }
+        return undefined;
       }
     }
   }

--- a/src/services/OpenAiCompatibilityService.ts
+++ b/src/services/OpenAiCompatibilityService.ts
@@ -1,0 +1,265 @@
+/**
+ * OpenAI compatibility helpers – expose the universal search + retrieval stack
+ * using the `search`/`fetch` contract that non-Developer-Mode ChatGPT accounts
+ * expect. All logic delegates to the existing universal services so we keep a
+ * single behaviour surface for every client.
+ */
+import { UniversalSearchService } from './UniversalSearchService.js';
+import { UniversalRetrievalService } from './UniversalRetrievalService.js';
+import {
+  UniversalResourceType,
+  UniversalSearchParams,
+  SearchType,
+  MatchType,
+  SortType,
+} from '../handlers/tool-configs/universal/types.js';
+import type { AttioRecord } from '../types/attio.js';
+import { SearchUtilities } from './search-utilities/SearchUtilities.js';
+import { safeJsonStringify } from '../utils/json-serializer.js';
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 25;
+
+const RESOURCE_API_PATH: Partial<Record<UniversalResourceType, string>> = {
+  [UniversalResourceType.COMPANIES]: 'objects/companies/records',
+  [UniversalResourceType.PEOPLE]: 'objects/people/records',
+  [UniversalResourceType.LISTS]: 'lists',
+  [UniversalResourceType.TASKS]: 'tasks',
+};
+
+const SEARCH_RESOURCE_MAP: Record<
+  'companies' | 'people' | 'lists' | 'tasks' | 'all',
+  UniversalResourceType[]
+> = {
+  companies: [UniversalResourceType.COMPANIES],
+  people: [UniversalResourceType.PEOPLE],
+  lists: [UniversalResourceType.LISTS],
+  tasks: [UniversalResourceType.TASKS],
+  all: [
+    UniversalResourceType.COMPANIES,
+    UniversalResourceType.PEOPLE,
+    UniversalResourceType.LISTS,
+    UniversalResourceType.TASKS,
+  ],
+};
+
+export interface OpenAiSearchParams {
+  query: string;
+  type?: keyof typeof SEARCH_RESOURCE_MAP;
+  limit?: number;
+}
+
+export interface OpenAiSearchResult {
+  id: string;
+  title: string;
+  url: string;
+  snippet?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OpenAiFetchResult {
+  id: string;
+  title: string;
+  url: string;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export class OpenAiCompatibilityService {
+  static async search(
+    params: OpenAiSearchParams
+  ): Promise<OpenAiSearchResult[]> {
+    const query = params.query?.trim();
+    if (!query) {
+      throw new Error('Query must be provided');
+    }
+
+    const typeKey = (
+      params.type ?? 'all'
+    ).toLowerCase() as keyof typeof SEARCH_RESOURCE_MAP;
+    const resourceTypes =
+      SEARCH_RESOURCE_MAP[typeKey] ?? SEARCH_RESOURCE_MAP.all;
+
+    const requestedLimit = params.limit ?? DEFAULT_LIMIT;
+    const limit = Math.min(Math.max(requestedLimit, 1), MAX_LIMIT);
+    const perTypeLimit = Math.max(1, Math.ceil(limit / resourceTypes.length));
+
+    const aggregated: OpenAiSearchResult[] = [];
+
+    for (const resourceType of resourceTypes) {
+      const searchParams: UniversalSearchParams = {
+        resource_type: resourceType,
+        query,
+        limit: perTypeLimit,
+        search_type: SearchType.BASIC,
+        match_type: MatchType.PARTIAL,
+        sort: SortType.RELEVANCE,
+      };
+
+      const records = await UniversalSearchService.searchRecords(searchParams);
+      aggregated.push(
+        ...records.map((record) =>
+          transformRecordToSearchResult(resourceType, record)
+        )
+      );
+    }
+
+    return aggregated.slice(0, limit);
+  }
+
+  static async fetch(id: string): Promise<OpenAiFetchResult> {
+    const { resourceType, recordId } = parseCompoundId(id);
+
+    const record = await UniversalRetrievalService.getRecordDetails({
+      resource_type: resourceType,
+      record_id: recordId,
+    });
+
+    return transformRecordToFetchResult(resourceType, record);
+  }
+}
+
+function parseCompoundId(id: string): {
+  resourceType: UniversalResourceType;
+  recordId: string;
+} {
+  if (!id || !id.includes(':')) {
+    throw new Error(
+      'Expected identifier format "<resource_type>:<record_id>" (e.g. companies:1234)'
+    );
+  }
+
+  const [rawType, ...rest] = id.split(':');
+  const recordId = rest.join(':');
+  if (!recordId) {
+    throw new Error('Record identifier is missing');
+  }
+
+  const resourceType = normalizeResourceType(rawType);
+  return { resourceType, recordId };
+}
+
+function normalizeResourceType(value: string): UniversalResourceType {
+  switch (value.toLowerCase()) {
+    case 'companies':
+      return UniversalResourceType.COMPANIES;
+    case 'people':
+      return UniversalResourceType.PEOPLE;
+    case 'lists':
+      return UniversalResourceType.LISTS;
+    case 'tasks':
+      return UniversalResourceType.TASKS;
+    default:
+      throw new Error(`Unsupported resource type: ${value}`);
+  }
+}
+
+function transformRecordToSearchResult(
+  resourceType: UniversalResourceType,
+  record: AttioRecord
+): OpenAiSearchResult {
+  const recordId = record.id?.record_id ?? 'unknown';
+  return {
+    id: `${resourceType}:${recordId}`,
+    title: buildTitle(resourceType, record),
+    url: buildApiUrl(resourceType, recordId),
+    snippet: buildSnippet(resourceType, record),
+    metadata: {
+      resource_type: resourceType,
+    },
+  };
+}
+
+function transformRecordToFetchResult(
+  resourceType: UniversalResourceType,
+  record: AttioRecord
+): OpenAiFetchResult {
+  const recordId = record.id?.record_id ?? 'unknown';
+  return {
+    id: `${resourceType}:${recordId}`,
+    title: buildTitle(resourceType, record),
+    url: buildApiUrl(resourceType, recordId),
+    text: safeJsonStringify(record, { indent: 2 }),
+    metadata: {
+      resource_type: resourceType,
+    },
+  };
+}
+
+function buildTitle(
+  resourceType: UniversalResourceType,
+  record: AttioRecord
+): string {
+  switch (resourceType) {
+    case UniversalResourceType.COMPANIES:
+      return (
+        SearchUtilities.getFieldValue(record, 'name') ||
+        SearchUtilities.getFieldValue(record, 'legal_name') ||
+        `Company ${record.id?.record_id ?? ''}`.trim()
+      );
+    case UniversalResourceType.PEOPLE:
+      return (
+        SearchUtilities.getFieldValue(record, 'name') ||
+        SearchUtilities.getFieldValue(record, 'full_name') ||
+        `Person ${record.id?.record_id ?? ''}`.trim()
+      );
+    case UniversalResourceType.LISTS:
+      return (
+        SearchUtilities.getFieldValue(record, 'name') ||
+        `List ${record.id?.record_id ?? ''}`.trim()
+      );
+    case UniversalResourceType.TASKS:
+      return (
+        SearchUtilities.getFieldValue(record, 'content') ||
+        SearchUtilities.getFieldValue(record, 'title') ||
+        `Task ${record.id?.record_id ?? ''}`.trim()
+      );
+    default:
+      return `Record ${record.id?.record_id ?? ''}`.trim();
+  }
+}
+
+function buildSnippet(
+  resourceType: UniversalResourceType,
+  record: AttioRecord
+): string | undefined {
+  if (resourceType === UniversalResourceType.COMPANIES) {
+    return firstNonEmpty([
+      SearchUtilities.getFieldValue(record, 'description'),
+      SearchUtilities.getFieldValue(record, 'about'),
+      SearchUtilities.getFieldValue(record, 'industry'),
+    ]);
+  }
+
+  if (resourceType === UniversalResourceType.PEOPLE) {
+    return firstNonEmpty([
+      SearchUtilities.getFieldValue(record, 'job_title'),
+      SearchUtilities.getFieldValue(record, 'role'),
+      SearchUtilities.getFieldValue(record, 'headline'),
+    ]);
+  }
+
+  if (resourceType === UniversalResourceType.TASKS) {
+    return firstNonEmpty([
+      SearchUtilities.getFieldValue(record, 'status'),
+      SearchUtilities.getFieldValue(record, 'due_date'),
+    ]);
+  }
+
+  return undefined;
+}
+
+function firstNonEmpty(values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value && value.trim().length > 0);
+}
+
+function buildApiUrl(
+  resourceType: UniversalResourceType,
+  recordId: string
+): string {
+  const path = RESOURCE_API_PATH[resourceType];
+  if (!path) {
+    return `https://api.attio.com/v2/${recordId}`;
+  }
+  return `https://api.attio.com/v2/${path}/${recordId}`;
+}

--- a/src/validators/company/index.ts
+++ b/src/validators/company/index.ts
@@ -216,8 +216,8 @@ export class CompanyValidator {
       processedValue &&
       typeof processedValue === 'string'
     ) {
-      LinkedInUrlValidator.validate(processedValue);
       const url = ensureSafeUrl(processedValue, 'LinkedIn URL');
+      LinkedInUrlValidator.validate(processedValue);
       if (!isLinkedInHostname(url.hostname)) {
         throw new InvalidCompanyDataError(
           'LinkedIn URL must be a valid LinkedIn URL'
@@ -333,8 +333,8 @@ export class CompanyValidator {
       attributes.linkedin_url &&
       typeof attributes.linkedin_url === 'string'
     ) {
-      LinkedInUrlValidator.validate(attributes.linkedin_url);
       const url = ensureSafeUrl(attributes.linkedin_url, 'LinkedIn URL');
+      LinkedInUrlValidator.validate(attributes.linkedin_url);
       if (!isLinkedInHostname(url.hostname)) {
         throw new InvalidCompanyDataError(
           'LinkedIn URL must be a valid LinkedIn URL'

--- a/test/config/tool-mode.test.ts
+++ b/test/config/tool-mode.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  filterAllowedTools,
+  isSearchOnlyMode,
+  isToolAllowed,
+} from '@/config/tool-mode.js';
+
+const originalMode = process.env.ATTIO_MCP_TOOL_MODE;
+
+afterEach(() => {
+  if (originalMode === undefined) {
+    delete process.env.ATTIO_MCP_TOOL_MODE;
+  } else {
+    process.env.ATTIO_MCP_TOOL_MODE = originalMode;
+  }
+});
+
+describe('tool mode configuration', () => {
+  it('returns false for search-only mode by default', () => {
+    delete process.env.ATTIO_MCP_TOOL_MODE;
+    expect(isSearchOnlyMode()).toBe(false);
+  });
+
+  it('filters tools when ATTIO_MCP_TOOL_MODE=search', () => {
+    process.env.ATTIO_MCP_TOOL_MODE = 'search';
+
+    expect(isSearchOnlyMode()).toBe(true);
+    expect(isToolAllowed('search')).toBe(true);
+    expect(isToolAllowed('create-record')).toBe(false);
+
+    const filtered = filterAllowedTools([
+      { name: 'search' },
+      { name: 'create-record' },
+      { name: 'fetch' },
+    ]);
+
+    expect(filtered.map((tool) => tool.name)).toEqual(['search', 'fetch']);
+  });
+});

--- a/test/handlers/tool-configs/openai/index.test.ts
+++ b/test/handlers/tool-configs/openai/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { openAiToolConfigs } from '@/handlers/tool-configs/openai/index.js';
+import { OpenAiCompatibilityService } from '@/services/OpenAiCompatibilityService.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OpenAI tool handlers', () => {
+  it('search handler returns MCP compliant payload', async () => {
+    vi.spyOn(OpenAiCompatibilityService, 'search').mockResolvedValue([
+      {
+        id: 'companies:123',
+        title: 'Acme Inc.',
+        url: 'https://api.attio.com/v2/objects/companies/records/123',
+      },
+    ]);
+
+    const handler = openAiToolConfigs['openai-search'].handler;
+    const response = await handler({ query: 'acme' });
+
+    expect(response.isError).toBe(false);
+    const payload = JSON.parse(response.content?.[0]?.text ?? '{}');
+    expect(payload.results).toHaveLength(1);
+  });
+
+  it('fetch handler surfaces errors with MCP structure', async () => {
+    vi.spyOn(OpenAiCompatibilityService, 'fetch').mockRejectedValue(
+      new Error('Unsupported resource type')
+    );
+
+    const handler = openAiToolConfigs['openai-fetch'].handler;
+    const response = await handler({ id: 'bad:id' });
+
+    expect(response.isError).toBe(true);
+    expect(response.error?.type).toBe('openai_fetch_error');
+  });
+});

--- a/test/handlers/tools/registry-mode.test.ts
+++ b/test/handlers/tools/registry-mode.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { findToolConfig } from '@/handlers/tools/registry.js';
+
+const originalMode = process.env.ATTIO_MCP_TOOL_MODE;
+
+afterEach(() => {
+  if (originalMode === undefined) {
+    delete process.env.ATTIO_MCP_TOOL_MODE;
+  } else {
+    process.env.ATTIO_MCP_TOOL_MODE = originalMode;
+  }
+});
+
+describe('findToolConfig in search-only mode', () => {
+  it('returns undefined for write tools when in search-only mode', () => {
+    process.env.ATTIO_MCP_TOOL_MODE = 'search';
+
+    expect(findToolConfig('create-record')).toBeUndefined();
+    expect(findToolConfig('search')).toBeDefined();
+  });
+});

--- a/test/services/openai-compatibility.service.test.ts
+++ b/test/services/openai-compatibility.service.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { OpenAiCompatibilityService } from '@/services/OpenAiCompatibilityService.js';
+import { UniversalSearchService } from '@/services/UniversalSearchService.js';
+import { UniversalRetrievalService } from '@/services/UniversalRetrievalService.js';
+import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
+import type { AttioRecord } from '@/types/attio.js';
+
+const companyRecord: AttioRecord = {
+  id: {
+    record_id: 'company-1',
+  },
+  values: {
+    name: [
+      {
+        value: 'Acme Inc.',
+      },
+    ],
+    description: [
+      {
+        value: 'Road-runner deterrent specialists',
+      },
+    ],
+  },
+};
+
+const personRecord: AttioRecord = {
+  id: {
+    record_id: 'person-1',
+  },
+  values: {
+    name: [
+      {
+        value: 'Wile E. Coyote',
+      },
+    ],
+    job_title: [
+      {
+        value: 'Inventor',
+      },
+    ],
+  },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OpenAiCompatibilityService.search', () => {
+  it('aggregates results across resource types', async () => {
+    const searchSpy = vi
+      .spyOn(UniversalSearchService, 'searchRecords')
+      .mockImplementation(async ({ resource_type }) => {
+        if (resource_type === UniversalResourceType.COMPANIES) {
+          return [companyRecord];
+        }
+
+        if (resource_type === UniversalResourceType.PEOPLE) {
+          return [personRecord];
+        }
+
+        return [];
+      });
+
+    const results = await OpenAiCompatibilityService.search({
+      query: 'acme',
+      type: 'all',
+      limit: 5,
+    });
+
+    expect(searchSpy).toHaveBeenCalled();
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      id: 'companies:company-1',
+      title: 'Acme Inc.',
+      url: 'https://api.attio.com/v2/objects/companies/records/company-1',
+    });
+    expect(results[1]).toMatchObject({
+      id: 'people:person-1',
+      title: 'Wile E. Coyote',
+    });
+  });
+
+  it('validates required query', async () => {
+    await expect(
+      OpenAiCompatibilityService.search({
+        // @ts-expect-error verifying runtime validation
+        query: '   ',
+      })
+    ).rejects.toThrow('Query must be provided');
+  });
+});
+
+describe('OpenAiCompatibilityService.fetch', () => {
+  it('returns a fetch payload with serialized record text', async () => {
+    vi.spyOn(UniversalRetrievalService, 'getRecordDetails').mockResolvedValue(
+      companyRecord
+    );
+
+    const result = await OpenAiCompatibilityService.fetch(
+      'companies:company-1'
+    );
+
+    expect(result).toMatchObject({
+      id: 'companies:company-1',
+      title: 'Acme Inc.',
+      url: 'https://api.attio.com/v2/objects/companies/records/company-1',
+    });
+    expect(result.text).toContain('Acme Inc.');
+  });
+
+  it('rejects malformed identifiers', async () => {
+    await expect(OpenAiCompatibilityService.fetch('bad-id')).rejects.toThrow(
+      'Expected identifier format'
+    );
+  });
+});

--- a/test/validators/company-validator-enhanced.test.ts
+++ b/test/validators/company-validator-enhanced.test.ts
@@ -379,7 +379,9 @@ describe('Enhanced Company Validator', () => {
           linkedin_url:
             'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
         })
-      ).rejects.toThrow('LinkedIn URL must use http or https protocol');
+      ).rejects.toThrow(
+        'Invalid company data: LinkedIn URL must use http or https protocol'
+      );
     });
 
     it('should reject LinkedIn URLs with deceptive hostnames', async () => {


### PR DESCRIPTION
## Summary
- add safety annotations and search-only capability gating to support ChatGPT Developer Mode alongside Claude
- introduce an OpenAI compatibility service plus search/fetch wrappers backed by the universal tooling
- document setup in docs/chatgpt-developer-mode.md and restore offline coverage

## Testing
- npm run test:offline
- npm test -- --run test/services/openai-compatibility.service.test.ts test/handlers/tool-configs/openai/index.test.ts test/config/tool-mode.test.ts test/handlers/tools/registry-mode.test.ts
- npm test # fails locally without Attio API credentials (expected)
