### PR TITLE
Feature: Enhance phone validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Structured phone validation helpers (`validatePhoneNumber`, `isValidPhoneNumber`, `isPossiblePhoneNumber`) with actionable `PhoneValidationError` metadata (#837)
 - CLI auto-configures `libphonenumber-js` to use the `min` metadata bundle; server runtime exposes `PHONE_METADATA_SOURCE` for diagnostics (#837)
+  - Phone normalization failures now include aggregated issue counts and newline-delimited details for easier parsing (#837)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Structured phone validation helpers (`validatePhoneNumber`, `isValidPhoneNumber`, `isPossiblePhoneNumber`) with actionable `PhoneValidationError` metadata (#837)
+- CLI auto-configures `libphonenumber-js` to use the `min` metadata bundle; server runtime exposes `PHONE_METADATA_SOURCE` for diagnostics (#837)
+
 ### Changed
+
+- `AttributeAwareNormalizer` now rejects invalid phone inputs with `UniversalValidationError`, surfacing precise length/country/format guidance instead of silently passing through values (#837)
 
 ### Fixed
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -9,21 +9,25 @@ This directory contains comprehensive development documentation for the Attio MC
 - **[TDD Guide](tdd-guide.md)** - Test-driven development approach
 - **[Extending MCP](extending-mcp.md)** - How to extend MCP functionality
 - **[Refactoring Guidelines](refactoring-guidelines.md)** - Best practices for refactoring
+- **[Phone Validation Helpers](phone-validation.md)** - Canonical normalization + error handling patterns
 
 ## Quick Start for Developers
 
 1. **Fork and Clone**
+
    ```bash
    git clone https://github.com/YOUR_USERNAME/attio-mcp-server.git
    cd attio-mcp-server
    ```
 
 2. **Setup Development Environment**
+
    ```bash
    ./scripts/setup-dev-env.sh
    ```
 
 3. **Run Tests**
+
    ```bash
    npm test
    ```

--- a/docs/development/phone-validation.md
+++ b/docs/development/phone-validation.md
@@ -49,6 +49,13 @@ This behaviour applies to arrays, scalar fields (e.g. `primary_phone`), and obje
 - CLI processes set `ATTIO_PHONE_METADATA=min` automatically, reducing the shipped bundle to the `min` metadata build (~67 kB).
 - You can override via environment variable before module load if a custom build requires a different dataset.
 
+### Custom Metadata Example
+
+```bash
+# Use the full metadata set for a diagnostic worker
+ATTIO_PHONE_METADATA=default node dist/worker.js
+```
+
 Use `PHONE_METADATA_SOURCE` from `@/utils/validation/phone-validation.js` in diagnostics to confirm which metadata bundle loaded at runtime.
 
 ## Testing Guidelines

--- a/docs/development/phone-validation.md
+++ b/docs/development/phone-validation.md
@@ -1,0 +1,58 @@
+# Phone Validation Helpers
+
+Our MCP server uses **`libphonenumber-js`** for all normalization and validation. Issue #837 introduced structured helpers that replace ad-hoc parsing.
+
+## Canonical API
+
+```typescript
+import {
+  isPossiblePhoneNumber,
+  isValidPhoneNumber,
+  validatePhoneNumber,
+  PhoneValidationError,
+  PhoneValidationResult,
+} from '@/services/normalizers/PhoneNormalizer.js';
+```
+
+- `validatePhoneNumber(value, country?)` returns `{ valid, possible, e164?, national?, error? }`.
+- `isValidPhoneNumber` and `isPossiblePhoneNumber` are thin wrappers around the library with our default country fallback (`DEFAULT_PHONE_COUNTRY`, default `US`).
+- `toE164` remains backward compatible and now routes through the shared helpers.
+
+## Error Model
+
+`validatePhoneNumber` surfaces a `PhoneValidationError` when input fails validation. The `.code` field maps to:
+
+| Code                   | Description                                   |
+| ---------------------- | --------------------------------------------- |
+| `INVALID_TYPE`         | Input was not a string                        |
+| `INVALID_FORMAT`       | Formatting error after metadata checks        |
+| `INVALID_COUNTRY_CODE` | Country/region not recognised                 |
+| `TOO_SHORT`            | Number shorter than the numbering plan allows |
+| `TOO_LONG`             | Number longer than the numbering plan allows  |
+| `NOT_A_NUMBER`         | Input cannot be parsed into a phone number    |
+
+Downstream services should throw or surface the formatted message returned by the error instead of silently passing through invalid data.
+
+## Normalizer Behaviour
+
+`AttributeAwareNormalizer` now collects phone validation errors and raises a `UniversalValidationError` when any phone field fails validation. Callers will receive actionable messages such as:
+
+```
+Phone number validation failed: phone_numbers[0]: Phone number is too short to be valid. (received "+1202")
+```
+
+This behaviour applies to arrays, scalar fields (e.g. `primary_phone`), and objects with `phone_number`/`original_phone_number` keys.
+
+## Metadata Strategy
+
+- Server/runtime code imports the full `libphonenumber-js` metadata by default.
+- CLI processes set `ATTIO_PHONE_METADATA=min` automatically, reducing the shipped bundle to the `min` metadata build (~67 kB).
+- You can override via environment variable before module load if a custom build requires a different dataset.
+
+Use `PHONE_METADATA_SOURCE` from `@/utils/validation/phone-validation.js` in diagnostics to confirm which metadata bundle loaded at runtime.
+
+## Testing Guidelines
+
+- Add unit tests with `validatePhoneNumber` for each edge case before updating normalizers.
+- Regression coverage lives in `test/unit/normalizers/phone-number-normalization.test.ts` and `test/utils/phone-validation.test.ts`.
+- Run `npm run test:offline` after touching phone validation to ensure no degenerate fallbacks.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,6 +87,11 @@ if (!isMain) {
     // Set server mode flag to enable background intervals (performance tracking, etc.)
     process.env.MCP_SERVER_MODE = 'true';
 
+    // Use reduced libphonenumber metadata in CLI runtime to minimize bundle size
+    if (!process.env.ATTIO_PHONE_METADATA) {
+      process.env.ATTIO_PHONE_METADATA = 'min';
+    }
+
     // Dynamic imports to avoid loading modules during help/version
     const { StdioServerTransport } = await import(
       '@modelcontextprotocol/sdk/server/stdio.js'

--- a/src/services/normalizers/AttributeAwareNormalizer.ts
+++ b/src/services/normalizers/AttributeAwareNormalizer.ts
@@ -1,14 +1,79 @@
-import { toE164 } from './PhoneNormalizer.js';
+import {
+  PhoneValidationError,
+  toE164,
+  validatePhoneNumber,
+} from './PhoneNormalizer.js';
+import {
+  ErrorType,
+  UniversalValidationError,
+} from '@/handlers/tool-configs/universal/errors/validation-errors.js';
+
+interface PhoneValidationIssue {
+  fieldPath: string;
+  error: PhoneValidationError;
+}
+
+function recordPhoneIssue(
+  issues: PhoneValidationIssue[],
+  fieldPath: string,
+  error: PhoneValidationError
+) {
+  issues.push({ fieldPath, error });
+}
+
+function normalizeSinglePhoneValue(
+  rawValue: unknown,
+  fieldPath: string,
+  issues: PhoneValidationIssue[]
+): string | null {
+  if (typeof rawValue !== 'string') {
+    recordPhoneIssue(
+      issues,
+      fieldPath,
+      new PhoneValidationError(
+        'INVALID_TYPE',
+        'Phone numbers must be provided as strings.',
+        String(rawValue)
+      )
+    );
+    return null;
+  }
+
+  const validation = validatePhoneNumber(rawValue);
+  if (validation.valid && validation.e164) {
+    return validation.e164;
+  }
+
+  if (validation.error) {
+    recordPhoneIssue(issues, fieldPath, validation.error);
+  } else {
+    recordPhoneIssue(
+      issues,
+      fieldPath,
+      new PhoneValidationError(
+        'INVALID_FORMAT',
+        'Phone number format is not recognized.',
+        rawValue
+      )
+    );
+  }
+
+  return null;
+}
 
 /**
  * Normalize phone number structure and format
  * Transforms {phone_number: X} to {original_phone_number: X} and applies E.164 formatting
  */
-function normalizePhoneNumbers(value: unknown): unknown {
+function normalizePhoneNumbers(
+  value: unknown,
+  fieldPath: string,
+  issues: PhoneValidationIssue[]
+): unknown {
   if (!Array.isArray(value)) {
     // Handle single phone number string
-    const e164 = toE164(value);
-    return e164 || value;
+    const normalized = normalizeSinglePhoneValue(value, fieldPath, issues);
+    return normalized ?? value;
   }
 
   return value.map((item) => {
@@ -21,7 +86,11 @@ function normalizePhoneNumbers(value: unknown): unknown {
     ) {
       const itemObj = item as Record<string, unknown>;
       const { phone_number, ...otherFields } = itemObj;
-      const normalized = toE164(phone_number);
+      const normalized = normalizeSinglePhoneValue(
+        phone_number,
+        `${fieldPath}.phone_number`,
+        issues
+      );
       return {
         ...otherFields,
         original_phone_number: normalized || phone_number,
@@ -37,7 +106,11 @@ function normalizePhoneNumbers(value: unknown): unknown {
     ) {
       const itemObj = item as Record<string, unknown>;
       const { original_phone_number, ...otherFields } = itemObj;
-      const normalized = toE164(original_phone_number);
+      const normalized = normalizeSinglePhoneValue(
+        original_phone_number,
+        `${fieldPath}.original_phone_number`,
+        issues
+      );
       return {
         ...otherFields,
         original_phone_number: normalized || original_phone_number,
@@ -46,7 +119,11 @@ function normalizePhoneNumbers(value: unknown): unknown {
 
     // Handle direct string format
     if (typeof item === 'string') {
-      const normalized = toE164(item);
+      const normalized = normalizeSinglePhoneValue(
+        item,
+        `${fieldPath}[]`,
+        issues
+      );
       return { original_phone_number: normalized || item };
     }
 
@@ -62,11 +139,34 @@ export async function normalizeValues(
 ) {
   void _attributes;
   const out: Record<string, unknown> = { ...values };
+  const phoneIssues: PhoneValidationIssue[] = [];
   for (const [k, v] of Object.entries(values)) {
     const isPhoney = /phone/.test(k); // fast path if you don't want to fetch schemas
     if (isPhoney) {
-      out[k] = normalizePhoneNumbers(v);
+      out[k] = normalizePhoneNumbers(v, k, phoneIssues);
     }
   }
+
+  if (phoneIssues.length > 0) {
+    const details = phoneIssues
+      .map((issue) => {
+        const sanitizedInput = issue.error.input.trim() || 'empty input';
+        return `${issue.fieldPath}: ${issue.error.message} (received "${sanitizedInput}")`;
+      })
+      .join(' ');
+
+    throw new UniversalValidationError(
+      `Phone number validation failed: ${details}`,
+      ErrorType.USER_ERROR,
+      {
+        field: phoneIssues[0]?.fieldPath,
+        suggestion:
+          'Provide phone numbers in E.164 format, for example +15551234567.',
+        example: '+15551234567',
+        cause: phoneIssues[0]?.error,
+      }
+    );
+  }
+
   return out;
 }

--- a/src/services/normalizers/AttributeAwareNormalizer.ts
+++ b/src/services/normalizers/AttributeAwareNormalizer.ts
@@ -176,7 +176,8 @@ export async function normalizeValues(
         : `${headline} ${formattedIssues[0]}`;
 
     throw new UniversalValidationError(details, ErrorType.USER_ERROR, {
-      field: phoneIssues[0]?.fieldPath,
+      field:
+        phoneIssues.length === 1 ? phoneIssues[0]?.fieldPath : 'phone_numbers',
       suggestion:
         'Provide phone numbers in E.164 format, for example +15551234567.',
       example: '+15551234567',

--- a/src/services/normalizers/PhoneNormalizer.ts
+++ b/src/services/normalizers/PhoneNormalizer.ts
@@ -1,10 +1,21 @@
-import { parsePhoneNumberFromString, CountryCode } from 'libphonenumber-js';
+import {
+  isPossiblePhoneNumber,
+  isValidPhoneNumber,
+  PhoneValidationError,
+  toE164OrNull,
+  validatePhoneNumber,
+} from '@/utils/validation/phone-validation.js';
+import type { PhoneValidationResult } from '@/utils/validation/phone-validation.js';
 
-export function toE164(
-  input: unknown,
-  defaultCountry = (process.env.DEFAULT_PHONE_COUNTRY || 'US') as CountryCode
-): string | null {
-  if (typeof input !== 'string') return null;
-  const parsed = parsePhoneNumberFromString(input, defaultCountry);
-  return parsed && parsed.isValid() ? parsed.number : null; // E.164 like +12135551234
+export {
+  isPossiblePhoneNumber,
+  isValidPhoneNumber,
+  PhoneValidationError,
+  validatePhoneNumber,
+};
+
+export type { PhoneValidationResult };
+
+export function toE164(input: unknown, defaultCountry?: string): string | null {
+  return toE164OrNull(input, defaultCountry);
 }

--- a/src/services/normalizers/PhoneNormalizer.ts
+++ b/src/services/normalizers/PhoneNormalizer.ts
@@ -1,21 +1,9 @@
-import {
-  isPossiblePhoneNumber,
-  isValidPhoneNumber,
-  PhoneValidationError,
-  toE164OrNull,
-  validatePhoneNumber,
-} from '@/utils/validation/phone-validation.js';
-import type { PhoneValidationResult } from '@/utils/validation/phone-validation.js';
-
 export {
   isPossiblePhoneNumber,
   isValidPhoneNumber,
   PhoneValidationError,
   validatePhoneNumber,
-};
+  toE164,
+} from '@/utils/validation/phone-validation.js';
 
-export type { PhoneValidationResult };
-
-export function toE164(input: unknown, defaultCountry?: string): string | null {
-  return toE164OrNull(input, defaultCountry);
-}
+export type { PhoneValidationResult } from '@/utils/validation/phone-validation.js';

--- a/src/utils/validation/phone-validation.ts
+++ b/src/utils/validation/phone-validation.ts
@@ -1,0 +1,226 @@
+import type { CountryCode, ParseError, PhoneNumber } from 'libphonenumber-js';
+
+export const PHONE_METADATA_SOURCE =
+  process.env.ATTIO_PHONE_METADATA === 'min' ? 'min' : 'default';
+
+const libModule = await (PHONE_METADATA_SOURCE === 'min'
+  ? import('libphonenumber-js/min')
+  : import('libphonenumber-js'));
+
+const {
+  parsePhoneNumberFromString,
+  isValidPhoneNumber: libIsValidPhoneNumber,
+  isPossiblePhoneNumber: libIsPossiblePhoneNumber,
+  validatePhoneNumberLength,
+} = libModule as typeof import('libphonenumber-js');
+
+const DEFAULT_COUNTRY = (process.env.DEFAULT_PHONE_COUNTRY ||
+  'US') as CountryCode;
+
+type PhoneValidationErrorCode =
+  | 'INVALID_FORMAT'
+  | 'INVALID_COUNTRY_CODE'
+  | 'TOO_SHORT'
+  | 'TOO_LONG'
+  | 'NOT_A_NUMBER'
+  | 'INVALID_TYPE'
+  | 'UNKNOWN_ERROR';
+
+export class PhoneValidationError extends Error {
+  readonly code: PhoneValidationErrorCode;
+  readonly input: string;
+  readonly country?: CountryCode;
+  readonly cause?: ParseError | Error;
+
+  constructor(
+    code: PhoneValidationErrorCode,
+    message: string,
+    input: string,
+    country?: CountryCode,
+    cause?: ParseError | Error
+  ) {
+    super(message);
+    this.name = 'PhoneValidationError';
+    this.code = code;
+    this.input = input;
+    this.country = country;
+    this.cause = cause;
+  }
+}
+
+export interface PhoneValidationResult {
+  valid: boolean;
+  possible: boolean;
+  e164?: string;
+  national?: string;
+  country?: CountryCode;
+  error?: PhoneValidationError;
+}
+
+function resolveCountry(country?: string): CountryCode {
+  if (!country) {
+    return DEFAULT_COUNTRY;
+  }
+  return country.toUpperCase() as CountryCode;
+}
+
+function mapLengthError(
+  issue: ReturnType<typeof validatePhoneNumberLength>,
+  input: string,
+  country?: CountryCode
+): PhoneValidationError | undefined {
+  switch (issue) {
+    case 'INVALID_COUNTRY':
+      return new PhoneValidationError(
+        'INVALID_COUNTRY_CODE',
+        'Invalid or unsupported country calling code provided for phone number.',
+        input,
+        country
+      );
+    case 'TOO_SHORT':
+      return new PhoneValidationError(
+        'TOO_SHORT',
+        'Phone number is too short to be valid.',
+        input,
+        country
+      );
+    case 'TOO_LONG':
+      return new PhoneValidationError(
+        'TOO_LONG',
+        'Phone number is too long to be valid.',
+        input,
+        country
+      );
+    case 'NOT_A_NUMBER':
+      return new PhoneValidationError(
+        'NOT_A_NUMBER',
+        'Input does not appear to be a valid phone number.',
+        input,
+        country
+      );
+    default:
+      return undefined;
+  }
+}
+
+export function isPossiblePhoneNumber(
+  value: string,
+  country?: string
+): boolean {
+  const candidate = value?.trim();
+  if (!candidate) return false;
+  const resolvedCountry = resolveCountry(country);
+  try {
+    return libIsPossiblePhoneNumber(candidate, resolvedCountry);
+  } catch {
+    return false;
+  }
+}
+
+export function isValidPhoneNumber(value: string, country?: string): boolean {
+  const candidate = value?.trim();
+  if (!candidate) return false;
+  const resolvedCountry = resolveCountry(country);
+  try {
+    return libIsValidPhoneNumber(candidate, resolvedCountry);
+  } catch {
+    return false;
+  }
+}
+
+function safeParse(
+  value: string,
+  country: CountryCode
+): PhoneNumber | undefined {
+  try {
+    return parsePhoneNumberFromString(value, country) || undefined;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+export function validatePhoneNumber(
+  value: string,
+  country?: string
+): PhoneValidationResult {
+  if (typeof value !== 'string') {
+    return {
+      valid: false,
+      possible: false,
+      error: new PhoneValidationError(
+        'INVALID_TYPE',
+        'Phone numbers must be provided as strings.',
+        String(value)
+      ),
+    };
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return {
+      valid: false,
+      possible: false,
+      error: new PhoneValidationError(
+        'INVALID_FORMAT',
+        'Phone number cannot be empty.',
+        value
+      ),
+    };
+  }
+
+  const resolvedCountry = resolveCountry(country);
+  const possible = isPossiblePhoneNumber(trimmed, resolvedCountry);
+  const valid = isValidPhoneNumber(trimmed, resolvedCountry);
+
+  let error: PhoneValidationError | undefined;
+
+  if (!possible) {
+    const lengthIssue = validatePhoneNumberLength(trimmed, resolvedCountry);
+    error =
+      mapLengthError(lengthIssue, value, resolvedCountry) ||
+      new PhoneValidationError(
+        'INVALID_FORMAT',
+        'Phone number format is not recognized.',
+        value,
+        resolvedCountry
+      );
+  } else if (!valid) {
+    error = new PhoneValidationError(
+      'INVALID_FORMAT',
+      'Phone number format is possible but not valid for the specified region.',
+      value,
+      resolvedCountry
+    );
+  }
+
+  const parsed = safeParse(trimmed, resolvedCountry);
+  if (parsed?.isValid()) {
+    return {
+      valid: true,
+      possible,
+      country: parsed.country,
+      national: parsed.formatNational(),
+      e164: parsed.number,
+    };
+  }
+
+  return {
+    valid,
+    possible,
+    error,
+  };
+}
+
+export function toE164OrNull(
+  value: unknown,
+  defaultCountry?: string
+): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const sanitized = value.trim();
+  if (!sanitized) return null;
+  const resolvedCountry = resolveCountry(defaultCountry);
+  const parsed = safeParse(sanitized, resolvedCountry);
+  return parsed && parsed.isValid() ? parsed.number : null;
+}

--- a/src/utils/validation/phone-validation.ts
+++ b/src/utils/validation/phone-validation.ts
@@ -224,3 +224,7 @@ export function toE164OrNull(
   const parsed = safeParse(sanitized, resolvedCountry);
   return parsed && parsed.isValid() ? parsed.number : null;
 }
+
+export function toE164(value: unknown, defaultCountry?: string): string | null {
+  return toE164OrNull(value, defaultCountry);
+}

--- a/test/e2e/mcp/task-operations/task-crud.mcp.test.ts
+++ b/test/e2e/mcp/task-operations/task-crud.mcp.test.ts
@@ -156,7 +156,7 @@ describe('MCP P1 Task CRUD Operations', () => {
       const taskId = testSuite.extractRecordId(responseText);
       expect(taskId).toBeTruthy();
 
-      testSuite.trackTaskForCleanup(taskId!);
+      testSuite.trackRecord('tasks', taskId!);
 
       console.log(`✅ Created full-featured task with ID: ${taskId}`);
     });

--- a/test/utils/phone-validation.test.ts
+++ b/test/utils/phone-validation.test.ts
@@ -22,6 +22,12 @@ describe('phone validation utilities', () => {
     expect(result.error?.code).toBe('TOO_SHORT');
   });
 
+  it('applies default country when missing country code', () => {
+    const result = validatePhoneNumber('2025550134');
+    expect(result.valid).toBe(true);
+    expect(result.e164).toBe('+12025550134');
+  });
+
   it('returns metadata source indicator', () => {
     expect(['default', 'min']).toContain(PHONE_METADATA_SOURCE);
   });

--- a/test/utils/phone-validation.test.ts
+++ b/test/utils/phone-validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PHONE_METADATA_SOURCE,
+  PhoneValidationError,
+  isPossiblePhoneNumber,
+  isValidPhoneNumber,
+  validatePhoneNumber,
+} from '../../src/utils/validation/phone-validation.js';
+
+describe('phone validation utilities', () => {
+  it('validates a correct E.164 number', () => {
+    const result = validatePhoneNumber('+12025550134');
+    expect(result.valid).toBe(true);
+    expect(result.e164).toBe('+12025550134');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('produces structured error for too-short numbers', () => {
+    const result = validatePhoneNumber('+1202');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeInstanceOf(PhoneValidationError);
+    expect(result.error?.code).toBe('TOO_SHORT');
+  });
+
+  it('returns metadata source indicator', () => {
+    expect(['default', 'min']).toContain(PHONE_METADATA_SOURCE);
+  });
+
+  it('detects possible and valid numbers correctly', () => {
+    expect(isPossiblePhoneNumber('+12025550134')).toBe(true);
+    expect(isValidPhoneNumber('+12025550134')).toBe(true);
+    expect(isPossiblePhoneNumber('12345')).toBe(false);
+    expect(isValidPhoneNumber('12345')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add central phone validation helpers exposing validatePhoneNumber/isValidPhoneNumber/isPossiblePhoneNumber with structured PhoneValidationError metadata
- route AttributeAwareNormalizer and CLI through the shared helpers, enforcing min metadata bundles for CLI while keeping toE164 backwards compatible
- update docs, changelog, and regression suites to cover actionable errors and metadata strategy for issue #837

## Testing
- npm run test -- --run test/unit/normalizers/phone-number-normalization.test.ts test/utils/phone-validation.test.ts
- npm run test:offline
- npm run build

Resolves #837