### PR TITLE
Docs: Add skills documentation and streamline README #1027

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,70 +91,24 @@ Transform your CRM workflows with AI-powered automation. Instead of clicking thr
 - **Data Export**: JSON serialization for integrations
 - **Real-time Updates**: Live data synchronization with Attio
 
-### 🧠 **Workspace Schema Skill Generator** (#983)
+### 🧠 **Claude Skills**
 
-Auto-generate Claude Skills from your Attio workspace to eliminate LLM errors caused by unknown attribute values.
+Supercharge Claude's Attio knowledge with pre-built skills that prevent common errors and teach best practices.
 
-**The Problem**: LLMs frequently make errors when working with Attio because they don't know:
+| Skill                      | Purpose                                        | Setup                                           |
+| -------------------------- | ---------------------------------------------- | ----------------------------------------------- |
+| **attio-mcp-usage**        | Error prevention + universal workflow patterns | Bundled - just use it                           |
+| **attio-workspace-schema** | YOUR workspace's exact field names and options | `npx attio-discover generate-skill --all --zip` |
+| **attio-skill-generator**  | Create custom workflow skills (advanced)       | Python + prompting                              |
 
-- Valid attribute names (Display Names vs API Slugs)
-- Valid select/status option values
-- Required vs optional fields
-- Multi-select vs single-select attributes
-- Complex type structures (location, personal-name, etc.)
-
-**The Solution**: One-command schema documentation generation:
+**Quick Start** (solves "wrong field name" errors):
 
 ```bash
-# Generate Claude Skill for all Phase 1 objects and package as ZIP
 npx attio-discover generate-skill --all --zip
-
-# Output: ./output/attio-workspace-skill.zip (ready for Claude upload)
+# Import ZIP into Claude Desktop: Settings > Skills > Install Skill
 ```
 
