### PR TITLE
Fix: Tighten daily changelog criteria #900

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -116,8 +116,9 @@ jobs:
           echo "Claude action failed, using fallback method..."
 
           # Avoid duplicate PRs: skip if an open Daily changelog PR already exists
-          EXISTING_PR=$(gh pr list --state open --search "chore: Daily changelog for" --limit 1 --json number 2>/dev/null || true)
-          if [ -n "$EXISTING_PR" ]; then
+          # Use --jq 'length' to correctly detect zero vs non-zero results (empty array [] is non-empty string)
+          EXISTING_PR_COUNT=$(gh pr list --state open --search "chore: Daily changelog for" --limit 1 --json number --jq 'length' 2>/dev/null || echo 0)
+          if [ "$EXISTING_PR_COUNT" -gt 0 ]; then
             echo "Open Daily changelog PR already exists - skipping fallback changelog update"
             exit 0
           fi
@@ -190,9 +191,6 @@ jobs:
           gh pr create --title "chore: Daily changelog for $TODAY" --body "Automated daily changelog generation (fallback method)"
 
           echo "Fallback changelog generation completed successfully"
-
-          # Mark that a changelog branch/PR was created for summary reporting
-          echo "BRANCH_CREATED=1" >> "$GITHUB_ENV"
 
       - name: Workflow summary
         if: always()

--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -63,12 +63,28 @@ jobs:
           prompt: |
             Generate a daily changelog by analyzing commits since yesterday.
 
-            IMPORTANT: You have full permissions to write files and create branches. Use the following workflow:
+            IMPORTANT POLICY:
+            - The changelog should only include **meaningful product changes**:
+              - Bug fixes
+              - New features
+              - Refactors or performance/UX improvements
+            - A commit is considered "meaningful" only if its subject line starts with one of:
+              - "Fix:", "Feature:", "Refactor:", "Perf:", "UI:", or "UX:"
+            - Commits with other prefixes (for example "Chore:", "Docs:", "Test:") should generally be ignored.
 
-            1. Review git commits from the last 24 hours using: git log --since="1 day ago" --oneline
-            2. Categorize changes (Features, Fixes, Refactor, Documentation, etc.)
-            3. Check if there are meaningful changes worth documenting
-            4. If yes, create a branch: git checkout -b chore/daily-changelog-$(date +%Y-%m-%d)
+            BEFORE creating any branch or editing files, you MUST:
+            1. Check if there is already an open Daily changelog PR using:
+               gh pr list --state open --search "chore: Daily changelog for" --limit 1
+               - If there is an open PR, log a short message like
+                 "Open Daily changelog PR already exists - skipping changelog update" and then exit without changes.
+
+            When there is no existing Daily changelog PR and there ARE meaningful commits in the last 24 hours, use the following workflow:
+
+            1. Review git commits from the last 24 hours using: git log --since="1 day ago" --oneline --no-merges
+            2. Filter to only those commits whose subject starts with one of:
+               "Fix:", "Feature:", "Refactor:", "Perf:", "UI:", "UX:"
+            3. If there are **no** such commits, log "No meaningful changes since yesterday - skipping changelog update" and exit without making any git changes.
+            4. If there ARE meaningful commits, create a branch: git checkout -b chore/daily-changelog-$(date +%Y-%m-%d)
             5. Update CHANGELOG.md by adding a new section after "## [Unreleased]"
             6. Commit changes: git add CHANGELOG.md && git commit -m "chore: Daily changelog for $(date +%Y-%m-%d)"
             7. Push branch: git push -u origin HEAD
@@ -86,7 +102,7 @@ jobs:
             - Docs updates with PR/issue references
 
             Rules:
-            - Only include meaningful changes (exclude merge commits)
+            - Only include meaningful changes (exclude merge commits and non-meaningful prefixes)
             - Include PR/issue numbers where available
             - If no meaningful changes, output "No meaningful changes since yesterday - skipping changelog update"
             - Group related changes logically
@@ -99,8 +115,18 @@ jobs:
         run: |
           echo "Claude action failed, using fallback method..."
 
