### PR TITLE
Chore: Bump version to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attio-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attio-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",


### PR DESCRIPTION
## Summary
- Version bump to 1.2.1 for npm release

## Changes included from v1.2.0
- MCP SDK v1.18 compatibility fix (prompts capability)
- Deal field alias improvements (`deal_owner → owner`)
- Improved stage discovery error messages

## Test plan
- [x] Build passes
- [x] All tests pass (`npm run test:offline`)
- [ ] CI passes
- [ ] Tag and publish to npm after merge