### PR TITLE
Refactor: Standardize MCP cleanup tracking #847

### DIFF
--- a/test/e2e/mcp/core-operations/create-records.mcp.test.ts
+++ b/test/e2e/mcp/core-operations/create-records.mcp.test.ts
@@ -188,7 +188,7 @@ describe('TC-003: Create Records - Data Creation', () => {
       // Extract and track for cleanup
       const recordId = testCase.extractRecordId(text);
       if (recordId) {
-        createdRecords.push({ type: 'companies', id: recordId });
+        testCase.trackRecord('companies', recordId);
       }
 
       passed = true;
@@ -225,7 +225,7 @@ describe('TC-003: Create Records - Data Creation', () => {
       );
 
       if (recordId) {
-        createdRecords.push({ type: 'companies', id: recordId });
+        testCase.trackRecord('companies', recordId);
 
         // Wait a moment for indexing (if needed)
         await new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
## Summary
- update the TC-003 create records test to rely on `trackRecord` instead of a local array when capturing new IDs
- reset and reseed the concurrent operations edge-case fixture before each test while tracking all created records via the shared helper
- override the concurrency runner to capture successful create responses and register their IDs for deterministic cleanup

## Testing
- `npm run test:e2e:mcp` *(script not found in package.json)*
- `npm run test:mcp` *(fails: ATTIO_API_KEY required in this environment)*
- `npm run cleanup:test-data -- --dry-run` *(fails: API token required in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e09cf1d3648325afca094b9c2630f2