+          # Avoid duplicate PRs: skip if an open Daily changelog PR already exists
+          EXISTING_PR=$(gh pr list --state open --search "chore: Daily changelog for" --limit 1 --json number 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Open Daily changelog PR already exists - skipping fallback changelog update"
+            exit 0
+          fi
+
           # Get commits from last 24 hours
-          COMMITS=$(git log --since="1 day ago" --oneline --no-merges | grep -E "(Fix|Feature|Add|Update|Improve|Remove|Refactor)" || true)
+          # Only treat commits as meaningful if they use conventional prefixes
+          # that indicate bugs, new features, or UX/performance improvements.
+          # Examples: "Fix: ...", "Feature: ...", "Refactor: ...", "Perf: ...", "UI: ...", "UX: ...".
+          COMMITS=$(git log --since="1 day ago" --format='%h %s' --no-merges | grep -E '^[0-9a-f]+ (Fix:|Feature:|Refactor:|Perf:|UI:|UX:)' || true)
 
           if [ -z "$COMMITS" ]; then
             echo "No meaningful changes since yesterday - skipping changelog update"
@@ -117,9 +143,9 @@ jobs:
           CHANGELOG_ENTRY="## [$TODAY] - Daily Update\n\n"
 
           # Categorize commits
-          FEATURES=$(echo "$COMMITS" | grep -E "(Feature|Add)" || true)
-          FIXES=$(echo "$COMMITS" | grep -E "(Fix|Improve)" || true)  
-          CHANGES=$(echo "$COMMITS" | grep -E "(Update|Refactor|Change)" || true)
+          FEATURES=$(echo "$COMMITS" | grep -E '^[0-9a-f]+ (Feature:)' || true)
+          FIXES=$(echo "$COMMITS" | grep -E '^[0-9a-f]+ (Fix:)' || true)
+          CHANGES=$(echo "$COMMITS" | grep -E '^[0-9a-f]+ (Refactor:|Perf:|UI:|UX:)' || true)
 
           if [ ! -z "$FEATURES" ]; then
             CHANGELOG_ENTRY="${CHANGELOG_ENTRY}### Added\n"
@@ -165,6 +191,9 @@ jobs:
 
           echo "Fallback changelog generation completed successfully"
 
+          # Mark that a changelog branch/PR was created for summary reporting
+          echo "BRANCH_CREATED=1" >> "$GITHUB_ENV"
+
       - name: Workflow summary
         if: always()
         run: |
@@ -173,8 +202,13 @@ jobs:
           echo "Repository: ${{ github.repository }}"
           echo "Triggered by: ${{ github.event_name }}"
 
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "✅ Status: SUCCESS - Changelog generated and PR created"
+          TODAY=$(date +%Y-%m-%d)
+          BRANCH_EXISTS=$(git ls-remote --heads origin chore/daily-changelog-${TODAY} || true)
+
+          if [ "${{ job.status }}" = "success" ] && [ ! -z "$BRANCH_EXISTS" ]; then
+            echo "✅ Status: SUCCESS - Daily changelog branch created (check PRs for details)"
+          elif [ "${{ job.status }}" = "success" ]; then
+            echo "✅ Status: SUCCESS - No daily changelog branch created (no meaningful changes or existing PR)"
           elif [ "${{ job.status }}" = "failure" ]; then
             echo "❌ Status: FAILED - Check logs for details"
           else
@@ -182,8 +216,6 @@ jobs:
           fi
 
           # Check if PR was created
-          TODAY=$(date +%Y-%m-%d)
-          BRANCH_EXISTS=$(git ls-remote --heads origin chore/daily-changelog-${TODAY} || true)
           if [ ! -z "$BRANCH_EXISTS" ]; then
             echo "📝 Branch created: chore/daily-changelog-${TODAY}"
             echo "🔗 Check for PR at: https://github.com/${{ github.repository }}/pulls"

--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -150,31 +150,31 @@ jobs:
 
           if [ ! -z "$FEATURES" ]; then
             CHANGELOG_ENTRY="${CHANGELOG_ENTRY}### Added\n"
-            echo "$FEATURES" | while read line; do
+            while read -r line; do
               if [ ! -z "$line" ]; then
                 CHANGELOG_ENTRY="${CHANGELOG_ENTRY}- ${line#* }\n"
               fi
-            done
+            done <<< "$FEATURES"
             CHANGELOG_ENTRY="${CHANGELOG_ENTRY}\n"
           fi
 
           if [ ! -z "$FIXES" ]; then
             CHANGELOG_ENTRY="${CHANGELOG_ENTRY}### Fixed\n"
-            echo "$FIXES" | while read line; do
+            while read -r line; do
               if [ ! -z "$line" ]; then
                 CHANGELOG_ENTRY="${CHANGELOG_ENTRY}- ${line#* }\n"
               fi
-            done
+            done <<< "$FIXES"
             CHANGELOG_ENTRY="${CHANGELOG_ENTRY}\n"
           fi
 
           if [ ! -z "$CHANGES" ]; then
             CHANGELOG_ENTRY="${CHANGELOG_ENTRY}### Changed\n"
-            echo "$CHANGES" | while read line; do  
+            while read -r line; do
               if [ ! -z "$line" ]; then
                 CHANGELOG_ENTRY="${CHANGELOG_ENTRY}- ${line#* }\n"
               fi
-            done
+            done <<< "$CHANGES"
             CHANGELOG_ENTRY="${CHANGELOG_ENTRY}\n"
           fi
 

--- a/docs/workflows/daily-changelog.md
+++ b/docs/workflows/daily-changelog.md
@@ -4,6 +4,23 @@
 
 The daily changelog workflow automatically generates changelog entries by analyzing git commits from the last 24 hours. It runs at 8 PM PT daily and can also be triggered manually.
 
+The changelog is intentionally focused on **meaningful product changes**:
+
+- Bug fixes
+- New features
+- Refactors or performance improvements that impact UX/behavior
+
+Commits are considered "meaningful" when their subject line starts with one of these prefixes:
+
+- `Fix:`
+- `Feature:`
+- `Refactor:`
+- `Perf:`
+- `UI:`
+- `UX:`
+
+Commits using other prefixes (for example `Chore:`, `Docs:`, `Test:`) are generally excluded from the automated daily changelog.
+
 ## Improvements Made
 
 ### Key Issues Resolved
@@ -70,6 +87,8 @@ flowchart TD
 - Commit changes with descriptive message
 - Create pull request automatically
 
+Only **one** Daily changelog PR should be open at any given time. If an open PR with title matching `chore: Daily changelog for [date]` already exists, the workflow will skip creating a new branch/PR for that run.
+
 ## Manual Testing
 
 Use the provided test script to debug locally:
@@ -114,6 +133,9 @@ permissions:
 1. **No Meaningful Changes**
    - Workflow will output: "No meaningful changes since yesterday"
    - This is expected behavior, not an error
+   - Common reasons:
+     - Only `Chore:`, `Docs:`, or `Test:` commits in the last 24 hours
+     - No commits at all in the last 24 hours
 
 2. **Permission Denied**
    - Check if `CLAUDE_CODE_OAUTH_TOKEN` secret is configured

--- a/docs/workflows/daily-changelog.md
+++ b/docs/workflows/daily-changelog.md
@@ -21,6 +21,8 @@ Commits are considered "meaningful" when their subject line starts with one of t
 
 Commits using other prefixes (for example `Chore:`, `Docs:`, `Test:`) are generally excluded from the automated daily changelog.
 
+> **Note:** These prefixes are **case-sensitive** and must appear exactly at the start of the commit subject line. For example, `fix:` (lowercase) or `Feature(scope):` will not be matched.
+
 ## Improvements Made
 
 ### Key Issues Resolved

--- a/scripts/test-changelog.sh
+++ b/scripts/test-changelog.sh
@@ -27,24 +27,26 @@ echo "Current git status:"
 git status --short
 
 # Get recent commits
+# Use the SAME prefix policy as the workflow: Fix:, Feature:, Refactor:, Perf:, UI:, UX:
+# These prefixes are CASE-SENSITIVE and must appear at the start of the commit subject.
 echo ""
-echo "Recent commits (last 24 hours):"
-COMMITS=$(git log --since="1 day ago" --oneline --no-merges | grep -E "(Fix|Feature|Add|Update|Improve|Remove|Refactor)" || true)
+echo "Recent commits (last 24 hours) matching meaningful prefixes:"
+COMMITS=$(git log --since="1 day ago" --format='%h %s' --no-merges | grep -E '^[0-9a-f]+ (Fix:|Feature:|Refactor:|Perf:|UI:|UX:)' || true)
 
 if [ -z "$COMMITS" ]; then
     echo "No meaningful changes in the last 24 hours"
-    echo "For testing, showing commits from last 7 days:"
-    COMMITS=$(git log --since="7 days ago" --oneline --no-merges | head -10)
+    echo "For testing, showing ALL commits from last 7 days (not filtered by prefix):"
+    COMMITS=$(git log --since="7 days ago" --format='%h %s' --no-merges | head -10)
 fi
 
 echo "$COMMITS"
 
-# Categorize commits
+# Categorize commits using the SAME categories as the workflow
 echo ""
 echo "Categorizing commits..."
-FEATURES=$(echo "$COMMITS" | grep -E "(Feature|Add)" || true)
-FIXES=$(echo "$COMMITS" | grep -E "(Fix|Improve)" || true)  
-CHANGES=$(echo "$COMMITS" | grep -E "(Update|Refactor|Change)" || true)
+FEATURES=$(echo "$COMMITS" | grep -E '^[0-9a-f]+ (Feature:)' || true)
+FIXES=$(echo "$COMMITS" | grep -E '^[0-9a-f]+ (Fix:)' || true)
+CHANGES=$(echo "$COMMITS" | grep -E '^[0-9a-f]+ (Refactor:|Perf:|UI:|UX:)' || true)
 
 # Generate changelog content
 TODAY=$(date +%Y-%m-%d)


### PR DESCRIPTION
Tighten the Daily Changelog workflow to only create PRs when there are meaningful commits (Fix/Feature/Refactor/Perf/UI/UX prefixes) and to ensure only one Daily changelog PR can be open at a time.\n\nChanges:\n- Align Claude and fallback paths on conventional-commit-style prefixes: Fix:, Feature:, Refactor:, Perf:, UI:, UX:\n- Skip daily changelog generation when no meaningful commits are present in the last 24 hours\n- Add guard to skip when an open Daily changelog PR already exists\n- Make workflow summary messaging accurately reflect whether a daily changelog branch was created\n- Update docs/workflows/daily-changelog.md to document the new policy and behavior