### PR TITLE
Chore: Release v1.3.6 - Documentation improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attio-mcp",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attio-mcp",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",


### PR DESCRIPTION
## Summary

Version bump for v1.3.6 release.

**Changes included in v1.3.6** (already merged via #961):
- Install script test suite (28 tests)
- E2E remote mode troubleshooting guide
- Expanded remote deployment production checklist (12→28+ items)

Closes #958

## Changes

- `package.json`: 1.3.5 → 1.3.6
- `package-lock.json`: version sync

## Post-Merge

After merge:
1. GitHub release will be created from tag v1.3.6 (already pushed)
2. npm publish to registry