### PR TITLE
Fix: Enhance uniqueness constraint violation errors #990

### DIFF
--- a/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
+++ b/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
@@ -605,6 +605,119 @@ const buildMissingDealStageMessage = async (
 };
 
 /**
+ * Issue #990: Configuration for unique field searchers per resource type
+ * Maps resource types to their unique fields and search functions
+ */
+interface UniqueFieldSearcher {
+  fields: string[];
+  search: (
+    value: string
+  ) => Promise<Array<{ id?: { record_id?: string }; values?: unknown }>>;
+}
+
+/**
+ * Issue #990: Searches for conflicting record when uniqueness constraint violation occurs
+ * Returns enhanced error message with existing record ID and actionable options
+ */
+async function enhanceUniquenessErrorWithSearch(
+  resourceType: string,
+  recordData: Record<string, unknown>
+): Promise<string | null> {
+  const UNIQUE_FIELD_SEARCHERS: Record<string, UniqueFieldSearcher> = {
+    companies: {
+      fields: ['domains', 'domain'],
+      search: async (value: string) => {
+        const { searchCompaniesByDomain } = await import(
+          '@/objects/companies/search.js'
+        );
+        return searchCompaniesByDomain(value);
+      },
+    },
+    people: {
+      fields: ['email_addresses', 'email', 'emails'],
+      search: async (value: string) => {
+        const { searchPeopleByEmail } = await import(
+          '@/objects/people/search.js'
+        );
+        return searchPeopleByEmail(value);
+      },
+    },
+  };
+
+  const searcher = UNIQUE_FIELD_SEARCHERS[resourceType.toLowerCase()];
+  if (!searcher) return null;
+
+  // Find which unique field has a value in recordData
+  for (const field of searcher.fields) {
+    let searchValue = recordData[field];
+
+    // Handle array format (e.g., domains: ["example.com"])
+    if (Array.isArray(searchValue) && searchValue.length > 0) {
+      searchValue = searchValue[0];
+    }
+
+    // Handle object format for emails (e.g., email_addresses: [{email_address: "..."}])
+    if (
+      searchValue &&
+      typeof searchValue === 'object' &&
+      !Array.isArray(searchValue)
+    ) {
+      const obj = searchValue as Record<string, unknown>;
+      searchValue = obj.email_address || obj.email || obj.value;
+    }
+
+    if (searchValue && typeof searchValue === 'string') {
+      try {
+        const existing = await searcher.search(searchValue);
+        if (existing && existing.length > 0) {
+          const recordId = existing[0]?.id?.record_id;
+          if (recordId) {
+            return formatUniquenessErrorMessage(
+              resourceType,
+              field,
+              searchValue,
+              recordId
+            );
+          }
+        }
+      } catch (err) {
+        // Search failed, log and continue to fallback
+        sanitizedLog(logger, 'debug', 'Uniqueness search failed', {
+          resourceType,
+          field,
+          error: String(err),
+        });
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Issue #990: Formats actionable error message for uniqueness constraint violations
+ */
+function formatUniquenessErrorMessage(
+  resourceType: string,
+  field: string,
+  value: string,
+  recordId: string
+): string {
+  const singular = getSingularResourceType(
+    resourceType as UniversalResourceType
+  );
+
+  return (
+    `Uniqueness conflict on "${field}": value "${value}" already exists on ${singular} record.\n\n` +
+    `EXISTING RECORD ID: ${recordId}\n\n` +
+    `OPTIONS:\n` +
+    `1. Update existing: update-record(resource_type="${resourceType}", record_id="${recordId}", record_data={...})\n` +
+    `2. View existing: records_get_details(resource_type="${resourceType}", record_id="${recordId}")\n` +
+    `3. Use a different ${field} value`
+  );
+}
+
+/**
  * Handles errors specific to record creation operations
  */
 export const handleCreateError = async (
@@ -646,12 +759,26 @@ export const handleCreateError = async (
     throw errorResult;
   }
 
-  if (error instanceof Error && error.message.includes('duplicate')) {
+  // Issue #990: Enhanced uniqueness constraint violation handling
+  if (
+    error instanceof Error &&
+    (error.message.includes('duplicate') ||
+      error.message.toLowerCase().includes('uniqueness constraint'))
+  ) {
     const resourceName = getSingularResourceType(
       resourceType as UniversalResourceType
     );
+
+    // Try to find and identify the conflicting record
+    const enhancedMessage = await enhanceUniquenessErrorWithSearch(
+      resourceType,
+      recordData
+    );
+
     const errorResult = createErrorResult(
-      `Failed to create ${resourceName}: A record with similar data already exists.`,
+      enhancedMessage
+        ? `Failed to create ${resourceName}: ${enhancedMessage}`
+        : `Failed to create ${resourceName}: A record with similar data already exists. Check unique fields like domains or email_addresses.`,
       'duplicate_error',
       { context }
     );


### PR DESCRIPTION
## Summary

- Enhance uniqueness constraint violation error messages to be actionable for LLMs
- Show which field caused the conflict (e.g., `domains`, `email_addresses`)
- Include the conflicting value and existing record ID
- Provide actionable options: update existing, view details, or use different value

## Problem

Current error message is generic and unhelpful:
```
❌ Failed to create company: A record with similar data already exists.
```

The LLM doesn't know:
1. Which field caused the conflict
2. What value conflicted  
3. Which existing record has that value
4. What to do next

## Solution

New error message format:
```
Failed to create company: Uniqueness conflict on "domains": value "createmedspa.com" already exists on company record.

EXISTING RECORD ID: 93c516be-d287-5690-a827-38e1bfdf75b5

OPTIONS:
1. Update existing: update-record(resource_type="companies", record_id="93c516be-d287-5690-a827-38e1bfdf75b5", record_data={...})
2. View existing: records_get_details(resource_type="companies", record_id="93c516be-d287-5690-a827-38e1bfdf75b5")
3. Use a different domains value
```

## Implementation

- Added `enhanceUniquenessErrorWithSearch()` function to search for conflicting records
- Added `formatUniquenessErrorMessage()` helper for consistent error formatting  
- Integrated into `handleCreateError()` for companies and people
- Uses dynamic imports for `searchCompaniesByDomain()` and `searchPeopleByEmail()`

## Test Plan

- [x] Unit tests: 9 new tests covering all scenarios
- [x] Offline tests pass (2925 tests)
- [x] TypeScript check passes
- [ ] CI validation

Closes #990