### PR TITLE
Fix: prevent stack trace exposure in prompt handlers

### DIFF
--- a/docs/TESTING-ERROR-HANDLING-IMPROVEMENTS.md
+++ b/docs/TESTING-ERROR-HANDLING-IMPROVEMENTS.md
@@ -43,6 +43,7 @@ The Attio MCP Server has undergone significant improvements to address critical 
 ### 1. Enhanced Error Handling System
 
 **Files Updated**:
+
 - `/src/utils/error-handler.ts`
 - `/src/utils/json-serializer.ts`
 - `/docs/api/error-handling.md`
@@ -50,30 +51,38 @@ The Attio MCP Server has undergone significant improvements to address critical 
 **Key Improvements**:
 
 #### Original Message Preservation
+
 ```typescript
 // Before: Lost context
 throw new Error('Parameter error');
 
 // After: Enhanced with preserved context
-const detailsString = typeof responseData?.error?.details === 'string'
-  ? responseData.error.details
-  : JSON.stringify(responseData?.error?.details || '');
+const detailsString =
+  typeof responseData?.error?.details === 'string'
+    ? responseData.error.details
+    : JSON.stringify(responseData?.error?.details || '');
 
-if (defaultMessage.includes('parameter') || detailsString.includes('parameter')) {
+if (
+  defaultMessage.includes('parameter') ||
+  detailsString.includes('parameter')
+) {
   errorType = ErrorType.PARAMETER_ERROR;
   message = `Parameter Error: ${defaultMessage}`; // Original message preserved
 }
 ```
 
 #### JSON Serialization Safety
+
 ```typescript
 // Safe details handling prevents circular reference issues
 let safeDetails: any = null;
 if (details) {
   try {
-    safeDetails = JSON.parse(safeJsonStringify(details, {
-      includeStackTraces: process.env.NODE_ENV === 'development',
-    }));
+    safeDetails = JSON.parse(
+      safeJsonStringify(details, {
+        includeStackTraces: false,
+      })
+    );
   } catch (err) {
     // Ultimate fallback prevents serialization failures
     safeDetails = {
@@ -88,6 +97,7 @@ if (details) {
 ### 2. Test Environment & Mock System
 
 **Files Created/Updated**:
+
 - `/test/setup.ts`
 - `/test/e2e/fixtures/`
 - `/docs/development/test-environment-setup.md`
@@ -95,6 +105,7 @@ if (details) {
 **Key Features**:
 
 #### Environment Detection
+
 ```typescript
 // Automatic environment detection
 const isTestEnv = process.env.NODE_ENV === 'test';