-**Features**:
-
-- **Display Name ↔ API Slug Mapping**: Eliminates the #1 error source
-- **Select/Status Options**: Complete list of valid values (truncated at 20)
-- **Complex Type Structures**: Location (10 fields), personal-name, phone-number, email
-- **Field Indicators**: Multi-select (✓/✗), Required (✓/✗), Unique (✓/✗)
-- **3 Output Formats**: Claude Skill (.md), Markdown (single file), JSON (machine-readable)
-- **ZIP Packaging**: Ready for Claude desktop upload with --zip flag
-- **Experimental Objects**: Try custom objects with warning for non-Phase 1
-
-**Examples**:
-
-```bash
-# Generate for companies only
-npx attio-discover generate-skill --object companies
-
-# Generate as plain markdown (for non-Claude LLMs)
-npx attio-discover generate-skill --all --format markdown
-
-# Include archived options
-npx attio-discover generate-skill --all --include-archived
-
-# Custom output directory
-npx attio-discover generate-skill --all --output ./my-skills
-```
-
-**Generated Skill Structure**:
-
-```
-attio-workspace-skill/
-├── SKILL.md                        # Main skill with routing logic
-└── resources/
-    ├── companies-attributes.md     # Companies object attributes
-    ├── people-attributes.md        # People object attributes
-    ├── deals-attributes.md         # Deals object attributes
-    ├── [other]-attributes.md       # Per-object attribute files
-    └── complex-types.md            # Shared complex type structures
-```
-
-**Progressive Disclosure**: Claude loads only the object file it needs (~2k tokens),
-not the entire monolithic reference (~10k tokens).
-
-See [Workspace Schema Skill Generator](#workspace-schema-skill-generator-1) for complete documentation.
+See [Skills Documentation](./docs/usage/skills/README.md) for complete setup and usage guides.
 
 ### 💬 **Pre-Built Prompts** (10 Prompts)
 
@@ -255,189 +209,9 @@ For complete prompt documentation, see [docs/prompts/v1-catalog.md](./docs/promp
 
 For detailed troubleshooting and solutions, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) and [GitHub Issues](https://github.com/kesslerio/attio-mcp-server/issues).
 
-## 🎯 **Mastering Advanced Search Filters**
+## 🎯 **Advanced Search Filters**
 
-**The Power Behind Precise CRM Queries** - Stop wrestling with complex data searches. Our advanced filtering system lets you find exactly what you need with surgical precision.
-
-> _"Find all AI companies with 50+ employees that we haven't contacted in 30 days and add them to our Q1 outreach list"_ - This kind of complex query is exactly what advanced search filters excel at.
-
-### 🏗️ **Filter Architecture**
-
-Every advanced search follows this proven pattern that's been battle-tested across thousands of CRM queries:
-
-```json
-{
-  "resource_type": "companies",
-  "filters": {
-    "filters": [
-      {
-        "attribute": { "slug": "field_name" },
-        "condition": "operator",
-        "value": "search_value"
-      }
-    ]
-  }
-}
-```
-
-### ⚡ **Real-World Examples**
-
-**🔍 Single Criteria Search**
-
-```json
-{
-  "resource_type": "companies",
-  "filters": {
-    "filters": [
-      {
-        "attribute": { "slug": "name" },
-        "condition": "contains",
-        "value": "Tech"
-      }
-    ]
-  }
-}
-```
-
-**🎯 Multi-Criteria Power Search (AND Logic)**
-
-```json
-{
-  "resource_type": "companies",
-  "filters": {
-    "filters": [
-      {
-        "attribute": { "slug": "name" },
-        "condition": "contains",
-        "value": "Tech"
-      },
-      {
-        "attribute": { "slug": "employee_count" },
-        "condition": "greater_than",
-        "value": 50
-      },
-      {
-        "attribute": { "slug": "industry" },
-        "condition": "equals",
-        "value": "AI/Machine Learning"
-      }
-    ]
-  }
-}
-```
-
-**🚀 Flexible OR Logic**
-
-```json
-{
-  "resource_type": "companies",
-  "filters": {
-    "filters": [
-      {
-        "attribute": { "slug": "name" },
-        "condition": "contains",
-        "value": "Tech"
-      },
-      {
-        "attribute": { "slug": "name" },
-        "condition": "contains",
-        "value": "AI"
-      }
-    ],
-    "matchAny": true
-  }
-}
-```
-
-### 🧠 **Smart Filter Operators**
-
-| Operator       | Perfect For         | Example Use Case                      |
-| -------------- | ------------------- | ------------------------------------- |
-| `contains`     | Text searches       | Finding companies with "Tech" in name |
-| `equals`       | Exact matches       | Specific industry classification      |
-| `starts_with`  | Prefix searches     | Companies beginning with "Acme"       |
-| `ends_with`    | Suffix searches     | Companies ending with "Inc"           |
-| `greater_than` | Numerical analysis  | Companies with 100+ employees         |
-| `less_than`    | Size filtering      | Startups under 50 people              |
-| `is_empty`     | Data cleanup        | Find records missing key information  |
-| `is_not_empty` | Completeness checks | Records with populated fields         |
-
-### 💡 **Pro Tips for Different Teams**
-
-**🎯 Sales Teams** - Use these field combinations:
-
-- **Companies**: `name`, `industry`, `employee_count`, `website`, `location`
-- **People**: `full_name`, `job_title`, `email`, `company`
-
-**📈 Marketing Teams** - Focus on engagement fields:
-
-- **Activity tracking**: `last_interaction`, `email_status`, `campaign_response`
-- **Segmentation**: `industry`, `company_size`, `location`, `engagement_score`
-
-**✅ Customer Success** - Monitor health metrics:
-
-- **Account health**: `renewal_date`, `support_tickets`, `usage_metrics`
-- **Risk indicators**: `last_contact`, `satisfaction_score`, `contract_value`
-
-### 🚨 **Avoid These Common Mistakes**
-
-❌ **Wrong** (Flat object structure):
-
-```json
-{
-  "filters": {
-    "name": { "operator": "contains", "value": "Test" }
-  }
-}
-```
-
-✅ **Correct** (Nested array structure):
-
-```json
-{
-  "filters": {
-    "filters": [
-      {
-        "attribute": { "slug": "name" },
-        "condition": "contains",
-        "value": "Test"
-      }
-    ]
-  }
-}
-```
-
-### 🔧 **Quick Troubleshooting**
-
-**Getting "Filters must include a 'filters' array property"?**
-
-1. ✅ Ensure your filters object contains a `filters` array
-2. ✅ Each array item needs `attribute`, `condition`, and `value`
-3. ✅ The `attribute` must be an object with a `slug` property
-4. ✅ Double-check your JSON structure matches the examples above
-
-**💬 Pro Tip**: Start with simple single-filter searches, then build complexity once you're comfortable with the structure.
-
-## 🏆 Latest Updates - Critical Issues Resolved
-
-✅ **100% Integration Test Pass Rate Achieved** - All critical API contract violations and build issues have been resolved:
-
-### Recently Fixed Issues (August 2025)
-
-- **P0 Critical API Failures**: Fixed response data structure handling for robust fallback patterns
-- **Build Compilation Errors**: Created missing enhanced-validation module and resolved TypeScript compilation
-- **E2E Test Implementation**: Fixed JSON truncation, resource mappings, and email validation consistency
-- **Field Parameter Filtering**: Resolved tasks attribute handling with special case for missing `/objects/tasks/attributes` endpoint
-- **Email Validation Consistency**: Fixed batch validation and create/update operation alignment
-- **Pagination System**: Documented tasks pagination limitation with in-memory handling workaround
-
-### Test Status
-
-- **Integration Tests**: 15/15 passing (100% pass rate)
-- **Build Status**: All TypeScript compilation successful
-- **API Contract**: All violations resolved with robust error handling
-
-See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for detailed solutions to these resolved issues.
+Build powerful CRM queries with multi-criteria AND/OR filtering. See the [Advanced Search Guide](./docs/usage/advanced-search.md) for complete examples and operator reference.
 
 ## 🚀 Installation
 
@@ -986,87 +760,14 @@ See [docs/deployment/smithery-cli-setup.md](./docs/deployment/smithery-cli-setup
 
 ### **Testing**
 
-The project includes comprehensive testing at multiple levels with **100% E2E test pass rate**:
-
-#### **🚀 E2E Test Framework (100% Pass Rate)**
-
-Our comprehensive E2E test framework validates all universal tools with real Attio API integration:
-
 ```bash
-# E2E Tests (requires ATTIO_API_KEY in .env file)
-npm run e2e                 # Run complete E2E test suite (51 tests, 100% pass rate)
-npm test -- test/e2e/suites/universal-tools.e2e.test.ts  # Universal tools E2E tests
-
-# Set up E2E environment
-echo "ATTIO_API_KEY=your_api_key_here" > .env
-npm run e2e                 # Should show 51/51 tests passing
-```
-
-**✅ Comprehensive Coverage:**
-
-- **Pagination Testing**: Validates `offset` parameter across all universal tools
-- **Field Filtering**: Tests `fields` parameter for selective data retrieval
-- **Tasks Integration**: Complete lifecycle testing for tasks resource type
-- **Cross-Resource Validation**: Ensures consistent behavior across companies, people, lists, tasks
-- **Error Handling**: Validates graceful error responses and edge cases
-- **Performance Monitoring**: Tracks execution times and API response sizes
-
-**🛠️ Enhanced Assertions (7 New Methods):**
-
-```typescript
-// Available in test/e2e/utils/assertions.ts
-expectValidPagination(result, params); // Validates pagination behavior
-expectFieldFiltering(result, fields); // Validates field selection
-expectValidTasksIntegration(result); // Tasks-specific validation
-expectSpecificError(result, errorType); // Typed error validation
-expectOptimalPerformance(result, budget); // Performance validation
-expectValidUniversalToolParams(params); // Parameter validation
-expectValidBatchOperation(result, records); // Batch operation validation
-```
-
-**📊 Performance Benchmarks:**
-
-- **Search Operations**: < 1000ms per API call
-- **CRUD Operations**: < 1500ms per operation
-- **Batch Operations**: < 3000ms for 10 records
-- **Field Filtering**: < 500ms additional overhead
-- **Pagination**: < 200ms additional per offset
-
-#### **Unit & Integration Tests**
-
-```bash
-# Unit Tests (no API required)
 npm test                    # Run all tests
-npm run test:offline        # Run only offline tests (206 tests)
-npm run test:watch          # Watch mode for development
-
-# Integration Tests (requires API key and test data)
-npm run test:integration    # Run all integration tests (15 tests, 100% pass rate)
-npm run setup:test-data     # Create test data in your workspace
+npm run test:offline        # Run only offline tests (no API required)
+npm run test:integration    # Integration tests (requires ATTIO_API_KEY)
+npm run e2e                 # E2E tests (requires ATTIO_API_KEY)
 ```
 
-#### **Test Environment Setup**
-
-For E2E and integration tests, you need:
-
-1. **Create `.env` file** in project root:
-
-```bash
-# Required for E2E/Integration tests
-ATTIO_API_KEY=your_64_character_api_key_here
-PORT=3000
-LOG_LEVEL=debug
-NODE_ENV=development
-```
-
-2. **Verify API key** format (must be exactly 64 characters)
-3. **Run tests** to validate setup:
-
-```bash
-npm run build && npm run test:integration
-```
-
-See the [Testing Guide](./docs/testing.md) and [E2E Troubleshooting Guide](./docs/testing/e2e-troubleshooting.md) for detailed setup instructions.
+For E2E/integration tests, create `.env` with your `ATTIO_API_KEY`. See the [Testing Guide](./docs/testing.md) for detailed setup.
 
 ### **Available Scripts**
 

--- a/docs/usage/advanced-search.md
+++ b/docs/usage/advanced-search.md
@@ -1,0 +1,176 @@
+# Advanced Search Filters
+
+Build precise CRM queries with multi-criteria filtering using AND/OR logic.
+
+**Example query**: "Find all AI companies with 50+ employees that we haven't contacted in 30 days"
+
+## Filter Architecture
+
+This is the supported structure used by the `advanced-search` tool:
+
+```json
+{
+  "resource_type": "companies",
+  "filters": {
+    "filters": [
+      {
+        "attribute": { "slug": "field_name" },
+        "condition": "operator",
+        "value": "search_value"
+      }
+    ]
+  }
+}
+```
+
+## Real-World Examples
+
+### Single Criteria Search
+
+```json
+{
+  "resource_type": "companies",
+  "filters": {
+    "filters": [
+      {
+        "attribute": { "slug": "name" },
+        "condition": "contains",
+        "value": "Tech"
+      }
+    ]
+  }
+}
+```
+
+### Multi-Criteria Power Search (AND Logic)
+
+```json
+{
+  "resource_type": "companies",
+  "filters": {
+    "filters": [
+      {
+        "attribute": { "slug": "name" },
+        "condition": "contains",
+        "value": "Tech"
+      },
+      {
+        "attribute": { "slug": "employee_count" },
+        "condition": "greater_than",
+        "value": 50
+      },
+      {
+        "attribute": { "slug": "industry" },
+        "condition": "equals",
+        "value": "AI/Machine Learning"
+      }
+    ]
+  }
+}
+```
+
+### Flexible OR Logic
+
+```json
+{
+  "resource_type": "companies",
+  "filters": {
+    "filters": [
+      {
+        "attribute": { "slug": "name" },
+        "condition": "contains",
+        "value": "Tech"
+      },
+      {
+        "attribute": { "slug": "name" },
+        "condition": "contains",
+        "value": "AI"
+      }
+    ],
+    "matchAny": true
+  }
+}
+```
+
+## Smart Filter Operators
+
+| Operator       | Perfect For         | Example Use Case                      |
+| -------------- | ------------------- | ------------------------------------- |
+| `contains`     | Text searches       | Finding companies with "Tech" in name |
+| `equals`       | Exact matches       | Specific industry classification      |
+| `starts_with`  | Prefix searches     | Companies beginning with "Acme"       |
+| `ends_with`    | Suffix searches     | Companies ending with "Inc"           |
+| `greater_than` | Numerical analysis  | Companies with 100+ employees         |
+| `less_than`    | Size filtering      | Startups under 50 people              |
+| `is_empty`     | Data cleanup        | Find records missing key information  |
+| `is_not_empty` | Completeness checks | Records with populated fields         |
+
+## Example Fields by Team
+
+> **Note**: These are example attribute names. Your workspace may have different field slugs. Use the `attio-workspace-schema` skill or `records_discover_attributes` tool to find your actual attribute names.
+
+### Sales Teams
+
+Common filter attributes:
+
+- **Companies**: `name`, `industry`, `employee_count`, `website`
+- **People**: `full_name`, `job_title`, `email`
+
+### Marketing Teams
+
+Common engagement attributes:
+
+- **Activity**: `last_interaction`, `email_status`
+- **Segmentation**: `industry`, `company_size`, `location`
+
+### Customer Success
+
+Common health metrics:
+
+- **Account**: `renewal_date`, `contract_value`
+- **Risk**: `last_contact`, `satisfaction_score`
+
+## Avoid These Common Mistakes
+
+**Wrong** (Flat object structure):
+
+```json
+{
+  "filters": {
+    "name": { "operator": "contains", "value": "Test" }
+  }
+}
+```
+
+**Correct** (Nested array structure):
+
+```json
+{
+  "filters": {
+    "filters": [
+      {
+        "attribute": { "slug": "name" },
+        "condition": "contains",
+        "value": "Test"
+      }
+    ]
+  }
+}
+```
+
+## Quick Troubleshooting
+
+**Getting "Filters must include a 'filters' array property"?**
+
+1. Ensure your filters object contains a `filters` array
+2. Each array item needs `attribute`, `condition`, and `value`
+3. The `attribute` must be an object with a `slug` property
+4. Double-check your JSON structure matches the examples above
+
+**Pro Tip**: Start with simple single-filter searches, then build complexity once you're comfortable with the structure.
+
+## Related Documentation
+
+- [API Overview](../api/api-overview.md)
+- [Advanced Filtering API](../api/advanced-filtering.md)
+- [Troubleshooting Guide](../troubleshooting.md)

--- a/docs/usage/skills/README.md
+++ b/docs/usage/skills/README.md
@@ -1,0 +1,271 @@
+# Attio MCP Server Skills
+
+Claude Skills that enhance LLM interactions with the Attio MCP server.
+
+## Why Skills?
+
+LLMs make predictable errors when working with Attio:
+
+- Using display names instead of API slugs
+- Forgetting arrays for multi-select fields
+- Missing required field structures
+- Not knowing valid option values
+
+**Skills solve this** by giving Claude workspace-specific knowledge and universal patterns.
+
+## Available Skills
+
+| Skill                                                | Type      | Purpose                                 | Complexity                |
+| ---------------------------------------------------- | --------- | --------------------------------------- | ------------------------- |
+| [attio-mcp-usage](./attio-mcp-usage.md)              | Universal | Error prevention, workflow patterns     | Low - works out of box    |
+| [attio-workspace-schema](./attio-workspace-skill.md) | Generated | YOUR workspace's attributes and options | Low - CLI generates it    |
+| [attio-skill-generator](./attio-skill-generator.md)  | Meta      | Create custom workflow skills           | High - requires prompting |
+
+## Quick Decision Guide
+
+**"I'm setting up for the first time"**
+
+1. Install `attio-mcp-usage` (patterns + error prevention)
+2. Generate `attio-workspace-schema` with `npx attio-discover generate-skill --all --zip`
+
+**"Claude keeps using wrong field names"**
+
+- Regenerate `attio-workspace-schema` (your workspace may have changed)
+
+**"I need a custom lead qualification workflow"**
+
+- Use `attio-skill-generator` to create a tailored skill
+
+**"I'm getting API errors"**
+
+- Check `attio-mcp-usage` golden rules
+
+## Skill Comparison
+
+### attio-mcp-usage (Universal)
+
+**What it provides:**
+
+- 5 "NEVER do" rules (error prevention)
+- 6 "ALWAYS do" best practices
+- 7 real-world integration patterns
+- Complete MCP tool reference
+
+**Install method:** Copy from `skills/attio-mcp-usage/`
+
+**Customization:** Minimal - works for any workspace
+
+**Best for:** Everyone. Install this first.
+
+### attio-workspace-schema (Generated)
+
+**What it provides:**
+
+- YOUR workspace's exact attribute slugs
+- YOUR select/status option values
+- YOUR complex type structures
+- Display name to API slug mapping
+
+**Install method:** Generate with CLI
+
+```bash
+npx attio-discover generate-skill --all --zip
+```
+
+**Customization:** Regenerate when workspace changes
+
+**Best for:** Anyone whose workspace has custom attributes or needs Claude to know exact field values.
+
+### attio-skill-generator (Advanced)
+
+**What it provides:**
+
+- Custom workflow skills (lead qualification, deal management, onboarding)
+- Tailored to YOUR workflow steps
+- Uses YOUR workspace schema
+
+**Install method:** Python scripts + prompting Claude
+
+```bash
+pip install chevron pyyaml
+# Then prompt Claude to use the skill
+```
+
+**Customization:** High - creates entirely new skills
+
+**Best for:** Power users who want tailored workflow automation.
+
+## Installing Skills
+
+### Claude Desktop
+
+**Option A: Drag and Drop (easiest)**
+
+1. ZIP the skill folder (e.g., `attio-mcp-usage/`)
+2. Drag the ZIP file into Claude Desktop chat window
+3. Claude will prompt to install the skill
+
+**Option B: Settings Menu**
+
+1. Open Claude Desktop Settings (gear icon)
+2. Navigate to **Skills**
+3. Click **Install Skill**
+4. Select the ZIP file or folder
+
+### Claude Code (CLI)
+
+Copy skill folders to your personal skills directory:
+
+```bash
+# Copy bundled skills to Claude Code
+cp -r skills/attio-mcp-usage ~/.claude/skills/
+cp -r skills/attio-skill-generator ~/.claude/skills/
+
+# Copy generated workspace skill
+cp -r output/attio-workspace-skill ~/.claude/skills/
+```
+
+Claude Code automatically discovers skills in `~/.claude/skills/`.
+
+### Project-Level Skills
+
+For team sharing, place skills in your project's `.claude/skills/` directory:
+
+```bash
+mkdir -p .claude/skills
+cp -r skills/attio-mcp-usage .claude/skills/
+```
+
+## Recommended Setup
+
+### Minimal Setup (Most Users)
+
+```bash
+# 1. Ensure API key is set (add to .env or environment)
+echo "ATTIO_API_KEY=your_key_here" >> .env
+
+# 2. Generate workspace schema
+npx attio-discover generate-skill --all --zip
+
+# 3. Import into Claude
+# - Claude Desktop: Settings > Skills > Install Skill > Select ZIP
+# - Claude Code: cp -r output/attio-workspace-skill ~/.claude/skills/
+```
+
+> **Security**: Ensure `.env` is in your `.gitignore` and never commit API keys to version control.
+
+The `attio-mcp-usage` skill is bundled with the server.
+
+### Full Setup (Power Users)
+
+```bash
+# 1. Ensure API key is set
+echo "ATTIO_API_KEY=your_key_here" >> .env
+
+# 2. Generate workspace schema
+npx attio-discover generate-skill --all --zip
+
+# 3. Install Python dependencies (for skill generator)
+pip install chevron pyyaml
+
+# 4. Install all skills
+# Claude Desktop: Settings > Skills > Install Skill for each ZIP
+# Claude Code: cp -r skills/* ~/.claude/skills/
+```
+
+Then prompt Claude:
+
+```
+Using the attio-skill-generator skill, create a Lead Qualification
+workflow skill for my workspace
+```
+
+## How Skills Work Together
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    User Request                              │
+│        "Update the deal stage for Acme Corp"                 │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│              attio-mcp-usage                                 │
+│   • HOW to structure the update                              │
+│   • Error prevention (arrays, types, validation)             │
+│   • Workflow pattern (find-then-update)                      │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│            attio-workspace-schema                            │
+│   • WHAT attribute slugs to use (deal_stage)                 │
+│   • WHAT option values are valid ("qualified", "proposal")   │
+│   • WHAT fields are read-only                                │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Correct MCP Tool Call                           │
+│   update-record with exact slugs and valid values            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Skill Files Location
+
+```
+attio-mcp-server/
+├── skills/
+│   ├── attio-mcp-usage/          # Universal patterns (bundled)
+│   │   ├── SKILL.md
+│   │   └── resources/
+│   │       ├── golden-rules.md
+│   │       ├── workflows.md
+│   │       ├── tool-reference.md
+│   │       └── integration-patterns.md
+│   └── attio-skill-generator/    # Meta skill (bundled)
+│       ├── SKILL.md
+│       ├── resources/
+│       │   ├── templates/
+│       │   └── use-cases/
+│       └── scripts/
+└── output/
+    └── attio-workspace-skill/    # Generated (you create this)
+        ├── SKILL.md
+        └── resources/
+            ├── companies-attributes.md
+            ├── people-attributes.md
+            ├── deals-attributes.md
+            └── complex-types.md
+```
+
+## Troubleshooting
+
+### "Claude doesn't use the skills"
+
+1. Verify skills are installed: ask "what skills do you have?"
+2. Reference explicitly: "using the attio-mcp-usage skill, how do I..."
+3. For Claude Desktop: check Settings > Skills shows them
+
+### "Generated skill has wrong data"
+
+Regenerate from fresh API data:
+
+```bash
+rm -rf ./output/attio-workspace-skill
+npx attio-discover generate-skill --all --zip
+```
+
+### "Skill generator fails"
+
+Check Python dependencies:
+
+```bash
+pip install chevron pyyaml
+```
+
+## Related Documentation
+
+- [Getting Started Guide](../getting-started.md) - First-time MCP server setup
+- [Attio Tools Reference](../../tools/attio-tools-reference.md) - Complete tool documentation
+- [Troubleshooting](../troubleshooting.md) - Common issues and solutions

--- a/docs/usage/skills/attio-mcp-usage.md
+++ b/docs/usage/skills/attio-mcp-usage.md
@@ -1,0 +1,195 @@
+# Attio MCP Usage Skill
+
+Universal workflow patterns and error prevention for the Attio MCP server.
+
+## Overview
+
+The `attio-mcp-usage` skill teaches Claude **HOW** to work with Attio MCP tools effectively. It provides universal patterns that work across ANY Attio workspace, preventing common API errors and guiding multi-step workflows.
+
+> **First skill to install**: This is your foundation skill. Install it before working with any Attio workspace.
+
+## When to Use
+
+| Scenario                                | Use This Skill                    |
+| --------------------------------------- | --------------------------------- |
+| Planning multi-step workflows           | Yes                               |
+| Troubleshooting API errors              | Yes                               |
+| Learning MCP tool syntax                | Yes                               |
+| Building integrations                   | Yes                               |
+| Need workspace-specific attribute names | No - use `attio-workspace-schema` |
+
+## Installation
+
+### Claude Desktop
+
+**Option A: Drag and Drop**
+
+1. ZIP the `skills/attio-mcp-usage/` folder
+2. Drag the ZIP into Claude Desktop chat window
+3. Confirm installation when prompted
+
+**Option B: Settings Menu**
+
+1. Open Settings (gear icon) > Skills
+2. Click **Install Skill**
+3. Select the ZIP or folder
+
+### Claude Code (CLI)
+
+```bash
+# Copy to personal skills directory
+cp -r skills/attio-mcp-usage ~/.claude/skills/
+
+# Or for project-level (shared with team)
+cp -r skills/attio-mcp-usage .claude/skills/
+```
+
+### Verify Installation
+
+Ask Claude:
+
+```
+What are the golden rules for Attio MCP usage?
+```
+
+Claude should reference the error prevention system with NEVER/ALWAYS rules.
+
+## What's Included
+
+### Resource Files
+
+| File                      | Purpose                                                          | Lines |
+| ------------------------- | ---------------------------------------------------------------- | ----- |
+| `golden-rules.md`         | Error prevention system (5 NEVER + 6 ALWAYS rules)               | ~326  |
+| `workflows.md`            | Universal workflow patterns (find-or-create, batch update, etc.) | ~220  |
+| `tool-reference.md`       | Complete MCP tool signatures and examples                        | ~747  |
+| `integration-patterns.md` | 7 real-world workflow examples                                   | ~535  |
+
+### Golden Rules Highlights
+
+**NEVER Do These:**
+
+1. Never update read-only fields (`record_id`, `created_at`, etc.)
+2. Never forget arrays for multi-select fields
+3. Never mix data types (strings vs numbers vs booleans)
+4. Never skip UUID validation
+5. Never use display names as API slugs
+
+**ALWAYS Do These:**
+
+1. Discover schema first - know your fields
+2. Check the schema skill for workspace specifics
+3. Validate before updating
+4. Use exact option values for select/status fields
+5. Verify field persistence after updates
+6. Add context with notes
+
+### Integration Patterns
+
+Seven complete workflow patterns:
+
+1. **Deal Pipeline Workflow** - 6-step deal progression
+2. **List-Based Organization** - 5-step list management
+3. **Lead Qualification** - 6-step lead scoring
+4. **Bulk Data Import** - 6-step import pattern
+5. **Deal Stage Automation** - 6-step automation
+6. **Data Enrichment Pipeline** - Company/deal/person enrichment
+7. **Error Handling Template** - Comprehensive try/catch pattern
+
+## How It Works with Other Skills
+
+```
+attio-mcp-usage (this skill)
+├── Teaches HOW to use MCP tools
+├── Universal error prevention
+└── Applies to ALL workspaces
+
+attio-workspace-schema (companion)
+├── Documents WHAT your workspace has
+├── Specific attribute slugs
+└── Specific option values
+
+Together:
+└── Usage skill tells you the patterns
+└── Schema skill gives you the specifics
+```
+
+**Example workflow:**
+
+1. Claude reads `attio-mcp-usage` to understand patterns
+2. Claude reads `attio-workspace-schema` for your attribute names
+3. Claude combines both to execute correctly
+
+## Example Prompts
+
+**Error troubleshooting:**
+
+```
+I'm getting "expects array" errors when updating companies.
+What am I doing wrong?
+```
+
+**Learning patterns:**
+
+```
+How should I structure a find-or-create workflow for deals?
+```
+
+**Tool reference:**
+
+```
+What parameters does the records_search tool accept?
+```
+
+## Customization
+
+This skill works out-of-the-box for most use cases. If you need to customize:
+
+### Extending Golden Rules
+
+Edit `skills/attio-mcp-usage/resources/golden-rules.md` to add workspace-specific rules:
+
+```markdown
+### 6. Never [Your Custom Rule]
+
+**Your workspace-specific constraint here**
+```
+
+### Adding Workflow Patterns
+
+Edit `skills/attio-mcp-usage/resources/integration-patterns.md`:
+
+```markdown
+## Pattern 8: [Your Custom Workflow]
+
+### Steps
+
+1. Step one
+2. Step two
+   ...
+```
+
+## Troubleshooting
+
+### "Claude doesn't know my attribute names"
+
+This skill provides **universal patterns**, not workspace-specific data. For your specific attribute names and option values, use the `attio-workspace-schema` skill:
+
+```bash
+npx attio-discover generate-skill --all --zip
+```
+
+### "Pattern doesn't match my workflow"
+
+The patterns are templates. Adapt them to your specific use case by:
+
+1. Keeping the error prevention rules
+2. Adjusting the tool sequence for your needs
+3. Using your workspace's actual attribute slugs
+
+## Related Documentation
+
+- [Attio Workspace Schema Skill](./attio-workspace-skill.md) - Generate workspace-specific documentation
+- [Attio Skill Generator](./attio-skill-generator.md) - Create custom workflow skills
+- [Skills Overview](./README.md) - All available skills
+- [Attio Tools Reference](../../tools/attio-tools-reference.md) - Complete tool documentation

--- a/docs/usage/skills/attio-workspace-skill.md
+++ b/docs/usage/skills/attio-workspace-skill.md
@@ -1,0 +1,278 @@
+# Attio Workspace Schema Skill
+
+Generate workspace-specific documentation from your Attio workspace using the CLI tool.
+
+## Overview
+
+The `attio-discover generate-skill` CLI command creates a Claude Skill that documents YOUR workspace's exact:
+
+- Attribute names (display name to API slug mapping)
+- Select/status option values
+- Complex type structures (location, phone, etc.)
+- Read-only vs writable fields
+
+> **Solves the #1 LLM error**: Using display names instead of API slugs. This skill gives Claude the exact values to use.
+
+## When to Use
+
+| Scenario                       | Use This Tool                    |
+| ------------------------------ | -------------------------------- |
+| Setting up a new workspace     | Yes - generate once              |
+| Attributes changed in Attio    | Yes - regenerate                 |
+| Claude using wrong field names | Yes - regenerate                 |
+| Need universal patterns        | No - use `attio-mcp-usage`       |
+| Need custom workflows          | No - use `attio-skill-generator` |
+
+## Quick Start
+
+```bash
+# Generate skill for all Phase 1 objects (companies, people, deals)
+npx attio-discover generate-skill --all --zip
+
+# Output: ./output/attio-workspace-skill.zip
+```
+
+Then import the ZIP into Claude Desktop or copy the folder for Claude Code.
+
+## CLI Reference
+
+### Basic Syntax
+
+```bash
+npx attio-discover generate-skill [OPTIONS]
+```
+
+### Options
+
+| Option               | Short | Type    | Default         | Description                                            |
+| -------------------- | ----- | ------- | --------------- | ------------------------------------------------------ |
+| `--object`           | `-o`  | string  | -               | Single object to generate (e.g., `companies`)          |
+| `--all`              | `-a`  | boolean | false           | Generate for Phase 1 objects: companies, people, deals |
+| `--format`           | `-f`  | choice  | `skill`         | Output format: `skill`, `markdown`, or `json`          |
+| `--output`           | -     | string  | `./output`      | Output directory path                                  |
+| `--zip`              | `-z`  | boolean | false           | Package as ZIP file (ready for Claude upload)          |
+| `--max-options`      | -     | number  | 20              | Max select/status options per attribute                |
+| `--include-archived` | -     | boolean | false           | Include archived options in output                     |
+| `--api-key`          | `-k`  | string  | `ATTIO_API_KEY` | Attio API key (env var preferred)                      |
+
+### Examples
+
+```bash
+# Generate for companies only
+npx attio-discover generate-skill --object companies
+
+# Generate as plain markdown (for non-Claude LLMs)
+npx attio-discover generate-skill --all --format markdown
+
+# Generate as JSON (machine-readable)
+npx attio-discover generate-skill --all --format json
+
+# Include archived options
+npx attio-discover generate-skill --all --include-archived
+
+# Custom output directory
+npx attio-discover generate-skill --all --output ./my-skills
+```
+
+## Output Formats
+
+### Claude Skill (default)
+
+Creates a structured skill directory:
+
+```
+attio-workspace-skill/
+├── SKILL.md                          # Main skill definition
+├── resources/
+│   ├── companies-attributes.md       # Companies attribute reference
+│   ├── people-attributes.md          # People attribute reference
+│   ├── deals-attributes.md           # Deals attribute reference
+│   └── complex-types.md              # Shared complex type structures
+```
+
+**Benefits:**
+
+- Progressive disclosure (Claude loads only what it needs)
+- Reduces token usage (~2k per object vs ~10k monolithic)
+- Structured for skill routing
+
+### Markdown
+
+Single file: `attio-workspace-schema.md`
+
+**Use for:** Non-Claude LLMs, documentation, reference
+
+### JSON
+
+Single file: `attio-workspace-schema.json`
+
+**Use for:** Programmatic access, tooling integration
+
+## Installation
+
+### Step 1: Generate the Skill
+
+```bash
+# Option A: Set API key in environment
+export ATTIO_API_KEY=your_key_here
+
+# Option B: Add to .env file (recommended)
+echo "ATTIO_API_KEY=your_key_here" >> .env
+
+# Generate and package as ZIP
+npx attio-discover generate-skill --all --zip
+```
+
+> **Tip**: The CLI reads `ATTIO_API_KEY` from your `.env` file automatically.
+
+### Step 2: Import into Claude
+
+**Claude Desktop:**
+
+- **Drag and Drop**: Drag `./output/attio-workspace-skill.zip` into chat window
+- **Or Settings**: Settings > Skills > Install Skill > Select ZIP
+
+**Claude Code (CLI):**
+
+```bash
+# Copy to personal skills directory
+cp -r output/attio-workspace-skill ~/.claude/skills/
+
+# Or for project-level (shared with team)
+cp -r output/attio-workspace-skill .claude/skills/
+```
+
+### Step 3: Verify
+
+Ask Claude:
+
+```
+What are the available attributes for companies in my Attio workspace?
+```
+
+Claude should list your workspace-specific attributes with API slugs.
+
+## What Gets Generated
+
+### Attribute Reference
+
+For each object, the generated skill includes:
+
+| Information  | Example                    |
+| ------------ | -------------------------- |
+| Display Name | "Lead Type"                |
+| API Slug     | `lead_type`                |
+| Type         | select, text, number, etc. |
+| Required     | Yes/No                     |
+| Writable     | Yes/No (read-only marked)  |
+| Multi-select | Yes/No                     |
+| Options      | For select/status fields   |
+
+### Select/Status Options
+
+```markdown
+#### lead_type (select)
+
+| Option     | API Value    |
+| ---------- | ------------ |
+| Enterprise | `enterprise` |
+| SMB        | `smb`        |
+| Startup    | `startup`    |
+```
+
+### Complex Types
+
+Documents structures for:
+
+- **Location**: 10 required fields with null defaults
+- **Personal Name**: first_name, last_name, full_name parsing
+- **Phone Number**: country_code, number format
+- **Email Address**: email_address field structure
+
+## Progressive Disclosure
+
+The skill uses progressive disclosure to minimize token usage:
+
+1. Claude reads `SKILL.md` (small, routing logic)
+2. When working with companies, Claude loads `companies-attributes.md`
+3. Only loads other objects when needed
+
+**Result:** ~2,000 tokens per object instead of ~10,000 for everything.
+
+## Regenerating
+
+Regenerate when:
+
+- You add/remove attributes in Attio
+- Select/status options change
+- You switch workspaces
+
+```bash
+# Delete old output and regenerate
+rm -rf ./output/attio-workspace-skill
+npx attio-discover generate-skill --all --zip
+```
+
+## How It Works with Other Skills
+
+```
+attio-workspace-schema (this skill)
+├── Documents YOUR workspace
+├── Specific attribute slugs
+├── Specific option values
+└── Generated by CLI
+
+attio-mcp-usage (companion)
+├── Universal HOW-TO patterns
+├── Error prevention rules
+└── Works with any workspace
+
+Together:
+└── Schema skill provides the WHAT
+└── Usage skill provides the HOW
+```
+
+## Troubleshooting
+
+### "No API key provided"
+
+```bash
+# Add to .env (recommended)
+echo "ATTIO_API_KEY=your_key_here" >> .env
+
+# Or set in environment
+export ATTIO_API_KEY=your_key_here
+
+# Or pass directly
+npx attio-discover generate-skill --all --api-key your_key_here
+```
+
+### "Objects are experimental"
+
+Phase 1 objects are: `companies`, `people`, `deals`. Other objects work but are less tested:
+
+```bash
+# Non-Phase 1 objects show a warning but still generate
+npx attio-discover generate-skill --object tasks
+```
+
+### "Claude uses wrong attribute names"
+
+1. Verify the skill is installed: ask Claude "what skills do you have?"
+2. Regenerate if your workspace changed
+3. Ensure Claude references the skill: "using the attio-workspace-schema skill, what are..."
+
+### "Too many options truncated"
+
+Increase the limit:
+
+```bash
+npx attio-discover generate-skill --all --max-options 50
+```
+
+## Related Documentation
+
+- [Attio MCP Usage Skill](./attio-mcp-usage.md) - Universal patterns and error prevention
+- [Attio Skill Generator](./attio-skill-generator.md) - Create custom workflow skills
+- [Skills Overview](./README.md) - All available skills
+- [Getting Started Guide](../getting-started.md) - First-time setup


### PR DESCRIPTION
## Summary

- Add comprehensive user-facing documentation for all 3 Claude Skills
- Streamline README by moving detailed content to dedicated docs
- Add installation instructions for Claude Desktop (drag-drop ZIP) and Claude Code (`~/.claude/skills/`)

## Changes

### New Documentation (`docs/usage/skills/`)

| File | Purpose |
|------|---------|
| `README.md` | Executive summary with decision matrix, installation guide |
| `attio-mcp-usage.md` | Universal patterns skill (error prevention, workflows) |
| `attio-workspace-skill.md` | CLI tool and generated schema documentation |

### README.md Cleanup (~300 lines removed)

- **Added**: Concise skills table linking to detailed docs
- **Moved**: Advanced search filters → `docs/usage/advanced-search.md`
- **Removed**: Dated "Latest Updates" section (belongs in CHANGELOG)
- **Condensed**: E2E test framework details (link to testing docs)

### Installation Instructions

- **Claude Desktop**: Drag-drop ZIP into chat or Settings > Skills > Import
- **Claude Code**: Copy to `~/.claude/skills/` directory
- **Project-level**: Copy to `.claude/skills/` for team sharing

## Test Plan

- [x] All markdown files formatted with Prettier
- [x] Links verified (relative paths correct)
- [x] Pre-commit hooks pass
- [x] Pre-push tests pass (2985 tests)

Closes #1027