### PR TITLE
Fix: Heredoc delimiter on own line for DELETIONS_CONTENT #816

### DIFF
--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -242,6 +242,7 @@ jobs:
             {
               echo 'DELETIONS_CONTENT<<DELETIONS_EOF'
               cat "$DELETIONS_PATH"
+              printf '\n'  # Ensure newline before delimiter (heredoc safety)
               echo 'DELETIONS_EOF'
             } >> "$GITHUB_ENV"
           else

--- a/scripts/claude/generate-review-scope.mjs
+++ b/scripts/claude/generate-review-scope.mjs
@@ -278,6 +278,7 @@ function main() {
       '2. No critical functionality is lost without replacement',
       '3. Coverage gaps are tracked or mitigated',
       '4. Related documentation/tests are updated accordingly',
+      '', // Ensure file ends with newline for heredoc safety
     ].join('\n');
     writeFileSync(deletionsSummaryPath, deletionContent);
   }


### PR DESCRIPTION
## Problem

Workflow run 18183016579 failed with:
```
##[error]Invalid value. Matching delimiter not found 'DELETIONS_EOF'
```

**Root Cause**: `DELETIONS.md` file didn't end with newline, causing heredoc closing delimiter to appear on same line as last content line. GitHub Actions heredoc parser requires delimiter on its own line.

## What This PR Does

Fixes the heredoc delimiter issue in two ways:

1. **`scripts/claude/generate-review-scope.mjs`**: Added empty string to array ensuring file ends with `\n`
2. **`claude-pr-review-labeled.yml`**: Added `printf '\n'` after cat for additional safety

## Before/After

**Before**:
```
DELETIONS_CONTENT<<DELETIONS_EOF
...content...
4. Related documentation/tests are updated accordinglyDELETIONS_EOF
```

**After**:
```
DELETIONS_CONTENT<<DELETIONS_EOF
...content...
4. Related documentation/tests are updated accordingly
DELETIONS_EOF
```

## Fixes

- Issue #816 - PR #811 showing empty despite having deletions

## Testing

- [x] Unit tests pass
- [x] Should fix workflow run 18183016579 error on PR #811

Closes #816