### PR TITLE
Chore: Bump version to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Security
+
+### Deprecated
+
+## [1.2.2] - 2025-12-01
+
+### Fixed
+
+- **Critical: Added axios to production dependencies** (#917, #919) - Package failed on startup with `ERR_MODULE_NOT_FOUND` because axios was incorrectly placed in devDependencies instead of dependencies. This caused 100% failure rate for all users installing via npm.
+
+- **CLI binary symlink resolution** (#916, #920) - `attio-mcp --help` and `--version` now work correctly when installed via npm global. The `isMain` check now resolves symlinks before path comparison, handling npm's symlink-based binary wrappers.
+
+## [1.2.1] - 2025-11-28
+
+### Changed
+
 - **Clarified npm package name confusion** (#903) - Updated all documentation to clearly indicate correct package name
   - **Problem**: GitHub repository is named `attio-mcp-server`, but npm package is named `attio-mcp` (renamed in June 2025)
   - **Old package**: `attio-mcp-server@0.0.2` (abandoned, February 2025) - only 4 legacy tools

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",


### PR DESCRIPTION
## Critical Bug Fix Release

This release addresses critical bugs that made v1.2.1 non-functional.

### Fixed

- **Critical: Added axios to production dependencies** (#917, #919) - Package failed on startup with `ERR_MODULE_NOT_FOUND` because axios was incorrectly placed in devDependencies
- **CLI binary symlink resolution** (#916, #920) - `attio-mcp --help` and `--version` now work correctly when installed via npm global

### Note
v1.2.1 is broken - this release is required for the package to function.

### Checklist
- [x] Version bumped to 1.2.2
- [x] CHANGELOG.md updated
- [x] Build passes
- [x] All offline tests pass (2647 tests)