### PR TITLE
Fix: Update @modelcontextprotocol/sdk peerDependency to ~1.24.0 #1063

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "libphonenumber-js": "^1.12.30"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.4.1"
+    "@modelcontextprotocol/sdk": "~1.24.0"
   },
   "peerDependenciesMeta": {
     "@modelcontextprotocol/sdk": {


### PR DESCRIPTION
## Fix: Syncpack Dependency Version Mismatch

### Problem
The v1.4.0 release pipeline failed at "Lint & Type Check" step:

```
✘ @modelcontextprotocol/sdk ^1.4.1 → ~1.24.0 packages/core/package.json > peerDependencies [HighestSemverMismatch]
```

**Syncpack** detected version inconsistency:
- Root package.json: `~1.24.0`
- packages/core/package.json: `^1.4.1` (outdated)

### Solution
Ran `npm run syncpack:fix` to auto-update the version:

```diff
"peerDependencies": {
-  "@modelcontextprotocol/sdk": "^1.4.1"
+  "@modelcontextprotocol/sdk": "~1.24.0"
}
```

### Impact
- ✅ Unblocks v1.4.0 release
- ✅ Ensures dependency version consistency across monorepo
- ✅ No functional changes (version sync only)

### Validation
- ✅ syncpack:check passes (55 valid dependencies)
- ✅ All tests pass (205 files, 3182 tests)
- ✅ TypeScript check passes
- ✅ Pre-push validation complete

### Related
- Issue #1063 - Syncpack dependency version mismatch
- v1.4.0 Release (blocked)
- PR #1062 - Fixed CI test exclusions (merged)