### PR TITLE
Docs: Clarify npm package name (attio-mcp vs attio-mcp-server) #903

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Clarified npm package name confusion** (#903) - Updated all documentation to clearly indicate correct package name
+  - **Problem**: GitHub repository is named `attio-mcp-server`, but npm package is named `attio-mcp` (renamed in June 2025)
+  - **Old package**: `attio-mcp-server@0.0.2` (abandoned, February 2025) - only 4 legacy tools
+  - **Current package**: `attio-mcp@1.2.0` (actively maintained) - 34 universal tools
+  - **Impact**: Users installing `npm install attio-mcp-server` got outdated v0.0.2 instead of current v1.2.0
+  - **Solution**: Added prominent warnings in README and documentation about correct package name
+  - **Note**: Old package owned by different npm user, cannot be deprecated by maintainers
+  - **Result**: Clear installation instructions prevent users from installing wrong package
+
 ### Fixed
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -376,7 +376,13 @@ See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for detailed solutions to these r
 
 ## 🚀 Installation
 
-### Installing via Smithery
+> ⚠️ **IMPORTANT: Correct Package Name**
+>
+> The npm package name is **`attio-mcp`** (not `attio-mcp-server`).
+> The GitHub repository is named `attio-mcp-server`, but the npm package was renamed to `attio-mcp` in June 2025.
+> Installing `attio-mcp-server` will give you an outdated v0.0.2 release with only 4 legacy tools.
+
+### Installing via Smithery (Recommended)
 
 To install Attio CRM Integration Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@kesslerio/attio-mcp-server):
 
