### PR TITLE
Fix: Daily changelog workflow missing approvals #1004

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -58,8 +58,14 @@ jobs:
 
       - name: Generate changelog with Claude
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }} # Ensure gh CLI has auth inside Claude's Bash
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --model claude-haiku-4-5
+            --max-turns 15
+            --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh pr list:*),Bash(gh pr create:*),Bash(date:*)"
           prompt: |
             Generate a daily changelog by analyzing commits since yesterday.
 


### PR DESCRIPTION
## Summary

Fixes the "missing approvals" issue in the daily changelog workflow by adding explicit tool permissions via `claude_args`.

## Changes

- Added `env.GH_TOKEN` to ensure `gh` CLI has authentication inside Claude's Bash environment
- Added `claude_args` with:
  - `--model claude-haiku-4-5` for cost efficiency (matches Sonnet 4 on coding/agent tasks)
  - `--max-turns 15` to prevent runaway execution
  - `--allowedTools` with minimal required permissions:
    - `Read`, `Edit`, `Write` for file operations
    - `Bash(git:*)` for branch/commit/push
    - `Bash(gh pr list:*)`, `Bash(gh pr create:*)` for PR operations
    - `Bash(date:*)` for branch naming

## Why this fixes the issue

Without explicit `--allowedTools`, Claude Code Action cannot execute Bash commands. The workflow prompt asks Claude to run `git` and `gh` commands, but those tools were not permitted, causing "missing approvals" status.

This follows the established pattern from `claude-commands.yml` but uses a more restricted toolset appropriate for the changelog workflow's scope.

## Test plan

- [ ] Manually trigger the workflow via Actions
- [ ] Verify Claude can execute git/gh commands without "missing approvals"
- [ ] Verify fallback step remains available as safety net

Fixes #1004