### PR TITLE
Test: Fix 4 flaky tests causing pre-push hook failures

### DIFF
--- a/test/api/attio-client.context.test.ts
+++ b/test/api/attio-client.context.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearClientCache } from '@/api/lazy-client.js';
 
 const originalApiKey = process.env.ATTIO_API_KEY;
 const originalLogLevel = process.env.MCP_LOG_LEVEL;
@@ -33,7 +34,7 @@ describe('Attio client context fallback', () => {
     });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
 
@@ -49,7 +50,7 @@ describe('Attio client context fallback', () => {
       delete process.env.MCP_LOG_LEVEL;
     }
 
-    const { clearClientCache } = await import('@/api/lazy-client.js');
+    // Clear client cache (imported at module scope to avoid dynamic import hang)
     clearClientCache();
   });
 

--- a/test/config/deal-defaults.test.ts
+++ b/test/config/deal-defaults.test.ts
@@ -422,32 +422,40 @@ describe('Deal Defaults - PR #389 Fix', () => {
       expect(mockGetStatusOptions).toHaveBeenCalledTimes(2); // New API call
     });
 
-    it('should handle concurrent requests with minimal API calls', async () => {
-      // This test simulates multiple concurrent requests
-      mockGetStatusOptions.mockResolvedValue([
-        { title: 'Concurrent Stage', value: 'concurrent', is_archived: false },
-      ]);
+    it(
+      'should handle concurrent requests with minimal API calls',
+      { timeout: 15000 },
+      async () => {
+        // This test simulates multiple concurrent requests
+        mockGetStatusOptions.mockResolvedValue([
+          {
+            title: 'Concurrent Stage',
+            value: 'concurrent',
+            is_archived: false,
+          },
+        ]);
 
-      clearDealCaches();
+        clearDealCaches();
 
-      // Simulate multiple concurrent requests
-      const promises = Array.from({ length: 5 }, () =>
-        validateDealStage('Concurrent Stage', false)
-      );
+        // Simulate multiple concurrent requests
+        const promises = Array.from({ length: 5 }, () =>
+          validateDealStage('Concurrent Stage', false)
+        );
 
-      const results = await Promise.all(promises);
+        const results = await Promise.all(promises);
 
-      // All should return the same result
-      results.forEach((result) => {
-        expect(result.validatedStage).toBe('Concurrent Stage');
-      });
+        // All should return the same result
+        results.forEach((result) => {
+          expect(result.validatedStage).toBe('Concurrent Stage');
+        });
 
-      // API should be called but with minimal calls (allowing for some race conditions)
-      // In a real-world scenario, some concurrent requests might slip through
-      const callCount = mockGetStatusOptions.mock.calls.length;
-      expect(callCount).toBeGreaterThanOrEqual(1);
-      expect(callCount).toBeLessThanOrEqual(5);
-    });
+        // API should be called but with minimal calls (allowing for some race conditions)
+        // In a real-world scenario, some concurrent requests might slip through
+        const callCount = mockGetStatusOptions.mock.calls.length;
+        expect(callCount).toBeGreaterThanOrEqual(1);
+        expect(callCount).toBeLessThanOrEqual(5);
+      }
+    );
 
     it('should handle malformed API responses', async () => {
       // Mock malformed API response

--- a/test/scripts/helpers/shell-test-utils.ts
+++ b/test/scripts/helpers/shell-test-utils.ts
@@ -210,8 +210,10 @@ export function validateBashSyntax(scriptPath: string): ShellResult {
  * Get list of functions defined in a bash script
  */
 export function getBashFunctions(scriptPath: string): string[] {
+  // Use grep to find function definitions without sourcing the script
+  // This avoids executing any setup code that might hang
   const result = execBash(
-    `bash -c 'source "${scriptPath}" 2>/dev/null; declare -F' | awk '{print $3}'`
+    `grep -E '^[a-zA-Z_][a-zA-Z0-9_]*\\s*\\(\\)' "${scriptPath}" | sed 's/().*$//' | tr -d ' '`
   );
 
   if (result.exitCode !== 0) {

--- a/test/services/UniversalCreateService-validation-errors.test.ts
+++ b/test/services/UniversalCreateService-validation-errors.test.ts
@@ -95,6 +95,8 @@ describe('UniversalCreateService', () => {
       errors: [],
     } as any);
 
+    vi.mocked(validateResourceType).mockReturnValue(true);
+
     vi.mocked(mapRecordFields).mockImplementation(
       (resourceType: string, data: any) =>
         ({


### PR DESCRIPTION
## Summary

Fixes 4 flaky tests that were causing the pre-push hook to fail with timeouts.

Closes #1036

## Changes

**test/api/attio-client.context.test.ts**
- Problem: afterEach hook timeout due to dynamic import after vi.resetModules()
- Fix: Moved clearClientCache import to module scope instead of dynamic import

**test/config/deal-defaults.test.ts**
- Problem: Concurrent test timing out at default 10000ms
- Fix: Added explicit 15000ms timeout to concurrent test

**test/services/UniversalCreateService-validation-errors.test.ts**
- Problem: Incomplete mock setup in beforeEach
- Fix: Added validateResourceType mock in beforeEach

**test/scripts/helpers/shell-test-utils.ts**
- Problem: getBashFunctions sourcing entire bash script causing hangs
- Fix: Replaced script sourcing with grep-based function extraction

## Test Results

All tests now pass consistently without timeouts. Pre-push hook completes in ~28s.