### PR TITLE
Fix: Wireit config and bump version to 1.1.10 #898

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [1.1.9] - 2025-10-23
+## [1.1.10] - 2025-10-23
 
 ### Fixed
 
+- **Release pipeline wireit configuration** (#898) - Fixed build configuration blocking NPM releases
+  - **Problem**: `lint:tools` script used direct command instead of wireit, causing Release Pipeline validation failures
+  - **Solution**: Updated package.json to use `"lint:tools": "wireit"` as required by wireit configuration
+  - **Result**: Release Pipeline can now complete successfully and publish to NPM
 - **Person creation now supports optional email addresses** (#895) - Removed unnecessary validation requiring `email_addresses` for person records
   - **Problem**: MCP server enforced `email_addresses` as required when Attio API only requires `name`
   - **Solution**: Updated `PersonCreator` to validate only `name` field (actual API requirement)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",
@@ -36,7 +36,7 @@
     "lint:fix": "wireit",
     "format": "npx prettier --write --config .prettierrc src/**/*.ts test/**/*.ts *.ts",
     "check:format": "npx prettier --check --config .prettierrc src/**/*.ts test/**/*.ts *.ts",
-    "lint:tools": "tsx scripts/tool-schema-lint.ts",
+    "lint:tools": "wireit",
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:offline": "SKIP_INTEGRATION_TESTS=true vitest --config configs/vitest/vitest.config.offline.ts",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/kesslerio/attio-mcp-server",
     "source": "github"
   },
-  "version": "1.1.9",
+  "version": "1.1.10",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "attio-mcp",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Fixes the Release Pipeline validation failure that was blocking NPM releases by correcting the wireit configuration and bumping version to 1.1.10.

## Changes

### Build Configuration Fix (#898)
- Fixed `lint:tools` script in package.json to use `"wireit"` instead of direct command
- This was causing the Release Pipeline to fail with: `This command should just be "wireit", as this script is configured in the wireit section`

### Version Bump
- Bumped version from 1.1.9 to 1.1.10 (v1.1.9 release attempt failed)
- Updated package.json, server.json, and CHANGELOG.md
- Included person creation optional email changes from PR #896

## Problem

The Release Pipeline was failing during lint/type-check validation:
```
package.json:39:19 This command should just be "wireit", as this script is configured in the wireit section.
        "lint:tools": "tsx scripts/tool-schema-lint.ts",
```

This prevented v1.1.9 from being published to NPM.

## Solution

Changed package.json line 39 from:
```json
"lint:tools": "tsx scripts/tool-schema-lint.ts",
```

To:
```json
"lint:tools": "wireit",
```

## Testing

- ✅ All 2575 tests passing
- ✅ TypeScript validation passing
- ✅ Pre-push hooks passing

## Acceptance Criteria

- [x] package.json lint:tools script uses wireit
- [x] Version bumped to 1.1.10
- [x] CHANGELOG.md updated
- [ ] Release Pipeline passes validation (will verify after merge)
- [ ] Successfully publish to NPM

Resolves #898
Related: #895, #897