### PR TITLE
Refactor: Normalize universal note operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@
 - **Logging**: structured `logger.*` only in `src/`; include `toolName,userId,requestId`; **no secrets/PII**.
 - **`formatResult`**: returns **string**; no env branching; wrap in `try/catch` + `createErrorResult`.
 - **Mocks**: use `/test/utils/mock-factories/`; for tasks (Issue #480) include `content` + `title`, preserve `task_id`.
-- **Schema**: avoid top‑level `oneOf/allOf/anyOf`; validate either/or in code.
+- **Schema**: avoid top-level `oneOf/allOf/anyOf`; validate either/or in code.
+- **Universal errors**: universal tool handlers should throw `ErrorService.createUniversalError(...)` on failure rather than returning `{ isError: true }` payloads.
 - **Attio tests**: real API tests require `ATTIO_API_KEY`.
 
 ## Precedence & Compatibility (with System‑Wide CLAUDE.md)

--- a/src/handlers/tool-configs/universal/core/utils/note-formatters.ts
+++ b/src/handlers/tool-configs/universal/core/utils/note-formatters.ts
@@ -1,0 +1,124 @@
+import {
+  AttioFieldValue,
+  AttioNote,
+  AttioNoteIdentifier,
+  AttioNoteValues,
+} from '@/types/attio.js';
+
+export interface NoteFields {
+  title: string;
+  content: string;
+  id: string;
+  timestamp: string;
+  preview: string;
+}
+
+const DEFAULT_PREVIEW_LENGTH = 50;
+
+const toStringValue = (value: unknown): string | undefined => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+  return undefined;
+};
+
+const toNoteIdentifier = (id: unknown): AttioNoteIdentifier | undefined => {
+  if (!id || typeof id !== 'object') {
+    return undefined;
+  }
+  return id as AttioNoteIdentifier;
+};
+
+const fromValuesArray = (
+  values?: AttioFieldValue[] | null
+): string | undefined => {
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+  for (const entry of values) {
+    const value = toStringValue(entry?.value ?? entry?.full_name);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const extractFromNoteValues = (
+  values: AttioNoteValues | null | undefined,
+  field: keyof AttioNoteValues
+): string | undefined => {
+  if (!values) {
+    return undefined;
+  }
+  const fieldValue = values[field];
+  if (!fieldValue) {
+    return undefined;
+  }
+  if (Array.isArray(fieldValue)) {
+    return fromValuesArray(fieldValue);
+  }
+  if (
+    fieldValue &&
+    typeof fieldValue === 'object' &&
+    'value' in fieldValue &&
+    typeof (fieldValue as AttioFieldValue).value === 'string'
+  ) {
+    return String((fieldValue as AttioFieldValue).value);
+  }
+  return undefined;
+};
+
+/**
+ * Normalize note fields from multiple potential Attio response shapes.
+ */
+export const extractNoteFields = (
+  note: Record<string, unknown> | undefined,
+  options?: { previewLength?: number }
+): NoteFields => {
+  const attioNote = (note ?? {}) as AttioNote;
+
+  const title =
+    toStringValue(attioNote.title) ||
+    extractFromNoteValues(attioNote.values, 'title') ||
+    'Untitled';
+
+  const content =
+    toStringValue(attioNote.content) ||
+    toStringValue(attioNote.content_markdown) ||
+    toStringValue(attioNote.content_plaintext) ||
+    extractFromNoteValues(attioNote.values, 'content') ||
+    '';
+
+  const noteId = toNoteIdentifier(attioNote.id);
+  const id =
+    toStringValue(attioNote.record_id) ||
+    toStringValue(attioNote.note_id) ||
+    (typeof attioNote.id === 'string'
+      ? toStringValue(attioNote.id)
+      : undefined) ||
+    toStringValue(noteId?.record_id) ||
+    toStringValue(noteId?.note_id) ||
+    toStringValue(noteId?.id) ||
+    'unknown';
+
+  const timestamp =
+    toStringValue(attioNote.created_at) ||
+    toStringValue(attioNote.timestamp) ||
+    'unknown date';
+
+  const previewLength = options?.previewLength ?? DEFAULT_PREVIEW_LENGTH;
+  const trimmedContent = content.trim();
+  const preview =
+    trimmedContent.length > previewLength
+      ? `${trimmedContent.slice(0, previewLength)}...`
+      : trimmedContent;
+
+  return {
+    title,
+    content,
+    id,
+    timestamp,
+    preview,
+  };
+};

--- a/src/objects/notes.ts
+++ b/src/objects/notes.ts
@@ -264,16 +264,34 @@ export function normalizeNoteResponse(note: AttioNote): {
       )
     : [];
 
+  const idObject =
+    typeof note.id === 'object' && note.id !== null ? note.id : undefined;
+  const derivedRecordId =
+    (typeof note.id === 'string' ? note.id : undefined) ??
+    note.record_id ??
+    note.note_id ??
+    idObject?.record_id ??
+    idObject?.note_id ??
+    idObject?.id ??
+    'unknown';
+
+  const title = note.title ?? null;
+  const contentMarkdown = note.content_markdown ?? note.content ?? null;
+  const contentPlaintext = note.content_plaintext ?? note.content ?? null;
+  const parentObject = note.parent_object ?? 'notes';
+  const parentRecordId = note.parent_record_id ?? derivedRecordId;
+  const createdAt = note.created_at ?? note.timestamp ?? '';
+
   return {
-    id: { record_id: note.id.note_id },
+    id: { record_id: derivedRecordId },
     resource_type: 'notes',
     values: {
-      title: note.title,
-      content_markdown: note.content,
-      content_plaintext: note.content,
-      parent_object: note.parent_object,
-      parent_record_id: note.parent_record_id,
-      created_at: note.created_at,
+      title: title ?? undefined,
+      content_markdown: contentMarkdown ?? undefined,
+      content_plaintext: contentPlaintext ?? undefined,
+      parent_object: parentObject,
+      parent_record_id: parentRecordId,
+      created_at: createdAt,
       meeting_id:
         typeof meetingIdField === 'string' || meetingIdField === null
           ? meetingIdField

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -44,6 +44,26 @@ export interface AttioRecordValues {
 }
 
 /**
+ * Identifier shape returned by Attio for note resources
+ */
+export interface AttioNoteIdentifier {
+  note_id?: string;
+  record_id?: string;
+  workspace_id?: string;
+  id?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Nested values payload used by Attio notes API (mirrors record value arrays)
+ */
+export interface AttioNoteValues {
+  title?: AttioFieldValue[];
+  content?: AttioFieldValue[];
+  [key: string]: unknown;
+}
+
+/**
  * Union type for fields that can be used as display names
  * Ordered by priority: name → full_name → title → content
  */
@@ -264,17 +284,20 @@ export interface BatchConfig {
  * Note record type
  */
 export interface AttioNote {
-  id: {
-    note_id: string;
-    [key: string]: unknown;
-  };
-  title: string;
-  content: string;
-  format: string;
-  parent_object: string;
-  parent_record_id: string;
-  created_at: string;
-  updated_at: string;
+  id?: AttioNoteIdentifier | string | null;
+  note_id?: string | null;
+  record_id?: string | null;
+  title?: string | null;
+  content?: string | null;
+  content_markdown?: string | null;
+  content_plaintext?: string | null;
+  format?: string | null;
+  parent_object?: string | null;
+  parent_record_id?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  timestamp?: string | null;
+  values?: AttioNoteValues | null;
   [key: string]: unknown; // Additional fields
 }
 

--- a/test/unit/handlers/tool-configs/universal/core/notes-operations.test.ts
+++ b/test/unit/handlers/tool-configs/universal/core/notes-operations.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  UniversalCreateNoteParams,
+  UniversalGetNotesParams,
+} from '@/handlers/tool-configs/universal/types.js';
+
+vi.mock('@/handlers/tool-configs/universal/schemas.js', () => ({
+  createNoteSchema: {},
+  listNotesSchema: {},
+  validateUniversalToolParams: vi.fn(),
+}));
+
+const mockCreateUniversalError = vi.fn(
+  (_operation: string, _resource: string, error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Error(`universal-error:${message}`);
+  }
+);
+
+vi.mock('@/services/ErrorService.js', () => ({
+  ErrorService: {
+    createUniversalError: mockCreateUniversalError,
+  },
+}));
+
+const mockHandleUniversalCreateNote = vi.fn();
+const mockHandleUniversalGetNotes = vi.fn();
+
+vi.mock('@/handlers/tool-configs/universal/shared-handlers.js', () => ({
+  handleUniversalCreateNote: mockHandleUniversalCreateNote,
+  handleUniversalGetNotes: mockHandleUniversalGetNotes,
+}));
+
+const mockIsValidUUID = vi.fn();
+
+vi.mock('@/utils/validation/uuid-validation.js', () => ({
+  isValidUUID: mockIsValidUUID,
+}));
+
+const { createNoteConfig, listNotesConfig } = await import(
+  '@/handlers/tool-configs/universal/core/notes-operations.js'
+);
+const { extractNoteFields } = await import(
+  '@/handlers/tool-configs/universal/core/utils/note-formatters.js'
+);
+const { validateUniversalToolParams } = await import(
+  '@/handlers/tool-configs/universal/schemas.js'
+);
+
+describe('extractNoteFields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns direct note fields when provided', () => {
+    const note = {
+      title: 'Direct Title',
+      content: 'Direct Content',
+      id: { record_id: 'note-123' },
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    const fields = extractNoteFields(note);
+
+    expect(fields).toMatchObject({
+      title: 'Direct Title',
+      content: 'Direct Content',
+      id: 'note-123',
+      timestamp: '2024-01-01T00:00:00Z',
+    });
+    expect(fields.preview).toBe('Direct Content');
+  });
+
+  it('falls back to nested values arrays and generates preview', () => {
+    const note = {
+      values: {
+        title: [{ value: 'Nested Title' }],
+        content: [{ value: 'Nested content from values that is quite long' }],
+      },
+      id: 'fallback-id',
+      timestamp: '2024-02-02T00:00:00Z',
+    };
+
+    const fields = extractNoteFields(note);
+
+    expect(fields.title).toBe('Nested Title');
+    expect(fields.content).toBe(
+      'Nested content from values that is quite long'
+    );
+    expect(fields.id).toBe('fallback-id');
+    expect(fields.timestamp).toBe('2024-02-02T00:00:00Z');
+    expect(fields.preview).toBe(
+      'Nested content from values that is quite long'.slice(0, 50)
+    );
+  });
+});
+
+describe('createNoteConfig.handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects invalid UUIDs before invoking upstream handler', async () => {
+    const sanitizedParams: UniversalCreateNoteParams = {
+      resource_type: 'notes',
+      record_id: 'not-a-uuid',
+      title: 'Invalid',
+      content: 'Invalid',
+    };
+
+    vi.mocked(validateUniversalToolParams).mockReturnValueOnce(sanitizedParams);
+    mockIsValidUUID.mockReturnValue(false);
+
+    await expect(createNoteConfig.handler({})).rejects.toThrow(
+      /Invalid record_id: must be a UUID/
+    );
+
+    expect(mockIsValidUUID).toHaveBeenCalledWith('not-a-uuid');
+    expect(mockHandleUniversalCreateNote).not.toHaveBeenCalled();
+    expect(mockCreateUniversalError).toHaveBeenCalled();
+  });
+
+  it('maps upstream error responses into universal errors', async () => {
+    const sanitizedParams: UniversalCreateNoteParams = {
+      resource_type: 'notes',
+      record_id: '123e4567-e89b-12d3-a456-426614174000',
+      title: 'Example',
+      content: 'Body',
+    };
+
+    vi.mocked(validateUniversalToolParams).mockReturnValueOnce(sanitizedParams);
+    mockIsValidUUID.mockReturnValue(true);
+    mockHandleUniversalCreateNote.mockResolvedValueOnce({
+      success: false,
+      error: 'invalid response from upstream',
+    });
+
+    await expect(createNoteConfig.handler({})).rejects.toThrow(
+      /invalid response from upstream/
+    );
+
+    expect(mockCreateUniversalError).toHaveBeenCalled();
+  });
+
+  it('returns successful note payloads when upstream succeeds', async () => {
+    const sanitizedParams: UniversalCreateNoteParams = {
+      resource_type: 'notes',
+      record_id: '123e4567-e89b-12d3-a456-426614174000',
+      title: 'Title',
+      content: 'Content',
+    };
+
+    const upstreamResult = { id: { record_id: 'note-1' } };
+
+    vi.mocked(validateUniversalToolParams).mockReturnValueOnce(sanitizedParams);
+    mockIsValidUUID.mockReturnValue(true);
+    mockHandleUniversalCreateNote.mockResolvedValueOnce(upstreamResult);
+
+    await expect(createNoteConfig.handler({})).resolves.toEqual(upstreamResult);
+  });
+});
+
+describe('listNotesConfig.handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects invalid record IDs', async () => {
+    const sanitizedParams: UniversalGetNotesParams = {
+      resource_type: 'notes',
+      record_id: 'invalid',
+    };
+
+    vi.mocked(validateUniversalToolParams).mockReturnValueOnce(sanitizedParams);
+    mockIsValidUUID.mockReturnValue(false);
+
+    await expect(listNotesConfig.handler({})).rejects.toThrow(
+      /Invalid record_id: must be a UUID/
+    );
+
+    expect(mockHandleUniversalGetNotes).not.toHaveBeenCalled();
+    expect(mockCreateUniversalError).toHaveBeenCalled();
+  });
+
+  it('returns normalized notes when upstream succeeds', async () => {
+    const sanitizedParams: UniversalGetNotesParams = {
+      resource_type: 'notes',
+      record_id: '123e4567-e89b-12d3-a456-426614174000',
+    };
+
+    vi.mocked(validateUniversalToolParams).mockReturnValueOnce(sanitizedParams);
+    mockIsValidUUID.mockReturnValue(true);
+    const upstreamNotes = [{ title: 'Note', id: { record_id: 'note-1' } }];
+    mockHandleUniversalGetNotes.mockResolvedValueOnce(upstreamNotes);
+
+    await expect(listNotesConfig.handler({})).resolves.toEqual(upstreamNotes);
+  });
+});
+
+describe('notes formatters', () => {
+  it('formats created note response', () => {
+    const message = createNoteConfig.formatResult({
+      title: 'Meeting',
+      content: 'Discussed roadmap',
+      id: { record_id: 'note-1' },
+    });
+
+    expect(message).toContain(
+      '✅ Note created successfully: Meeting (ID: note-1)'
+    );
+    expect(message).toContain('Discussed roadmap');
+  });
+
+  it('formats list notes response with preview', () => {
+    const response = listNotesConfig.formatResult([
+      {
+        values: {
+          title: [{ value: 'Nested' }],
+          content: [{ value: 'Preview content for nested note extraction' }],
+        },
+        id: { record_id: 'note-xyz' },
+        created_at: '2024-05-20T00:00:00Z',
+      },
+    ]);
+
+    expect(response).toContain('Found 1 notes');
+    expect(response).toContain('Nested (2024-05-20T00:00:00Z) (ID: note-xyz)');
+    expect(response).toContain(
+      'Preview content for nested note extraction'.slice(0, 50)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared note field formatter and tighten note typings
- align create/list handlers on UUID validation + ErrorService exceptions
- add unit coverage for formatter and handler failure paths

## Testing
- npm run test:offline
- npm run build
