### PR TITLE
feat: enrich enhanced error context metadata

### DIFF
--- a/docs/api/error-handling.md
+++ b/docs/api/error-handling.md
@@ -41,6 +41,15 @@ DEBUG ErrorService field-context {"field":"status","fieldType":"select","resourc
 
 These additions make it easier to audit failed requests and reconcile validation errors with the exact Attio configuration that triggered them.
 
+### Creating Errors with Field Metadata
+
+Prefer the ErrorService helpers when you need field-aware diagnostics:
+
+- `ErrorService.createFieldError({ ... })` for field-specific validation failures
+- `ErrorService.createValidationError({ ... })` for broader validation errors with optional field context
+
+Both helpers automatically hydrate `fieldType` and `fieldMetadata` from attribute discovery results. See [ErrorService Helpers](#errorservice-helpers) for usage details and logging behavior.
+
 ## Filter Validation Error Categories
 
 As of version 0.0.2, the server implements a more granular categorization system for filter validation errors. This allows for more targeted error handling and better user feedback.

--- a/docs/api/error-handling.md
+++ b/docs/api/error-handling.md
@@ -2,6 +2,45 @@
 
 This document describes the error handling system implemented in the Attio MCP server.
 
+## Enhanced Error Context Metadata
+
+Enhanced API errors automatically capture field-specific metadata when the server can resolve it from Attio's attribute catalog. Every enhanced error context now includes:
+
+- `fieldType` – a human-readable type hint such as `phone_number`, `email`, or `select`
+- `fieldMetadata` – the Attio attribute configuration snapshot that was used to determine the field type
+
+```typescript
+throw ErrorService.createFieldError({
+  field: 'status',
+  message: 'Invalid status value',
+  resourceType: 'tasks',
+  operation: 'update',
+  attributeMetadataIndex,
+});
+```
+
+The resulting error context contains both the type and metadata, enabling richer troubleshooting messages and downstream tooling:
+
+```json
+{
+  "field": "status",
+  "fieldType": "select",
+  "fieldMetadata": {
+    "api_slug": "status",
+    "field_type": "select",
+    "options": ["new", "active", "completed"]
+  }
+}
+```
+
+When a field type is resolved, the error service emits a structured debug log to aid incident triage:
+
+```
+DEBUG ErrorService field-context {"field":"status","fieldType":"select","resourceType":"tasks","operation":"update"}
+```
+
+These additions make it easier to audit failed requests and reconcile validation errors with the exact Attio configuration that triggered them.
+
 ## Filter Validation Error Categories
 
 As of version 0.0.2, the server implements a more granular categorization system for filter validation errors. This allows for more targeted error handling and better user feedback.
@@ -666,6 +705,33 @@ it('should preserve field type metadata when enhancing errors', () => {
   expect(enhanced.getContextualMessage()).toContain("type 'select'");
 });
 ```
+
+#### ErrorService Helpers
+
+Utility methods in `ErrorService` now hydrate error context directly from attribute discovery metadata:
+
+```typescript
+const attributeMetadataIndex = buildAttributeMetadataIndex(attributes);
+
+throw ErrorService.createFieldError({
+  field: 'status',
+  message: 'Invalid status value',
+  resourceType: 'tasks',
+  operation: 'update',
+  attributeMetadataIndex,
+});
+
+throw ErrorService.createValidationError({
+  message: 'Priority must be numeric',
+  resourceType: 'tasks',
+  operation: 'update',
+  field: 'priority',
+  attributeMetadataIndex,
+  documentationHint: 'Use numeric values between 1-5',
+});
+```
+
+Both helpers log a `field-context` debug entry showing the resolved `fieldType`, making it visible in structured logs for debugging.
 
 #### Common Field Types
 

--- a/src/errors/enhanced-api-errors.ts
+++ b/src/errors/enhanced-api-errors.ts
@@ -20,7 +20,10 @@ export interface EnhancedApiErrorContext {
   field?: string;
   /** Type information for the problematic field */
   fieldType?: string;
-  /** Attio field configuration snapshot for deep diagnostics */
+  /**
+   * Attio field configuration snapshot for deep diagnostics.
+   * @remarks Commonly includes api_slug, field_type, title, and config.select options.
+   */
   fieldMetadata?: AttributeMetadata;
   /** Valid values for select fields */
   validValues?: string[];

--- a/src/errors/enhanced-api-errors.ts
+++ b/src/errors/enhanced-api-errors.ts
@@ -8,8 +8,9 @@
  * - Issue #417: Task-specific error guidance and field mapping help
  */
 
-import { AttioApiError } from './api-errors.js';
-import { isValidUUID } from '../utils/validation/uuid-validation.js';
+import { AttioApiError } from '@errors/api-errors.js';
+import type { AttributeMetadata } from '@services/utils/attribute-metadata.js';
+import { isValidUUID } from '@utils/validation/uuid-validation.js';
 
 /**
  * Enhanced error context interface providing rich information for better UX
@@ -20,7 +21,7 @@ export interface EnhancedApiErrorContext {
   /** Type information for the problematic field */
   fieldType?: string;
   /** Attio field configuration snapshot for deep diagnostics */
-  fieldMetadata?: unknown;
+  fieldMetadata?: AttributeMetadata;
   /** Valid values for select fields */
   validValues?: string[];
   /** Suggested field names for typos */

--- a/src/services/utils/attribute-metadata.ts
+++ b/src/services/utils/attribute-metadata.ts
@@ -1,4 +1,7 @@
-export type AttributeMetadata = Record<string, unknown>;
+import type { AttioAttributeMetadata } from '@/api/attribute-types.js';
+
+export type AttributeMetadata = AttioAttributeMetadata &
+  Record<string, unknown>;
 export type AttributeMetadataIndex = Record<string, AttributeMetadata>;
 
 const ATTRIBUTE_KEY_CANDIDATES = [
@@ -8,6 +11,13 @@ const ATTRIBUTE_KEY_CANDIDATES = [
   'title',
   'name',
   'label',
+];
+
+const FIELD_TYPE_CANDIDATES = [
+  'field_type',
+  'attribute_type',
+  'type',
+  'input_type',
 ];
 
 function normalizeKey(key: string): string {
@@ -67,6 +77,34 @@ export function findAttributeMetadata(
   const underscored = normalized.replace(/[\s.-]+/g, '_');
   if (underscored in index) {
     return index[underscored];
+  }
+
+  return undefined;
+}
+
+export function resolveFieldType(
+  metadata?: AttributeMetadata
+): string | undefined {
+  if (!metadata) return undefined;
+
+  const directType = FIELD_TYPE_CANDIDATES.find((candidate) => {
+    const value = metadata[candidate];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+
+  if (directType) {
+    return String(metadata[directType]).trim();
+  }
+
+  const configType = metadata?.config as Record<string, unknown> | undefined;
+  if (configType && typeof configType === 'object') {
+    const nestedType = FIELD_TYPE_CANDIDATES.find((candidate) => {
+      const value = configType[candidate];
+      return typeof value === 'string' && value.trim().length > 0;
+    });
+    if (nestedType) {
+      return String(configType[nestedType]).trim();
+    }
   }
 
   return undefined;

--- a/src/services/utils/attribute-metadata.ts
+++ b/src/services/utils/attribute-metadata.ts
@@ -1,0 +1,73 @@
+export type AttributeMetadata = Record<string, unknown>;
+export type AttributeMetadataIndex = Record<string, AttributeMetadata>;
+
+const ATTRIBUTE_KEY_CANDIDATES = [
+  'api_slug',
+  'attribute_slug',
+  'slug',
+  'title',
+  'name',
+  'label',
+];
+
+function normalizeKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function addKey(
+  index: AttributeMetadataIndex,
+  key: string,
+  metadata: AttributeMetadata
+): void {
+  const normalized = normalizeKey(key);
+  if (!normalized) return;
+
+  index[normalized] = metadata;
+  // Also map underscored variations to support space-separated titles
+  const underscored = normalized.replace(/[\s.-]+/g, '_');
+  index[underscored] = metadata;
+}
+
+export function buildAttributeMetadataIndex(
+  attributes: unknown[]
+): AttributeMetadataIndex {
+  const index: AttributeMetadataIndex = {};
+
+  attributes.forEach((attribute) => {
+    if (!attribute || typeof attribute !== 'object') {
+      return;
+    }
+
+    const metadata = attribute as AttributeMetadata;
+
+    ATTRIBUTE_KEY_CANDIDATES.forEach((candidate) => {
+      const value = metadata[candidate];
+      if (typeof value === 'string' && value.trim().length > 0) {
+        addKey(index, value, metadata);
+      }
+    });
+  });
+
+  return index;
+}
+
+export function findAttributeMetadata(
+  field: string,
+  index?: AttributeMetadataIndex
+): AttributeMetadata | undefined {
+  if (!index || !field) {
+    return undefined;
+  }
+
+  const normalized = normalizeKey(field);
+  if (normalized in index) {
+    return index[normalized];
+  }
+
+  const underscored = normalized.replace(/[\s.-]+/g, '_');
+  if (underscored in index) {
+    return index[underscored];
+  }
+
+  return undefined;
+}

--- a/src/services/utils/attribute-metadata.ts
+++ b/src/services/utils/attribute-metadata.ts
@@ -29,13 +29,22 @@ function addKey(
   key: string,
   metadata: AttributeMetadata
 ): void {
-  const normalized = normalizeKey(key);
-  if (!normalized) return;
+  const variants = createLookupKeys(key);
+  variants.forEach((variant) => {
+    index[variant] = metadata;
+  });
+}
 
-  index[normalized] = metadata;
-  // Also map underscored variations to support space-separated titles
+function createLookupKeys(key: string): string[] {
+  const normalized = normalizeKey(key);
+  if (!normalized) return [];
+
   const underscored = normalized.replace(/[\s.-]+/g, '_');
-  index[underscored] = metadata;
+  if (underscored === normalized) {
+    return [normalized];
+  }
+
+  return [normalized, underscored];
 }
 
 export function buildAttributeMetadataIndex(
@@ -69,14 +78,11 @@ export function findAttributeMetadata(
     return undefined;
   }
 
-  const normalized = normalizeKey(field);
-  if (normalized in index) {
-    return index[normalized];
-  }
-
-  const underscored = normalized.replace(/[\s.-]+/g, '_');
-  if (underscored in index) {
-    return index[underscored];
+  const variants = createLookupKeys(field);
+  for (const variant of variants) {
+    if (variant in index) {
+      return index[variant];
+    }
   }
 
   return undefined;

--- a/test/services/ErrorService-create-universal-error.test.ts
+++ b/test/services/ErrorService-create-universal-error.test.ts
@@ -2,6 +2,26 @@
  * Split: ErrorService.createUniversalError tests
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { createScopedLoggerMock, mockFieldContextLogger } = vi.hoisted(() => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  return {
+    createScopedLoggerMock: vi.fn(() => logger),
+    mockFieldContextLogger: logger,
+  };
+});
+
+vi.mock('../../src/utils/logger.js', () => ({
+  createScopedLogger: createScopedLoggerMock,
+  OperationType: { DATA_PROCESSING: 'data_processing' },
+}));
+
 import { ErrorService } from '../../src/services/ErrorService.js';
 import {
   UniversalValidationError,
@@ -18,6 +38,11 @@ import { validateResourceType } from '../../src/handlers/tool-configs/universal/
 describe('ErrorService.createUniversalError', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    createScopedLoggerMock.mockClear();
+    mockFieldContextLogger.debug.mockClear();
+    mockFieldContextLogger.info.mockClear();
+    mockFieldContextLogger.warn.mockClear();
+    mockFieldContextLogger.error.mockClear();
     vi.mocked(validateResourceType).mockReturnValue({
       valid: true,
       suggestion: undefined,
@@ -212,6 +237,74 @@ describe('ErrorService.createUniversalError', () => {
 
       expect(result.context?.fieldMetadata).toBe(fieldMetadata);
       expect(result.context?.fieldType).toBe('select');
+    });
+  });
+
+  describe('field error utilities', () => {
+    it('creates enhanced field error with metadata-derived field type', () => {
+      const attributeMetadataIndex = {
+        status: { api_slug: 'status', type: 'select' },
+      } as Record<string, Record<string, unknown>>;
+
+      const error = ErrorService.createFieldError({
+        field: 'status',
+        message: 'Invalid status value',
+        resourceType: 'tasks',
+        operation: 'update',
+        attributeMetadataIndex,
+      }) as EnhancedApiError;
+
+      expect(error).toBeInstanceOf(EnhancedApiError);
+      expect(error.context?.fieldType).toBe('select');
+      expect(error.context?.fieldMetadata).toBe(attributeMetadataIndex.status);
+    });
+
+    it('logs resolved field type for downstream debugging', () => {
+      const attributeMetadataIndex = {
+        status: { api_slug: 'status', field_type: 'select' },
+      } as Record<string, Record<string, unknown>>;
+
+      ErrorService.createFieldError({
+        field: 'status',
+        message: 'Invalid status value',
+        resourceType: 'tasks',
+        operation: 'update',
+        attributeMetadataIndex,
+      });
+
+      expect(mockFieldContextLogger.debug).toHaveBeenCalledWith(
+        'Resolved field type for error context',
+        expect.objectContaining({
+          field: 'status',
+          fieldType: 'select',
+          resourceType: 'tasks',
+          operation: 'update',
+        })
+      );
+    });
+
+    it('creates validation error with metadata context', () => {
+      const attributeMetadataIndex = {
+        priority: { api_slug: 'priority', attribute_type: 'number' },
+      } as Record<string, Record<string, unknown>>;
+
+      const error = ErrorService.createValidationError({
+        message: 'Priority must be numeric',
+        resourceType: 'tasks',
+        operation: 'update',
+        field: 'priority',
+        attributeMetadataIndex,
+        documentationHint: 'Use numeric values between 1-5',
+        retryable: false,
+      }) as EnhancedApiError;
+
+      expect(error).toBeInstanceOf(EnhancedApiError);
+      expect(error.context?.fieldType).toBe('number');
+      expect(error.context?.fieldMetadata).toBe(
+        attributeMetadataIndex.priority
+      );
+      expect(error.context?.retryable).toBe(false);
+      expect(error.context?.documentationHint).toContain('numeric');
     });
   });
 });


### PR DESCRIPTION
## Summary
- expose attribute metadata helpers and surface field type snapshots in enhanced API errors
- validate error service logging of field type resolution and preserve metadata in tests
- document field type and metadata capture in the error handling guide for debugging

## Testing
- npm test -- --run test/services/ErrorService-create-universal-error.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68df0b95d82c8325912e7676edbfe480