### PR TITLE
Fix: Address PR #860 critical review issues

### DIFF
--- a/test/e2e/mcp/shared/edge-case-test-base.ts
+++ b/test/e2e/mcp/shared/edge-case-test-base.ts
@@ -258,6 +258,9 @@ export abstract class EdgeCaseTestBase extends MCPTestBase {
 
   /**
    * Generate invalid data patterns for testing
+   *
+   * ⚠️  WARNING: This method intentionally creates malformed/invalid data for error-path testing.
+   * DO NOT use this data for normal test scenarios. Use TestDataFactory for valid test data.
    */
   protected generateInvalidData(): Record<string, unknown>[] {
     return [

--- a/test/e2e/mcp/task-operations/task-crud.mcp.test.ts
+++ b/test/e2e/mcp/task-operations/task-crud.mcp.test.ts
@@ -120,8 +120,8 @@ describe('MCP P1 Task CRUD Operations', () => {
         expect(responseText).toMatch(
           /Created task|Successfully created task|task/i
         );
-        console.log(
-          `✅ Created minimal task - ID extraction failed but creation succeeded`
+        console.warn(
+          `⚠️  Created minimal task but ID extraction failed - SKIPPING CLEANUP TRACKING. Manual cleanup may be required.`
         );
         return; // Skip cleanup tracking if we can't get the ID
       }
@@ -326,9 +326,6 @@ describe('MCP P1 Task CRUD Operations', () => {
         responseText.includes('validation');
       expect(hasError).toBe(true);
       expect(responseText).toMatch(/not found|invalid|error|validation|uuid/i);
-
-      // Always pass since we're testing graceful handling - any response is valid
-      expect(true).toBeTruthy();
 
       console.log(`✅ Handled non-existent task deletion gracefully`);
     });


### PR DESCRIPTION
## Summary
Addresses critical issues identified in PR #860 review comment [#3367910976](https://github.com/kesslerio/attio-mcp-server/pull/860#issuecomment-3367910976)

## Changes
1. **Removed redundant catch-all assertion** (`expect(true).toBeTruthy()`) in task-crud.mcp.test.ts that defeats test purpose
2. **Added explicit cleanup warning** when ID extraction fails to prevent silent test data accumulation in workspace
3. **Enhanced JSDoc documentation** for `generateInvalidData()` method to clarify it's for error-path testing only

## Testing
- ✅ Pre-commit hooks passed (lint-staged, prettier, eslint)
- ✅ Pre-push validation passed (TypeScript + fast tests)
- ✅ Test suite: 2556 passed, 20 skipped

## Impact
- **Risk**: Low - Test-only changes, no production code modified
- **Size**: Small (2 files, 5 insertions, 5 deletions)
- **Scope**: Improves test reliability and clarity

Closes improvements suggested in PR #860 review