### PR TITLE
Fix: Track and review file deletions in PR scope #816

### DIFF
--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -208,6 +208,7 @@ jobs:
           RING0_JSON_PATH="$SCOPE_DIR/ring0.json"
           RING1_JSON_PATH="$SCOPE_DIR/ring1.json"
           SUMMARY_PATH="$SCOPE_DIR/scope-summary.json"
+          DELETIONS_PATH="$SCOPE_DIR/DELETIONS.md"
 
           if [ ! -f "$SUMMARY_PATH" ]; then
             echo "scope-summary.json missing; skipping sparse checkout"
@@ -224,13 +225,22 @@ jobs:
           printf 'RING1_JSON=%s\n' "$ring1_json" >> "$GITHUB_ENV"
           printf 'RING_SCOPE_FALLBACK=%s\n' "$fallback" >> "$GITHUB_ENV"
 
+          # Check for deletions summary
+          if [ -f "$DELETIONS_PATH" ]; then
+            printf 'HAS_DELETIONS=true\n' >> "$GITHUB_ENV"
+            printf 'DELETIONS_SUMMARY_PATH=%s\n' "$DELETIONS_PATH" >> "$GITHUB_ENV"
+          else
+            printf 'HAS_DELETIONS=false\n' >> "$GITHUB_ENV"
+          fi
+
           ring0_count=$(jq -r '.ring0Count' "$SUMMARY_PATH")
           ring1_count=$(jq -r '.ring1Count' "$SUMMARY_PATH")
+          deletions_count=$(jq -r '.deletionsCount // 0' "$SUMMARY_PATH")
           base_ref=$(jq -r '.baseRef // empty' "$SUMMARY_PATH")
           head_ref=$(jq -r '.headRef // empty' "$SUMMARY_PATH")
 
           {
-            echo "📂 Claude scope: Ring 0 = ${ring0_count}, Ring 1 = ${ring1_count}, fallback=${fallback}";
+            echo "📂 Claude scope: Ring 0 = ${ring0_count}, Ring 1 = ${ring1_count}, Deletions = ${deletions_count}, fallback=${fallback}";
             if [ -n "$base_ref" ] || [ -n "$head_ref" ]; then
               echo "Base: ${base_ref:-unknown} → Head: ${head_ref:-unknown}";
             fi
@@ -316,6 +326,18 @@ jobs:
 
             Context files (Ring 1 JSON):
             ${{ env.RING1_JSON }}
+
+            ${{ env.HAS_DELETIONS == 'true' && format('
+            DELETIONS SUMMARY:
+            This PR includes file deletions. Review the deletions summary at:
+            {0}
+
+            When reviewing deletions:
+            1. Verify deletions are intentional and justified
+            2. Ensure no critical functionality is lost
+            3. Check that coverage gaps are tracked
+            4. Confirm related docs/tests are updated
+            ', env.DELETIONS_SUMMARY_PATH) || '' }}
 
             Perform a PR review with full working tree access.
 
@@ -420,6 +442,18 @@ jobs:
 
             Context files (Ring 1 JSON):
             ${{ env.RING1_JSON }}
+
+            ${{ env.HAS_DELETIONS == 'true' && format('
+            DELETIONS SUMMARY:
+            This PR includes file deletions. Review the deletions summary at:
+            {0}
+
+            When reviewing deletions:
+            1. Verify deletions are intentional and justified
+            2. Ensure no critical functionality is lost
+            3. Check that coverage gaps are tracked
+            4. Confirm related docs/tests are updated
+            ', env.DELETIONS_SUMMARY_PATH) || '' }}
 
             Perform a PR review with full working tree access.
 


### PR DESCRIPTION
## Problem

PR #811 (deletion-only: 17 test files removed) shows as "empty" in Claude reviews:

```
Ring 0 (changed files) array is empty []
This PR appears to be empty or contains no changed files
```

### Root Cause

**Location:** `scripts/claude/generate-review-scope.mjs:80`

```javascript
if (status === 'D') continue; // skip deletions
```

The scope generation script **intentionally filters out all deleted files**, causing:
- Ring 0 = `[]` for deletion-only PRs  
- Claude reports "no changes detected"
- **No review** of deletion rationale or coverage tracking

## Solution

### 1. Track Deletions Separately (`generate-review-scope.mjs`)

```javascript
function listRing0(baseRef, headRef) {
  // ... existing code ...
  const files = [];
  const deletions = [];
  
  for (const line of output.split('\n')) {
    // ... parsing ...
    if (status === 'D') {
      deletions.push(safePath);  // Track instead of skip
    } else {
      files.push(safePath);
    }
  }
  
  return {
    files: Array.from(new Set(files)),
    deletions: Array.from(new Set(deletions))
  };
}
```

### 2. Generate Deletion Summary

When deletions exist, creates `.github/claude-cache/{run-id}/DELETIONS.md`:

```markdown
# Deleted Files in This PR

This PR deletes 17 file(s):

- `test/integration/advanced-search-filters.test.ts`
- `test/integration/company-write-operations.test.ts`
... (full list)

**Review Focus:** Verify that:
1. Deletions are intentional and justified in the PR description
2. No critical functionality is lost without replacement
3. Coverage gaps are tracked or mitigated
4. Related documentation/tests are updated accordingly
```

### 3. Include in Review Scope (`claude-pr-review-labeled.yml`)

- Adds `deletionsCount` to scope summary
- Displays: `Ring 0 = X, Ring 1 = Y, Deletions = Z`
- Injects deletion summary path into Claude prompt when `HAS_DELETIONS=true`

## Impact

**Before:**
```
Ring 0: 0, Ring 1: 2
Review: "This PR appears to be empty"
```

**After:**
```
Ring 0: 0, Ring 1: 2, Deletions: 17
Review includes DELETIONS.md with:
- Full list of deleted files
- Deletion review checklist
- Verification of coverage gap tracking (#812-#815)
```

## Testing

- ✅ Logic tested locally with PR #811 scenario
- ✅ Generates `DELETIONS.md` for deletion-only PRs
- ✅ Workflow displays deletion count in scope summary
- ✅ Claude prompt includes deletion review guidelines

## Related Issues

- Fixes #816 (deletion-only PRs show as empty)
- Validates #811 (17 test file deletions now reviewable)

## Migration Notes

**No breaking changes.** Enhanced scope generation is backward compatible:
- PRs without deletions: No change in behavior
- PRs with deletions: Now properly tracked and reviewed
- Mixed PRs (add/modify/delete): All changes captured

## Files Changed

1. **`scripts/claude/generate-review-scope.mjs`**
   - Modified `listRing0()` to return `{files, deletions}`
   - Added deletion summary generation
   - Updated console output to show deletion count

2. **`.github/workflows/claude-pr-review-labeled.yml`**
   - Added `DELETIONS_PATH` and `HAS_DELETIONS` env vars
   - Updated scope summary to show deletion count
   - Injected deletion review guidelines into Claude prompt