### PR TITLE
Feature: Add custom objects support to resource type validation #918

### DIFF
--- a/src/handlers/tools/dispatcher/utils.ts
+++ b/src/handlers/tools/dispatcher/utils.ts
@@ -1,6 +1,7 @@
 /**
  * Dispatcher utilities
  */
+import { loadMappingConfig } from '../../../utils/config-loader.js';
 
 /**
  * Normalize error messages by stripping tool execution prefixes.
@@ -10,11 +11,14 @@ export function normalizeToolMsg(msg: string): string {
 }
 
 /**
- * Canonicalize resource type to valid values and prevent mutations
+ * Canonicalize resource type to valid values and prevent mutations.
+ * Supports both standard objects and custom objects defined in mapping config.
  */
 export function canonicalizeResourceType(rt: unknown): string {
   const value = String(rt ?? '').toLowerCase();
-  const validTypes = [
+
+  // Standard resource types that are always valid
+  const standardTypes = [
     'records',
     'lists',
     'people',
@@ -23,6 +27,14 @@ export function canonicalizeResourceType(rt: unknown): string {
     'deals',
     'notes',
   ];
+
+  // Load custom objects from mapping configuration
+  // Custom objects are discovered via attio-discover and stored in config/mappings/user.json
+  const config = loadMappingConfig();
+  const customObjects = Object.keys(config.mappings.attributes.objects || {});
+
+  // Merge standard types with custom objects (deduplicated)
+  const validTypes = [...new Set([...standardTypes, ...customObjects])];
 
   if (!validTypes.includes(value)) {
     throw new Error(


### PR DESCRIPTION
## Description
Enables universal record tools to work with custom Attio objects (e.g., funds, investment_opportunities, portfolios) discovered via `attio-discover`.

## Related Issue
Fixes #918

## Problem
Previously, `canonicalizeResourceType()` used a hardcoded list of valid resource types:
- `companies`, `people`, `tasks`, `deals`, `lists`, `notes`, `records`

Custom Attio objects were rejected with an error, preventing users from accessing their custom CRM data via universal record tools (`search-records`, `create-record`, `update-record`, etc.).

## Solution
- Load mapping configuration via `loadMappingConfig()`
- Extract custom object types from `config.mappings.attributes.objects`  
- Merge custom objects with standard types (deduplicated via Set)
- Use combined list for resource type validation

## Changes Made
- **File modified**: `src/handlers/tools/dispatcher/utils.ts`
- Added import: `loadMappingConfig` from `../../../utils/config-loader.js`
- Dynamic validation list instead of static hardcoded array
- Updated comments to clarify custom object support

## How It Works
1. User runs `attio-discover` to discover custom objects in their Attio workspace
2. Discovery results stored in `config/mappings/user.json`
3. `canonicalizeResourceType()` loads config and extracts object keys
4. Custom objects (e.g., `funds`, `investment_opportunities`) now pass validation
5. Users can use universal tools with custom objects just like standard types

## Impact
✅ **Enables custom object support** - Users can now access custom Attio objects  
✅ **No breaking changes** - All existing functionality preserved  
✅ **Better error messages** - Error messages automatically include custom objects in suggestions  
✅ **Zero code changes for users** - Works automatically after running `attio-discover`

## Testing Completed
- ✅ All offline tests pass: `npm run test:offline:run` (2646 passed)
- ✅ Build succeeds: `npm run build`
- ✅ No TypeScript errors
- ✅ Backwards compatible with existing tests
- ✅ Pre-push validation passed: TypeScript check + fast tests

## Example Usage
```bash
# Step 1: Discover custom objects in workspace
attio-discover

# Step 2: Use custom objects with universal tools
# These now work with discovered custom objects like "funds" or "investment_opportunities"
search-records --resource_type=funds --query="Series A"
create-record --resource_type=investment_opportunities --data='{...}'
update-record --resource_type=portfolios --record_id=... --data='{...}'
```

## Checklist
- [x] Code builds without errors
- [x] Tests pass
- [x] No breaking changes
- [x] Follows project commit message format
- [x] P2 Medium priority feature
- [x] Documentation updated (inline comments)