@@ -384,14 +390,14 @@ To install Attio CRM Integration Server for Claude Desktop automatically via [Sm
 npx -y @smithery/cli install @kesslerio/attio-mcp-server --client claude
 ```
 
-### Option 1: NPM (Recommended)
+### Option 1: NPM
 
 ```bash
 # Global installation for CLI usage
-npm install -g attio-mcp-server
+npm install -g attio-mcp
 
 # Or local installation for project integration
-npm install attio-mcp-server
+npm install attio-mcp
 ```
 
 ### Option 2: One-Command Script Installation
@@ -433,10 +439,10 @@ export ATTIO_DEFAULT_CURRENCY="USD"                    # Default currency for de
 
 ```bash
 # Test the MCP server
-attio-mcp-server --help
+attio-mcp --help
 
 # Discover your Attio workspace attributes
-attio-mcp-server discover attributes
+attio-discover attributes
 ```
 
 ### 3. 🎯 **CRITICAL: Configure Field Mappings**
@@ -530,7 +536,7 @@ Deal stages are specific to your workspace. Check your Attio workspace settings 
 {
   "mcpServers": {
     "attio-mcp": {
-      "command": "attio-mcp-server",
+      "command": "attio-mcp",
       "env": {
         "ATTIO_API_KEY": "your_api_key_here",
         "ATTIO_WORKSPACE_ID": "your_workspace_id_here",
@@ -783,5 +789,5 @@ This project is licensed under the **Apache License 2.0** - see the [LICENSE](LI
 **Ready to transform your CRM workflow?** Install Attio MCP Server today and experience the future of CRM automation with AI!
 
 ```bash
-npm install -g attio-mcp-server
+npm install -g attio-mcp
 ```

--- a/docs/api/mcp-integration-guide.md
+++ b/docs/api/mcp-integration-guide.md
@@ -14,8 +14,10 @@ This guide explains how to integrate the Attio MCP server with Claude to enable 
 
 ### 1. Install the Attio MCP Server
 
+> ⚠️ **Note**: The npm package name is `attio-mcp` (not `attio-mcp-server`)
+
 ```sh
-npm install attio-mcp-server
+npm install attio-mcp
 ```
 
 ### 2. Configure Environment Variables
@@ -35,7 +37,7 @@ Add the following configuration to Claude Desktop:
   "mcpServers": {
     "attio": {
       "command": "npx",
-      "args": ["attio-mcp-server"],
+      "args": ["attio-mcp"],
       "env": {
         "ATTIO_API_KEY": "YOUR_ATTIO_API_KEY"
       }
@@ -87,11 +89,13 @@ Show me the most recent companies in our CRM
 If you prefer to run the MCP server in Docker:
 
 1. Pull the image:
+
    ```sh
    docker pull attio-mcp-server:latest
    ```
 
 2. Run the container:
+
    ```sh
    docker run -p 3000:3000 \
      -e ATTIO_API_KEY=your_api_key_here \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,11 +15,13 @@ Before you begin, ensure you have the following:
 
 ### Option 1: Install from npm (Recommended for Users)
 
+> ⚠️ **Note**: The npm package name is `attio-mcp` (not `attio-mcp-server`)
+
 ```bash
-npm install -g attio-mcp-server
+npm install -g attio-mcp
 ```
 
-This makes the `attio-mcp-server` command available globally.
+This makes the `attio-mcp` command available globally.
 
 ### Option 2: Clone Repository (Recommended for Development)
 
@@ -50,6 +52,7 @@ The server requires the following environment variables:
 - `ATTIO_WORKSPACE_ID` (optional): Your Attio workspace ID
 
 **Optional Deal Configuration**:
+
 - `ATTIO_DEFAULT_DEAL_OWNER` (optional): Default owner email address for new deals (e.g., "user@company.com")
 - `ATTIO_DEFAULT_DEAL_STAGE` (optional): Default stage for new deals (e.g., "Interested")
 - `ATTIO_DEFAULT_CURRENCY` (optional): Default currency for deal values (e.g., "USD")
@@ -73,7 +76,7 @@ Or pass them as environment variables when running the server.
 ### Option 1: Using npx (if installed globally)
 
 ```bash
-attio-mcp-server
+attio-mcp
 ```
 
 ### Option 2: From cloned repository
@@ -113,6 +116,7 @@ For developers contributing to the project, we provide a comprehensive setup scr
 ```
 
 The setup script will:
+
 - ✅ Check and validate Node.js version (>=18.0.0)
 - ✅ Install npm dependencies
 - ✅ Set up git hooks (Husky) for pre-commit validation
@@ -125,6 +129,7 @@ The setup script will:
 - ✅ Provide clear feedback and next steps
 
 For a minimal setup (e.g., in CI/CD):
+
 ```bash
 ./scripts/setup-dev-env.sh --skip-tdd --skip-ide --skip-hooks
 ```
@@ -138,7 +143,7 @@ To use the Attio MCP Server with Claude Desktop, add the following to your Claud
   "mcpServers": {
     "attio": {
       "command": "npx",
-      "args": ["attio-mcp-server"],
+      "args": ["attio-mcp"],
       "env": {
         "ATTIO_API_KEY": "YOUR_ATTIO_API_KEY"
       }
@@ -165,7 +170,7 @@ You can customize the behavior via environment variables in your `.env` file:
 # Disable auto-discovery (default: true)
 ATTIO_AUTO_DISCOVERY=false
 
-# Disable discovery on startup (default: true)  
+# Disable discovery on startup (default: true)
 ATTIO_DISCOVERY_ON_STARTUP=false
 
 # Set update interval in minutes (default: 60)
@@ -195,6 +200,7 @@ To verify that the server is running correctly:
 4. Claude should respond with data from your Attio instance
 
 The server will automatically discover attributes on startup. Check the logs for:
+
 ```
 Starting automatic attribute discovery...
 Discovered X attributes for companies
@@ -202,6 +208,7 @@ Automatic attribute discovery completed successfully
 ```
 
 If discovery fails, it won't prevent the server from starting. You can:
+
 - Check logs for error details
 - Run manual discovery: `npm run discover:all-attributes:robust`
 - See [CLI Troubleshooting](./cli/README.md#troubleshooting) for more help


### PR DESCRIPTION
## Summary

Fixes #903 - Package name confusion causing users to install outdated version

## Problem

- GitHub repository: `attio-mcp-server`
- Current npm package: `attio-mcp` (renamed June 2025)
- Old abandoned package: `attio-mcp-server@0.0.2` (February 2025)
- Users installing `npm install attio-mcp-server` get outdated v0.0.2 with only 4 legacy tools

## Root Cause

The repository name `attio-mcp-server` naturally leads users to try installing `attio-mcp-server` from npm, but:

1. **Two different packages exist on npm:**
   - `attio-mcp-server@0.0.2` - Abandoned, February 2025, 4 legacy tools
   - `attio-mcp@1.2.0` - Current, actively maintained, 34 universal tools

2. **Package name history:**
   - Original: `attio-mcp-server` (v0.0.1, v0.0.2 in Feb 2025)
   - Renamed: `attio-mcp` (June 2025, issue #868)
   - Old package never deprecated (different npm owner)

3. **Tool name mismatch confirms version:**
   - User reported seeing: `search-companies`, `read-company-details`, `read-company-notes`, `create-company-note`
   - These 4 tool names **do not exist** in current codebase
   - Proves user is running ancient v0.0.2

## Solution

Added prominent warnings and updated all documentation:

### Changes Made

- ✅ **README.md**: Added warning box at top of installation section explaining package name
- ✅ **docs/getting-started.md**: Updated npm package name and commands
- ✅ **docs/api/mcp-integration-guide.md**: Corrected installation instructions
- ✅ **CHANGELOG.md**: Added detailed entry under [Unreleased] > Changed
- ✅ All `npm install` commands now use `attio-mcp` (not `attio-mcp-server`)
- ✅ All CLI examples updated (`attio-mcp`, `attio-discover` binaries)
- ✅ Claude Desktop config examples updated

### Files Changed

- `README.md` - Added warning, updated 3 npm install commands + 2 CLI examples
- `docs/getting-started.md` - Added note, updated install + CLI commands
- `docs/api/mcp-integration-guide.md` - Added note, updated install + config
- `CHANGELOG.md` - Added comprehensive entry explaining package history

## Why We Can't Deprecate Old Package

Attempted to deprecate `attio-mcp-server@0.0.2`:

```bash
npm deprecate attio-mcp-server@"<=0.0.2" "⚠️ DEPRECATED: ..."
```

Result:
```
npm error 403 403 Forbidden - You do not have permission to publish "attio-mcp-server"
```

The old package has **multiple npm owners** (heimark + kesslerio). Only original owner (heimark) can deprecate it.

## Testing

- [x] Updated README warning displays correctly
- [x] All npm install commands use correct package name
- [x] CLI command examples match actual binaries
- [x] CHANGELOG entry is clear and informative
- [x] Pre-commit checks pass (lint-staged + prettier)

## Verification Steps for Users

```bash
# Check installed version
npm list -g attio-mcp
# Should show: attio-mcp@1.2.0

# Check available tools
attio-mcp --help
# Should show 34 tools, not 4
```

## Related

- Issue #903: Bug report from user @mlemos
- Issue #868: Original MCP naming optimization (June 2025)
- Smithery installation: Always has correct version (https://smithery.ai/server/@kesslerio/attio-mcp-server)

## Checklist

- [x] Documentation updated with clear warnings
- [x] All installation commands corrected
- [x] CHANGELOG entry added
- [x] Issue #903 updated with root cause analysis
- [x] Tests pass
- [ ] Consider contacting @heimark about deprecating old package