### PR TITLE
Feat: Support markdown note format #854

### DIFF
--- a/src/api/operations/notes.ts
+++ b/src/api/operations/notes.ts
@@ -3,14 +3,14 @@
  * Handles note creation and retrieval
  */
 
-import { getLazyAttioClient } from '../../api/lazy-client.js';
+import { getLazyAttioClient } from '@/api/lazy-client.js';
 import {
   AttioNote,
   ResourceType,
   AttioListResponse,
   AttioSingleResponse,
-} from '../../types/attio.js';
-import { callWithRetry, RetryConfig } from './retry.js';
+} from '@/types/attio.js';
+import { callWithRetry, RetryConfig } from '@/api/operations/retry.js';
 
 /**
  * Generic function to get notes for a specific record
@@ -45,6 +45,7 @@ export async function getObjectNotes(
  * @param recordId - ID of the parent record
  * @param noteTitle - Title of the note
  * @param noteText - Content of the note
+ * @param format - Content format ('plaintext' | 'markdown'), defaults to 'plaintext'
  * @param retryConfig - Optional retry configuration
  * @returns Created note
  */
@@ -53,6 +54,7 @@ export async function createObjectNote(
   recordId: string,
   noteTitle: string,
   noteText: string,
+  format: 'plaintext' | 'markdown' = 'plaintext',
   retryConfig?: Partial<RetryConfig>
 ): Promise<AttioNote> {
   const api = getLazyAttioClient();
@@ -61,7 +63,7 @@ export async function createObjectNote(
   return callWithRetry(async () => {
     const response = await api.post<AttioSingleResponse<AttioNote>>(path, {
       data: {
-        format: 'plaintext',
+        format,
         parent_object: objectType,
         parent_record_id: recordId,
         title: `[AI] ${noteTitle}`,

--- a/src/handlers/tool-configs/universal/core/notes-operations.ts
+++ b/src/handlers/tool-configs/universal/core/notes-operations.ts
@@ -2,19 +2,19 @@ import {
   UniversalToolConfig,
   UniversalCreateNoteParams,
   UniversalGetNotesParams,
-} from '../types.js';
+} from '@/handlers/tool-configs/universal/types.js';
 import {
   createNoteSchema,
   listNotesSchema,
   validateUniversalToolParams,
-} from '../schemas.js';
+} from '@/handlers/tool-configs/universal/schemas.js';
 import {
   handleUniversalCreateNote,
   handleUniversalGetNotes,
-} from '../shared-handlers.js';
+} from '@/handlers/tool-configs/universal/shared-handlers.js';
 import { ErrorService } from '@/services/ErrorService.js';
 import { formatToolDescription } from '@/handlers/tools/standards/index.js';
-import { extractNoteFields } from './utils/note-formatters.js';
+import { extractNoteFields } from '@/handlers/tool-configs/universal/core/utils/note-formatters.js';
 import { isValidUUID } from '@/utils/validation/uuid-validation.js';
 import { createErrorResult } from '@/utils/error-handler.js';
 
@@ -149,10 +149,12 @@ export const listNotesConfig: UniversalToolConfig<
 export const createNoteDefinition = {
   name: 'create-note',
   description: formatToolDescription({
-    capability: 'Create note for companies, people, or deals.',
+    capability:
+      'Create note for companies, people, or deals with optional markdown formatting.',
     boundaries: 'update or delete notes; creates only.',
     requiresApproval: true,
-    constraints: 'Requires resource_type, record_id, title, content.',
+    constraints:
+      'Requires resource_type, record_id, title, content. Optional format (plaintext or markdown).',
     recoveryHint: 'If record not found, use records_search first.',
   }),
   inputSchema: createNoteSchema,

--- a/src/handlers/tool-configs/universal/schemas/utility-schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas/utility-schemas.ts
@@ -1,8 +1,8 @@
-import { UniversalResourceType } from '../types.js';
+import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import {
   paginationProperties,
   resourceTypeProperty,
-} from './common/properties.js';
+} from '@/handlers/tool-configs/universal/schemas/common/properties.js';
 
 export const createNoteSchema = {
   type: 'object' as const,
@@ -18,6 +18,12 @@ export const createNoteSchema = {
     },
     title: { type: 'string' as const, description: 'Title of the note' },
     content: { type: 'string' as const, description: 'Content of the note' },
+    format: {
+      type: 'string' as const,
+      enum: ['plaintext', 'markdown'],
+      description: 'Content format (default: plaintext)',
+      default: 'plaintext',
+    },
   },
   required: [
     'resource_type' as const,

--- a/test/unit/handlers/tool-configs/universal/core/notes-operations.test.ts
+++ b/test/unit/handlers/tool-configs/universal/core/notes-operations.test.ts
@@ -159,6 +159,25 @@ describe('createNoteConfig.handler', () => {
 
     await expect(createNoteConfig.handler({})).resolves.toEqual(upstreamResult);
   });
+
+  it('passes markdown format through to the upstream handler', async () => {
+    const sanitizedParams: UniversalCreateNoteParams = {
+      resource_type: 'notes',
+      record_id: '123e4567-e89b-12d3-a456-426614174000',
+      title: 'Markdown Title',
+      content: '# Heading',
+      format: 'markdown',
+    };
+
+    const upstreamResult = { id: { record_id: 'note-2' } };
+
+    vi.mocked(validateUniversalToolParams).mockReturnValueOnce(sanitizedParams);
+    mockIsValidUUID.mockReturnValue(true);
+    mockHandleUniversalCreateNote.mockResolvedValueOnce(upstreamResult);
+
+    await expect(createNoteConfig.handler({})).resolves.toEqual(upstreamResult);
+    expect(mockHandleUniversalCreateNote).toHaveBeenCalledWith(sanitizedParams);
+  });
 });
 
 describe('listNotesConfig.handler', () => {


### PR DESCRIPTION
## Summary
- expose a `format` option on the universal create-note schema with markdown/plaintext validation
- document markdown support in the create-note tool definition and allow API helpers to accept the format parameter
- cover markdown note creation in unit tests to ensure the format flag is forwarded upstream

## Testing
- `npm test -- --run notes-operations`


------
https://chatgpt.com/codex/tasks/task_b_68e09d067c088325829e7bb61ac6d044