### PR TITLE
Chore: Bump version to 1.1.9 for NPM publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Security
+
+### Deprecated
+
+## [1.1.9] - 2025-10-23
+
+### Fixed
+
 - **Person creation now supports optional email addresses** (#895) - Removed unnecessary validation requiring `email_addresses` for person records
   - **Problem**: MCP server enforced `email_addresses` as required when Attio API only requires `name`
   - **Solution**: Updated `PersonCreator` to validate only `name` field (actual API requirement)
@@ -21,10 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added comprehensive unit tests for person creation without email
   - Updated E2E fixtures to include truly minimal person (name only)
   - Modified `PersonMockFactory` to support optional email addresses
-
-### Security
-
-### Deprecated
 
 ## [1.1.2] - 2025-10-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/kesslerio/attio-mcp-server",
     "source": "github"
   },
-  "version": "1.1.8",
+  "version": "1.1.9",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "attio-mcp",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Version bump from 1.1.8 to 1.1.9 to enable NPM publishing of the email_addresses optional fix (#895).

## Reason for Version Bump

Version 1.1.8 was already published to NPM on October 10, 2025 **before** PR #896 was merged. This means the published `attio-mcp@1.1.8` package does NOT include the optional email addresses fix from #895.

To get the fix published to NPM, we need a new version number.

## Changes

- **package.json**: Bumped version to 1.1.9
- **CHANGELOG.md**: Moved [1.1.8] content to [1.1.9] section with today's date
- **server.json**: Updated both version fields to 1.1.9

## What's Included

This release includes all changes from PR #896:
- Person creation with optional email addresses (#895)
- Enhanced data normalizer validation
- Refactored PersonMockFactory email handling
- Comprehensive test coverage for name-only person creation

## Next Steps

After merging:
1. Create GitHub release for v1.1.9  
2. Trigger publish workflow to NPM
3. Verify package is available at `npm install attio-mcp@1.1.9`

Closes #897