### PR TITLE
Fix: Disable track_progress to prevent 404 crashes #794

### DIFF
--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
-          track_progress: true
+          track_progress: false
           claude_args: >-
             --model claude-4.5-sonnet
             --max-turns 32


### PR DESCRIPTION
## Summary
Disables `track_progress` in the claude-commands workflow to prevent 404 crashes when the action tries to compare branches that don't exist yet.

## Root Cause
The `claude-code-action@v1` with `track_progress: true` attempts to check if branches exist remotely and compare them against main before Claude creates any branches. This causes:
- 404 errors on GET `/repos/.../branches/claude%2Fissue-794-...`
- 404 errors on GET `/repos/.../compare/main...claude%2Fissue-794-...`
- Workflow failure before Claude even starts

## Solution
Changed `track_progress: false` on line 97 of `.github/workflows/claude-commands.yml`

## Trade-offs
- **Lost**: Automatic branch links in workflow comments
- **Gained**: Stable workflow execution without pre-flight 404 crashes

## Testing
- Pre-push validation passed (TypeScript check + fast tests)
- Workflow will be tested on next @claude command trigger

Fixes #794