### PR TITLE
Fix: Pin @modelcontextprotocol/sdk to ~1.24.0 #1025

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
   "dependencies": {
     "@dqbd/tiktoken": "^1.0.15",
     "@leeoniya/ufuzzy": "^1.0.14",
-    "@modelcontextprotocol/sdk": "^1.4.1",
+    "@modelcontextprotocol/sdk": "~1.24.0",
     "@smithery/sdk": "^1.6.6",
     "axios": "^1.12.0",
     "chalk": "^5.3.0",


### PR DESCRIPTION
## Summary

Pin @modelcontextprotocol/sdk to ~1.24.0 to prevent CI breaks from SDK 1.25.0 breaking changes.

## Problem

SDK version 1.25.0 introduced breaking type changes in `ListResourcesResult`. CI performance comparison fails when building main branch because `npm install` (with `package-lock.json` removed per CI config) pulls in 1.25.0.

## Fix

Pin to `~1.24.0` which restricts to 1.24.x versions, preventing automatic upgrades to incompatible 1.25.x.

## Test plan

- [ ] CI passes on this PR
- [ ] Once merged, other PRs (like #1024) should have passing performance comparisons

Closes #1025