### PR TITLE
Fix: Claude PR Review false positives from missing dynamic import detection #1002

### DIFF
--- a/.github/workflows/claude-pr-review-labeled.yml
+++ b/.github/workflows/claude-pr-review-labeled.yml
@@ -327,6 +327,16 @@ jobs:
             printf 'HAS_DELETIONS=false\n' >> "$GITHUB_ENV"
           fi
 
+          # Load alias resolutions if available (pre-computed from full repo)
+          # Filter to only confirmed existing paths so prompt claim is accurate
+          ALIAS_PATH="$SCOPE_DIR/alias-resolutions.json"
+          if [ -f "$ALIAS_PATH" ]; then
+            alias_json=$(jq -c '[.[] | select(.exists == true)]' "$ALIAS_PATH")
+            printf 'ALIAS_RESOLUTIONS=%s\n' "$alias_json" >> "$GITHUB_ENV"
+          else
+            printf 'ALIAS_RESOLUTIONS=[]\n' >> "$GITHUB_ENV"
+          fi
+
           ring0_count=$(jq -r '.ring0Count' "$SUMMARY_PATH")
           ring1_count=$(jq -r '.ring1Count' "$SUMMARY_PATH")
           deletions_count=$(jq -r '.deletionsCount // 0' "$SUMMARY_PATH")
@@ -503,6 +513,11 @@ jobs:
               * State: "could not verify - outside sparse checkout scope"
               * Or skip verification and focus on Ring 0 changes only
             - Never claim files are missing based solely on Glob "no files found" results
+            - If a file or function name is **referenced in Ring 0 code** but Glob/Grep cannot find it:
+              * Assume it exists **outside sparse checkout scope**, not that it's missing
+              * Say "could not verify (outside sparse checkout scope)" rather than "missing"
+              * This applies especially to dynamic imports like `await import('@/...')`
+              * Check the "Pre-computed alias resolutions" section above - those paths are CONFIRMED to exist
 
             PATH RESOLUTION RULES
             - Source files use ESM imports like "../foo.js" but live on disk as "../foo.ts".
@@ -514,6 +529,10 @@ jobs:
 
             Context files (Ring 1 JSON):
             ${{ env.RING1_JSON }}
+
+            Pre-computed alias resolutions (verified from full repo before sparse checkout):
+            ${{ env.ALIAS_RESOLUTIONS }}
+            NOTE: These paths are CONFIRMED to exist in the full repository. If Glob/Grep cannot find them in sparse checkout, they exist outside the checkout scope - do NOT report them as missing.
 
             ${{ env.HAS_DELETIONS == 'true' && format('
             {0}
@@ -693,6 +712,11 @@ jobs:
               * State: "could not verify - outside sparse checkout scope"
               * Or skip verification and focus on Ring 0 changes only
             - Never claim files are missing based solely on Glob "no files found" results
+            - If a file or function name is **referenced in Ring 0 code** but Glob/Grep cannot find it:
+              * Assume it exists **outside sparse checkout scope**, not that it's missing
+              * Say "could not verify (outside sparse checkout scope)" rather than "missing"
+              * This applies especially to dynamic imports like `await import('@/...')`
+              * Check the "Pre-computed alias resolutions" section above - those paths are CONFIRMED to exist
 
             PATH RESOLUTION RULES
             - Source files use ESM imports like "../foo.js" but live on disk as "../foo.ts".
@@ -704,6 +728,10 @@ jobs:
 
             Context files (Ring 1 JSON):
             ${{ env.RING1_JSON }}
+
+            Pre-computed alias resolutions (verified from full repo before sparse checkout):
+            ${{ env.ALIAS_RESOLUTIONS }}
+            NOTE: These paths are CONFIRMED to exist in the full repository. If Glob/Grep cannot find them in sparse checkout, they exist outside the checkout scope - do NOT report them as missing.
 
             ${{ env.HAS_DELETIONS == 'true' && format('
             {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Claude PR review dynamic import detection** (#1002) - Ring 1 scope now includes dynamically imported modules
+  - Fixes false positive "missing dependency" errors when PR files use `await import('@/...')` or `await import('./...')`
+  - Adds prompt hardening to prevent "missing file" claims from sparse checkout limitations
+  - Pre-computes alias resolutions from full repo and passes them to Claude
+
 - **Complex attribute validation** (#991) - clearer validation and error messages for location, personal-name, and phone-number fields
   - Pre-validates complex types with actionable errors and examples before Attio API calls
   - Auto-fills missing location fields with nulls; enforces phone_number/original_phone_number and non-empty names


### PR DESCRIPTION
## Summary

Fixes false positive "missing dependency" errors in Claude PR reviews when PR files use dynamic imports like `await import('@/path/module.js')`.

## Problem

PR #1000 (`crud-error-handlers.ts`) uses dynamic imports:
```typescript
const { searchCompaniesByDomain } = await import('@/objects/companies/search.js');
const { searchPeopleByEmail } = await import('@/objects/people/search.js');
```

The scope generator only captured static imports, so these files were excluded from Ring 1 → sparse checkout → Claude couldn't find them → false positive "Missing Search Function Dependencies" error.

## Solution

Three enhancements:

### 1. Core fix: Dynamic import detection
- Added regex patterns for `await import('./...')` and `await import('@/...')` 
- Ring 1 now includes dynamically imported modules

### 2. Prompt hardening
- Added explicit instructions that files referenced in Ring 0 but not found via Glob should be assumed to exist outside sparse checkout scope
- Prevents Claude from claiming files are "missing" when they simply aren't in the sparse checkout

### 3. Alias resolution hints
- Added `collectAliasResolutions()` to pre-compute all `@/` alias paths from Ring 0 files
- Outputs `alias-resolutions.json` with resolved paths and existence info
- Passes this to Claude so it knows which paths are confirmed to exist

## Files Changed

- `scripts/claude/generate-review-scope.mjs` - Dynamic import regex + alias resolution output
- `.github/workflows/claude-pr-review-labeled.yml` - Prompt hardening + alias hints

## Test Plan

- [x] Verified regex patterns capture dynamic imports correctly
- [x] Verified alias resolution works for `@/objects/companies/search.js` → `src/objects/companies/search.ts`
- [x] All 2926 tests pass
- [x] TypeScript checks pass

Closes #1002