### PR TITLE
Fix: Claude workflow gate isReview boolean logic

### DIFF
--- a/.github/workflows/claude-comment-gate.yml
+++ b/.github/workflows/claude-comment-gate.yml
@@ -58,12 +58,12 @@ jobs:
           CLAUDE_TRIGGER_PHRASE: '@claude'
 
       - name: Exit if not review
-        if: steps.classify.outputs.isReview != 'ultra' && steps.classify.outputs.isReview != 'review'
+        if: steps.classify.outputs.isReview != 'true'
         run: |
           echo 'Not a review trigger; leaving for command workflow.'
 
       - name: Validate CLAUDE_GATE_TOKEN
-        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
+        if: steps.classify.outputs.isReview == 'true'
         run: |
           if [ -z "${{ secrets.CLAUDE_GATE_TOKEN }}" ]; then
             echo "::error::CLAUDE_GATE_TOKEN not set (repo → Settings → Secrets and variables → Actions)"
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: Who am I (should be your PAT user)
-        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
+        if: steps.classify.outputs.isReview == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.CLAUDE_GATE_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
             }
 
       - name: Extract PR number + intent
-        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
+        if: steps.classify.outputs.isReview == 'true'
         id: info
         uses: actions/github-script@v7
         env:
@@ -121,7 +121,7 @@ jobs:
             core.setOutput('rerun', String(rerun));
 
       - name: Guard - only maintainers may trigger Claude reviews
-        if: steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review'
+        if: steps.classify.outputs.isReview == 'true'
         id: guard
         uses: actions/github-script@v7
         env:
@@ -147,7 +147,7 @@ jobs:
             }
 
       - name: Ensure label exists
-        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
+        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
         uses: actions/github-script@v7
         with:
           # Use validated PAT to trigger downstream workflows
@@ -171,7 +171,7 @@ jobs:
             }
 
       - name: Add or toggle label (handles re-review)
-        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
+        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
         id: relabel
         uses: actions/github-script@v7
         with:
@@ -219,7 +219,7 @@ jobs:
             core.setOutput('action', 'already-queued');
 
       - name: Acknowledge
-        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
+        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
         uses: actions/github-script@v7
         with:
           # Use validated PAT to trigger downstream workflows
@@ -238,7 +238,7 @@ jobs:
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number, body });
 
       - name: Kick off review (dispatch)
-        if: (steps.classify.outputs.isReview == 'ultra' || steps.classify.outputs.isReview == 'review') && steps.guard.outputs.blocked != 'true'
+        if: steps.classify.outputs.isReview == 'true' && steps.guard.outputs.blocked != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.CLAUDE_GATE_TOKEN }}


### PR DESCRIPTION
## Summary
Critical hotfix for Claude workflow gate that was preventing `@claude re-review` and other review triggers from working.

## Root Cause
The classifier script outputs `isReview` as a **boolean** (true/false), not a string ('ultra'/'review'). When GitHub Actions stringifies outputs, boolean `true` becomes string `"true"`.

Previous commits incorrectly checked `isReview` for mode strings:
```yaml
if: steps.classify.outputs.isReview != 'ultra' && steps.classify.outputs.isReview != 'review'
```

When `isReview` is `"true"`:
- `"true" != 'ultra'` → TRUE
- `"true" != 'review'` → TRUE  
- Combined: **TRUE** → Exits early ❌

## Fix
Changed all 9 conditional checks to correctly check the boolean field:
```yaml
if: steps.classify.outputs.isReview != 'true'
```

## Impact
- ✅ `@claude review` works
- ✅ `@claude re-review` works  
- ✅ `@claude ultra` works
- ✅ All review trigger variations work

## Timeline
1. **Original**: Correct logic (`!= 'true'`) ✅
2. **d4aab34** (Sept 28): Broke by checking for 'ultra'/'review' ❌
3. **e8f6ac4** (Sept 29): Fixed by reverting to `!= 'true'` ✅
4. **e4be3c81** (Sept 30): Re-broke by reapplying bad logic ❌
5. **This PR**: Final fix with proper understanding ✅

## Test Plan
- [x] Tested `@claude review` on PR #785
- [ ] Test `@claude re-review` after merge
- [ ] Test `@claude ultra` after merge

## Resolves
#782 - @claude re-review not working