### PR TITLE
Fix: Critical bug in task-crud test - trackTaskForCleanup() method doesn't exist

### DIFF
--- a/test/e2e/mcp/task-operations/task-crud.mcp.test.ts
+++ b/test/e2e/mcp/task-operations/task-crud.mcp.test.ts
@@ -156,7 +156,7 @@ describe('MCP P1 Task CRUD Operations', () => {
       const taskId = testSuite.extractRecordId(responseText);
       expect(taskId).toBeTruthy();
 
-      testSuite.trackTaskForCleanup(taskId!);
+      testSuite.trackRecord('tasks', taskId!);
 
       console.log(`✅ Created full-featured task with ID: ${taskId}`);
     });


### PR DESCRIPTION
## Summary
Fixes a critical P0 bug in the task-crud MCP test where a non-existent method `trackTaskForCleanup()` was being called, causing runtime errors during test execution.

## Changes
- **File**: `test/e2e/mcp/task-operations/task-crud.mcp.test.ts:159`
- **Fix**: Replaced `testSuite.trackTaskForCleanup(taskId!)` with `testSuite.trackRecord('tasks', taskId!)`

## Test Results
✅ All 10 tests in task-crud.mcp.test.ts pass
✅ Cleanup works correctly for created tasks

## Impact
- **Severity**: P0 (blocking bug)
- **Scope**: Task creation test with all optional fields
- **Risk**: Previously caused runtime error and orphaned task data

Closes #846