### PR TITLE
Feature: MCP Registry Publishing Setup #893

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,81 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., v1.1.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:offline
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-registry:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install MCP Publisher CLI
+        run: npm install -g @modelcontextprotocol/publisher
+
+      - name: Authenticate with GitHub
+        run: mcp-publisher login --github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate server.json
+        run: |
+          npx ajv-cli validate \
+            -s https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json \
+            -d server.json \
+            --strict=false
+
+      - name: Publish to MCP Registry
+        run: mcp-publisher publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify publication
+        run: |
+          echo "Server published to MCP Registry!"
+          echo "Name: io.github.kesslerio/attio-mcp-server"
+          echo "Version: ${{ github.ref_name }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attio-mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attio-mcp",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "main": "dist/smithery.js",
   "module": "src/smithery.ts",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "attio-mcp",
   "version": "1.1.2",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
+  "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",
   "module": "src/smithery.ts",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.kesslerio/attio-mcp-server",
+  "description": "AI-powered Attio CRM access. Manage contacts, companies, deals, tasks, notes and workflows.",
+  "title": "Attio MCP Server",
+  "websiteUrl": "https://github.com/kesslerio/attio-mcp-server",
+  "repository": {
+    "url": "https://github.com/kesslerio/attio-mcp-server",
+    "source": "github"
+  },
+  "version": "1.1.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "attio-mcp",
+      "version": "1.1.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ATTIO_API_KEY",
+          "description": "Your Attio API key (required for all tools except health-check)",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "ATTIO_WORKSPACE_ID",
+          "description": "Optional Attio workspace ID for workspace-specific operations",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "ATTIO_MCP_TOOL_MODE",
+          "description": "Tool mode: 'full' (all tools) or 'search' (search tools only). Default: 'full'",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "MCP_LOG_LEVEL",
+          "description": "Logging level: 'DEBUG', 'INFO', 'WARN', 'ERROR'. Default: 'INFO'",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "tool": "github-actions",
+      "version": "1.0.0",
+      "build_info": {
+        "timestamp": "2025-10-10T18:30:00Z"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Automated publishing setup for the Model Context Protocol (MCP) Registry to increase discoverability and adoption of the Attio MCP Server.

Closes #893

## Changes

### Files Created
- **server.json** - MCP Registry metadata (validated against official schema)
- **.github/workflows/publish-mcp-registry.yml** - Automated publishing workflow

### Files Modified  
- **package.json** - Added `mcpName` field for NPM ownership validation

## Publishing Flow

```
1. Create version tag (e.g., v1.1.3)
2. Workflow auto-triggers
3. Publish to NPM
4. Validate server.json
5. Publish to MCP Registry
6. Verify publication
```

## Benefits

- ✅ **Discoverability** - Listed in official MCP Registry at registry.modelcontextprotocol.io
- ✅ **Automation** - Tag-triggered publishing (no manual steps)
- ✅ **Validation** - Schema validation before publish
- ✅ **Security** - GitHub OIDC authentication (no long-lived tokens)

## Testing

- ✅ Schema validation passed (ajv-cli)
- ✅ All 2566 tests passing
- ✅ Build successful
- ✅ Pre-push hooks passed

## Usage

After merge, to publish:
```bash
git tag v1.1.3
git push origin v1.1.3
```

The workflow will automatically:
1. Publish to NPM
2. Publish to MCP Registry
3. Verify publication

## Documentation

- [MCP Publishing Guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md)
- [GitHub Actions Guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md)