### PR TITLE
Docs: Fix stale cloudflare-oauth-worker references #928

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ OAuth access token support - enables delegated authentication for third-party in
   - Tokens saved to `.env.local` for easy configuration
 
 - **Cloudflare Worker OAuth template** (#928) - Self-hostable OAuth broker for teams
-  - Full OAuth 2.1 + PKCE implementation at `examples/cloudflare-oauth-worker/`
+  - Full OAuth 2.1 + PKCE implementation at `examples/cloudflare-mcp-server/`
   - OAuth discovery endpoint, CORS support for Claude.ai
   - Deploy with `wrangler deploy`
 

--- a/docs/guides/oauth-authentication.md
+++ b/docs/guides/oauth-authentication.md
@@ -218,4 +218,4 @@ This usually means:
 
 ## Self-Hosted OAuth Broker
 
-For teams that need a managed OAuth flow without handling tokens manually, see the [Cloudflare Worker OAuth template](../../examples/cloudflare-oauth-worker/README.md) for a self-hostable OAuth broker.
+For teams that need a managed OAuth flow without handling tokens manually, see the [Cloudflare Worker MCP Server](../../examples/cloudflare-mcp-server/README.md) for a self-hostable remote MCP server with OAuth.


### PR DESCRIPTION
Updates two stale references to `cloudflare-oauth-worker` → `cloudflare-mcp-server`