### PR TITLE
Release: Bump version to 1.2.0 #911

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attio-mcp",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attio-mcp",
-      "version": "1.1.8",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",


### PR DESCRIPTION
## Summary

Bumps package version from 1.1.10 to 1.2.0 for the v1.2.0 release.

## Changes

- Updated `package.json` version: 1.1.10 → 1.2.0
- Updated `package-lock.json` to match

## Context

This PR completes the release preparation started in PR #912 (CHANGELOG updates).

After this PR is merged:
1. Create GitHub release v1.2.0 using `gh release create v1.2.0`
2. GitHub Actions will automatically publish to NPM
3. Smithery will auto-sync from NPM

Related: #911