### PR TITLE
Fix: Add Format 6 parser for Claude Code session log format #798

### DIFF
--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -303,6 +303,23 @@ jobs:
                 else if (parsed?.content?.[0]?.text) {
                   deltas.push(parsed.content[0].text);
                 }
+                // Format 6: Claude Code session log with nested content
+                else if (parsed?.message?.content && Array.isArray(parsed.message.content)) {
+                  for (const block of parsed.message.content) {
+                    // Text blocks directly in content
+                    if (block?.type === 'text' && block?.text) {
+                      deltas.push(block.text);
+                    }
+                    // Tool results with nested text content
+                    else if (block?.type === 'tool_result' && block?.content && Array.isArray(block.content)) {
+                      for (const innerBlock of block.content) {
+                        if (innerBlock?.type === 'text' && innerBlock?.text) {
+                          deltas.push(innerBlock.text);
+                        }
+                      }
+                    }
+                  }
+                }
               } catch (e) {
                 // Skip unparseable lines
               }

--- a/.github/workflows/claude-issue-review.yml
+++ b/.github/workflows/claude-issue-review.yml
@@ -276,6 +276,23 @@ jobs:
                 else if (parsed?.content?.[0]?.text) {
                   chunks.push(parsed.content[0].text);
                 }
+                // Format 6: Claude Code session log with nested content
+                else if (parsed?.message?.content && Array.isArray(parsed.message.content)) {
+                  for (const block of parsed.message.content) {
+                    // Text blocks directly in content
+                    if (block?.type === 'text' && block?.text) {
+                      chunks.push(block.text);
+                    }
+                    // Tool results with nested text content
+                    else if (block?.type === 'tool_result' && block?.content && Array.isArray(block.content)) {
+                      for (const innerBlock of block.content) {
+                        if (innerBlock?.type === 'text' && innerBlock?.text) {
+                          chunks.push(innerBlock.text);
+                        }
+                      }
+                    }
+                  }
+                }
               } catch (e) {
                 // Skip unparseable lines
               }


### PR DESCRIPTION
## Problem

PR #801 fixed response capture by adding 5 NDJSON parsing formats, but testing revealed it still failed to extract Claude's responses. Workflow run 18175950783 showed:

```
Processed 3558 lines, parsed 3 JSON objects, extracted 0 text chunks
```

## Root Cause

Claude Code action with `--output-format stream-json` produces **session logs**, not streaming API deltas. The response text is nested in:

```javascript
{
  type: 'user',
  message: {
    role: 'user',
    content: [{
      type: 'tool_result',
      content: [{ type: 'text', text: 'actual response here...' }]
    }]
  }
}
```

The existing 5 formats checked `message.content[0].text` but missed the nested array iteration.

## Solution

Added **Format 6 parser** that:
1. Checks if `parsed.message.content` is an array
2. Iterates through content blocks
3. Extracts text from direct text blocks: `{ type: 'text', text: '...' }`
4. Extracts text from nested tool results: `{ type: 'tool_result', content: [{ type: 'text', text: '...' }] }`

## Changes

- `.github/workflows/claude-commands.yml` (lines 306-322): Added Format 6 parser
- `.github/workflows/claude-issue-review.yml` (lines 279-295): Applied same parser for consistency

## Validation

Claude DID generate a comprehensive response about issue #798 (phone numbers, error handling, etc.) - it just wasn't being extracted. Format 6 now properly handles the nested structure.

Fixes #798