@@ -111,6 +122,7 @@ if (isTestEnv && !isE2EMode) {
 ```
 
 #### Mock Data Structures
+
 ```typescript
 // Complete API response structure matching
 const mockCompany = {
@@ -118,32 +130,34 @@ const mockCompany = {
   values: {
     name: [{ value: 'Test Company' }],
     domain: [{ value: 'test.com' }],
-    industry: [{ value: 'Technology' }]
-  }
+    industry: [{ value: 'Technology' }],
+  },
 };
 ```
 
 ### 3. UUID Format Standardization
 
 **Standard Test UUIDs**:
+
 ```typescript
 const standardTestUUIDs = {
   company: '00000000-0000-0000-0000-000000000000',
   person: '11111111-1111-1111-1111-111111111111',
   task: '22222222-2222-2222-2222-222222222222',
   list: '33333333-3333-3333-3333-333333333333',
-  note: '44444444-4444-4444-4444-444444444444'
+  note: '44444444-4444-4444-4444-444444444444',
 };
 ```
 
 **Usage in Tests**:
+
 ```typescript
 // ✅ Correct: Valid UUID format for 404 testing
 test('should return 404 for non-existent company', async () => {
   const result = await getCompanyDetails({
-    record_id: '00000000-0000-0000-0000-000000000000' // Valid UUID, doesn't exist
+    record_id: '00000000-0000-0000-0000-000000000000', // Valid UUID, doesn't exist
   });
-  
+
   expect(result.error).toContain('Company not found');
 });
 ```
@@ -151,15 +165,16 @@ test('should return 404 for non-existent company', async () => {
 ### 4. Flexible Error Pattern Matching
 
 **Enhanced Test Assertions**:
+
 ```typescript
 // ✅ Flexible pattern matching for enhanced errors
 test('should handle parameter errors with enhanced messages', async () => {
   const result = await callApiFunction(invalidParams);
-  
+
   expect(result.error).toEqual(
     expect.objectContaining({
       type: 'parameter_error',
-      message: expect.stringMatching(/Parameter Error:.*parameter/)
+      message: expect.stringMatching(/Parameter Error:.*parameter/),
     })
   );
 });
@@ -172,31 +187,31 @@ test('should handle parameter errors with enhanced messages', async () => {
 
 ### Test Reliability Improvements
 
-| Metric | Before | After | Improvement |
-|--------|--------|-------|-------------|
-| Test Pass Rate | ~85% | 100% | +15% |
-| UUID Format Failures | ~10% of tests | 0% | -10% |
-| Serialization Errors | ~5% of tests | 0% | -5% |
-| Mock Data Issues | ~8% of tests | 0% | -8% |
+| Metric               | Before        | After | Improvement |
+| -------------------- | ------------- | ----- | ----------- |
+| Test Pass Rate       | ~85%          | 100%  | +15%        |
+| UUID Format Failures | ~10% of tests | 0%    | -10%        |
+| Serialization Errors | ~5% of tests  | 0%    | -5%         |
+| Mock Data Issues     | ~8% of tests  | 0%    | -8%         |
 
 ### Error Handling Quality
 
-| Aspect | Before | After |
-|--------|--------|-------|
-| Original Message Preservation | ❌ Lost | ✅ Preserved with context |
-| Circular Reference Safety | ❌ Throws errors | ✅ Safe handling |
-| MCP Protocol Compatibility | ❌ Frequent failures | ✅ 100% compatibility |
-| Debug Information | ❌ Limited | ✅ Comprehensive |
+| Aspect                        | Before               | After                     |
+| ----------------------------- | -------------------- | ------------------------- |
+| Original Message Preservation | ❌ Lost              | ✅ Preserved with context |
+| Circular Reference Safety     | ❌ Throws errors     | ✅ Safe handling          |
+| MCP Protocol Compatibility    | ❌ Frequent failures | ✅ 100% compatibility     |
+| Debug Information             | ❌ Limited           | ✅ Comprehensive          |
 
 ### Developer Experience
 
-| Improvement | Benefit |
-|-------------|---------|
-| Clear Error Messages | Faster debugging and issue resolution |
-| Standardized Test UUIDs | Consistent test data across all suites |
-| Flexible Assertions | Tests resilient to error message enhancements |
-| Environment Detection | Automatic test configuration |
-| Comprehensive Documentation | Self-service troubleshooting |
+| Improvement                 | Benefit                                       |
+| --------------------------- | --------------------------------------------- |
+| Clear Error Messages        | Faster debugging and issue resolution         |
+| Standardized Test UUIDs     | Consistent test data across all suites        |
+| Flexible Assertions         | Tests resilient to error message enhancements |
+| Environment Detection       | Automatic test configuration                  |
+| Comprehensive Documentation | Self-service troubleshooting                  |
 
 ## New Documentation Structure
 
@@ -235,11 +250,13 @@ test('should handle parameter errors with enhanced messages', async () => {
 ### Quick Reference
 
 #### For Developers
+
 - **Writing Tests**: Use [Test Environment Setup Guide](development/test-environment-setup.md)
 - **Error Handling**: Follow [Enhanced Error Handling patterns](api/error-handling.md#enhanced-error-message-format-improvements)
 - **Troubleshooting**: Check [Test Failure Troubleshooting](troubleshooting.md#test-failure-troubleshooting)
 
 #### For Debugging
+
 - **Test Failures**: Start with [UUID Format Fixes](troubleshooting.md#uuid-format-errors)
 - **Serialization Issues**: Review [JSON Serialization Fixes](development/json-serialization-fixes.md)
 - **Mock Problems**: Check [Mock Data System Guidelines](development/test-environment-setup.md#mock-data-system)
@@ -271,19 +288,19 @@ test('should handle parameter errors with enhanced messages', async () => {
 
 ### Test Execution Performance
 
-| Test Type | Before | After | Change |
-|-----------|--------|-------|--------|
-| Unit Tests | 45s | 42s | -7% (more reliable mocks) |
-| Integration Tests | 180s | 175s | -3% (fewer retries needed) |
-| E2E Tests | 300s | 285s | -5% (reduced flakiness) |
+| Test Type         | Before | After | Change                     |
+| ----------------- | ------ | ----- | -------------------------- |
+| Unit Tests        | 45s    | 42s   | -7% (more reliable mocks)  |
+| Integration Tests | 180s   | 175s  | -3% (fewer retries needed) |
+| E2E Tests         | 300s   | 285s  | -5% (reduced flakiness)    |
 
 ### Error Processing Performance
 
-| Operation | Before | After | Impact |
-|-----------|--------|-------|--------|
-| Simple Error | 1ms | 1ms | No change |
-| Complex Error | 5ms or fail | 8ms | +60% time but 100% reliability |
-| Circular Reference | Failure | 10ms | From failure to success |
+| Operation          | Before      | After | Impact                         |
+| ------------------ | ----------- | ----- | ------------------------------ |
+| Simple Error       | 1ms         | 1ms   | No change                      |
+| Complex Error      | 5ms or fail | 8ms   | +60% time but 100% reliability |
+| Circular Reference | Failure     | 10ms  | From failure to success        |
 
 ## Future Considerations
 
@@ -297,7 +314,7 @@ test('should handle parameter errors with enhanced messages', async () => {
 ### Maintenance Notes
 
 1. **Regular UUID Updates**: Ensure test UUIDs remain valid and unique
-2. **Mock Data Sync**: Keep mock structures aligned with API changes  
+2. **Mock Data Sync**: Keep mock structures aligned with API changes
 3. **Error Pattern Updates**: Update patterns when API error formats change
 4. **Documentation Updates**: Keep troubleshooting guides current
 

--- a/src/prompts/error-handler.ts
+++ b/src/prompts/error-handler.ts
@@ -2,6 +2,23 @@
  * Error handling utilities for the prompts module
  */
 import { ErrorType, formatErrorResponse } from '../utils/error-handler.js';
+import {
+  createScopedLogger,
+  generateCorrelationId,
+  OperationType,
+} from '@/utils/logger.js';
+
+const logger = createScopedLogger(
+  'prompts',
+  'error-handler',
+  OperationType.SYSTEM
+);
+
+interface CreatePromptErrorOptions {
+  requestId?: string;
+  logError?: unknown;
+  logContext?: Record<string, unknown>;
+}
 
 // Extend the error response type to allow string codes for Express
 interface PromptErrorResponse {
@@ -26,7 +43,8 @@ interface PromptErrorResponse {
 export function createErrorResult(
   error: Error,
   message: string,
-  statusCode: number
+  statusCode: number,
+  options: CreatePromptErrorOptions = {}
 ): PromptErrorResponse {
   let errorType = ErrorType.UNKNOWN_ERROR;
 
@@ -43,10 +61,29 @@ export function createErrorResult(
     errorType = ErrorType.SERVER_ERROR;
   }
 
+  const requestId = options.requestId ?? generateCorrelationId();
   const errorDetails = {
     statusCode,
     message,
+    requestId,
   };
+
+  const internalError = (() => {
+    if (!options.logError) {
+      return statusCode >= 500 ? error : undefined;
+    }
+    if (options.logError instanceof Error) {
+      return options.logError;
+    }
+    return new Error(String(options.logError));
+  })();
+
+  if (internalError) {
+    logger.error(`Prompt handler error (${statusCode})`, internalError, {
+      requestId,
+      ...options.logContext,
+    });
+  }
 
   // Get the base response from the utility function
   const baseResponse = formatErrorResponse(
@@ -61,6 +98,10 @@ export function createErrorResult(
     error: {
       ...baseResponse.error,
       code: String(statusCode), // Convert to string for Express
+      details: {
+        ...(baseResponse.error.details || {}),
+        requestId,
+      },
     },
   };
 

--- a/src/prompts/handlers.ts
+++ b/src/prompts/handlers.ts
@@ -204,8 +204,9 @@ export async function getPromptDetails(
   req: Request,
   res: Response
 ): Promise<void> {
+  const promptId = req.params.id;
+
   try {
-    const promptId = req.params.id;
     const prompt = getPromptById(promptId);
 
     if (!prompt) {
@@ -351,8 +352,9 @@ export async function executePrompt(
   req: Request,
   res: Response
 ): Promise<void> {
+  const promptId = req.params.id;
+
   try {
-    const promptId = req.params.id;
     const prompt = getPromptById(promptId);
 
     if (!prompt) {

--- a/src/prompts/handlers.ts
+++ b/src/prompts/handlers.ts
@@ -151,12 +151,15 @@ export async function listPrompts(req: Request, res: Response): Promise<void> {
       data: prompts,
     });
   } catch (error: unknown) {
-    const errorObj = new Error('Failed to list prompts');
-    const errorResult = createErrorResult(
-      errorObj,
-      error instanceof Error ? error.message : 'Unknown error',
-      500
-    );
+    const clientMessage = 'Unable to list prompts at this time.';
+    const errorObj = new Error(clientMessage);
+    const errorResult = createErrorResult(errorObj, clientMessage, 500, {
+      logError: error,
+      logContext: {
+        endpoint: 'listPrompts',
+        category: req.query.category,
+      },
+    });
     res.status(Number(errorResult.error.code)).json(errorResult);
   }
 }
@@ -179,12 +182,14 @@ export async function listPromptCategories(
       data: categories,
     });
   } catch (error: unknown) {
-    const errorObj = new Error('Failed to list prompt categories');
-    const errorResult = createErrorResult(
-      errorObj,
-      error instanceof Error ? error.message : 'Unknown error',
-      500
-    );
+    const clientMessage = 'Unable to list prompt categories at this time.';
+    const errorObj = new Error(clientMessage);
+    const errorResult = createErrorResult(errorObj, clientMessage, 500, {
+      logError: error,
+      logContext: {
+        endpoint: 'listPromptCategories',
+      },
+    });
     res.status(Number(errorResult.error.code)).json(errorResult);
   }
 }
@@ -219,12 +224,15 @@ export async function getPromptDetails(
       data: prompt,
     });
   } catch (error: unknown) {
-    const errorObj = new Error('Failed to get prompt details');
-    const errorResult = createErrorResult(
-      errorObj,
-      error instanceof Error ? error.message : 'Unknown error',
-      500
-    );
+    const clientMessage = 'Unable to retrieve prompt details at this time.';
+    const errorObj = new Error(clientMessage);
+    const errorResult = createErrorResult(errorObj, clientMessage, 500, {
+      logError: error,
+      logContext: {
+        endpoint: 'getPromptDetails',
+        promptId,
+      },
+    });
     res.status(Number(errorResult.error.code)).json(errorResult);
   }
 }
@@ -352,7 +360,13 @@ export async function executePrompt(
       const errorResult = createErrorResult(
         errorObj,
         `No prompt found with ID: ${promptId}`,
-        404
+        404,
+        {
+          logContext: {
+            endpoint: 'executePrompt',
+            promptId,
+          },
+        }
       );
       res.status(Number(errorResult.error.code)).json(errorResult);
       return;
@@ -367,7 +381,13 @@ export async function executePrompt(
       const errorResult = createErrorResult(
         errorObj,
         validation.errors.join(', '),
-        400
+        400,
+        {
+          logContext: {
+            endpoint: 'executePrompt',
+            promptId,
+          },
+        }
       );
       res.status(Number(errorResult.error.code)).json(errorResult);
       return;
@@ -391,7 +411,14 @@ export async function executePrompt(
               ? compileError.message
               : 'Unknown error'
           }`,
-          500
+          500,
+          {
+            logError: compileError,
+            logContext: {
+              endpoint: 'executePrompt',
+              promptId,
+            },
+          }
         );
         res.status(Number(errorResult.error.code)).json(errorResult);
         return;
@@ -409,7 +436,14 @@ export async function executePrompt(
         `Template rendering error for prompt ${promptId}: ${
           renderError instanceof Error ? renderError.message : 'Unknown error'
         }`,
-        500
+        500,
+        {
+          logError: renderError,
+          logContext: {
+            endpoint: 'executePrompt',
+            promptId,
+          },
+        }
       );
       res.status(Number(errorResult.error.code)).json(errorResult);
       return;
@@ -423,12 +457,15 @@ export async function executePrompt(
       },
     });
   } catch (error: unknown) {
-    const errorObj = new Error('Failed to execute prompt');
-    const errorResult = createErrorResult(
-      errorObj,
-      error instanceof Error ? error.message : 'Unknown error',
-      500
-    );
+    const clientMessage = 'Unable to execute prompt at this time.';
+    const errorObj = new Error(clientMessage);
+    const errorResult = createErrorResult(errorObj, clientMessage, 500, {
+      logError: error,
+      logContext: {
+        endpoint: 'executePrompt',
+        promptId,
+      },
+    });
     res.status(Number(errorResult.error.code)).json(errorResult);
   }
 }

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -344,7 +344,7 @@ export function formatErrorResponse(
       // Use createSafeCopy which handles circular references and non-serializable values
       safeDetails = JSON.parse(
         safeJsonStringify(details, {
-          includeStackTraces: process.env.NODE_ENV === 'development',
+          includeStackTraces: false,
         })
       );
     } catch (err) {

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -168,7 +168,7 @@ export function createApiError(
       const detailsString =
         typeof errorDetails === 'string'
           ? errorDetails
-          : JSON.stringify(errorDetails || '');
+          : safeJsonStringify(errorDetails ?? '', { indent: 0 });
 
       if (
         defaultMessage.includes('parameter') ||

--- a/src/utils/json-serializer.ts
+++ b/src/utils/json-serializer.ts
@@ -287,7 +287,7 @@ export function sanitizeMcpResponse(response: unknown): unknown {
     // Create safe copy with MCP-specific options optimized for Attio responses
     return createSafeCopy(response, {
       maxStringLength: 40000, // 40KB for response content - reasonable limit
-      includeStackTraces: process.env.NODE_ENV === 'development',
+      includeStackTraces: false,
     });
   } catch (error: unknown) {
     // Provide a valid fallback response if sanitization fails

--- a/test/prompts/error-handler.test.ts
+++ b/test/prompts/error-handler.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createErrorResult } from '../../src/prompts/error-handler';
+
+describe('prompts/error-handler', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development';
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('omits stack traces from serialized error responses', () => {
+    const internalError = new Error('Internal failure');
+    internalError.stack = 'Sensitive stack trace that must stay internal';
+
+    const clientError = new Error('Safe message');
+    const result = createErrorResult(clientError, 'Safe message', 500, {
+      logError: internalError,
+    });
+
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain('Sensitive stack trace');
+    expect(result.error.details).toBeDefined();
+    const requestId = result.error.details?.requestId;
+    expect(typeof requestId).toBe('string');
+    if (typeof requestId === 'string') {
+      expect(requestId).toHaveLength(36);
+    }
+    expect(result.error.message).toBe('Safe message');
+  });
+});


### PR DESCRIPTION
## Summary
- replace raw console logging in JSON serialization utilities with scoped structured logging that stays MCP-safe
- switch API error detail coercion to safeJsonStringify and harden prompt error handling against circular metadata
- extend prompt security regression suite to cover the new sanitization paths and circular context serialization

## Testing
- npm run lint:check
- npx vitest run test/prompts/error-handler.security.test.ts test/prompts/error-handler.test.ts test/utils/json-serializer.test.ts
- npm run test:offline -- --run test/prompts/error-handler.test.ts test/prompts/error-handler.security.test.ts test/utils/json-serializer.test.ts

Closes #836
