### PR TITLE
Fix: Classifier isReview must return boolean, not string

### DIFF
--- a/scripts/workflows/claude/is-review-command.mjs
+++ b/scripts/workflows/claude/is-review-command.mjs
@@ -48,8 +48,9 @@ function main() {
       rerun = true;
     }
   }
-  const isReview =
-    Boolean(tokens.length) && (mode || rerun || tokens.includes('review'));
+  const isReview = Boolean(
+    tokens.length && (mode || rerun || tokens.includes('review'))
+  );
   process.stdout.write(
     JSON.stringify({
       isReview,


### PR DESCRIPTION
## Summary
**CRITICAL HOTFIX** - Fixes JavaScript bug in classifier causing `@claude review` commands to fail after PR #791.

## The Bug
JavaScript `&&` operator returns the **last truthy value**, not a boolean!

### Before (Broken):
```javascript
const isReview = Boolean(tokens.length) && (mode || rerun || tokens.includes('review'));
```

When `mode='review'`:
- `Boolean(['review'].length)` → `true`
- `true && ('review' || false || true)` → `true && 'review'` → `'review'` ❌

Output: `{"isReview":"review","mode":"review","rerun":false}` ❌

### After (Fixed):
```javascript
const isReview = Boolean(tokens.length && (mode || rerun || tokens.includes('review')));
```

When `mode='review'`:
- `tokens.length && ('review' || false || true)` → `1 && 'review'` → `'review'`
- `Boolean('review')` → `true` ✅

Output: `{"isReview":true,"mode":"review","rerun":false}` ✅

## Root Cause Chain

1. **Original workflow** (pre-#791): Checked `isReview != 'ultra' && != 'review'`
   - This was WRONG but accidentally worked because classifier output string 'review'
   - `'review' != 'ultra'` AND `'review' != 'review'` → TRUE AND FALSE = FALSE → Didn't exit ✅

2. **PR #791**: Fixed workflow to check `isReview != 'true'`
   - This is CORRECT for boolean values
   - But exposed hidden bug in classifier outputting strings

3. **After #791**: Classifier outputs `'review'`, workflow checks `'review' != 'true'`
   - `'review' != 'true'` → TRUE → Exits early ❌
   - All `@claude review` commands broke

## Impact
- ✅ Fixes all `@claude review` commands
- ✅ Fixes all `@claude re-review` commands
- ✅ Fixes all `@claude ultra` commands
- ✅ Ensures `isReview` is ALWAYS boolean true/false, never a string

## Test Plan
- [x] Analyzed classifier logic
- [x] Wrapped expression in Boolean() to force boolean output
- [ ] Test `@claude review` after merge
- [ ] Test `@claude re-review` after merge
- [ ] Test `@claude ultra` after merge

## Related
- Fixes regression introduced by PR #791
- Works together with PR #791 to fully fix the workflow
- Resolves #782