### PR TITLE
Fix: Universal tools return proper list format (not wrapped in values) #1068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Universal tools (`search_records`, `get_record_details`) now return proper list format matching list-specific tools instead of generic record format with values wrapper (#1068)
 - MCP Registry publishing workflow schema version and re-publish errors (#1066)
 
 ## [1.4.0] - 2025-12-29

--- a/src/handlers/tool-configs/universal/core/crud-operations.ts
+++ b/src/handlers/tool-configs/universal/core/crud-operations.ts
@@ -122,8 +122,13 @@ export const createRecordConfig: UniversalToolConfig<
       ? getSingularResourceType(resourceType)
       : 'record';
 
+    // For lists, fields are at top level (no values wrapper)
+    // For other records, fields are in values wrapper
+    const hasValues = record.values && Object.keys(record.values).length > 0;
     const inferredName = extractDisplayName(
-      record.values as Record<string, unknown> | undefined,
+      hasValues
+        ? (record.values as Record<string, unknown>)
+        : (record as Record<string, unknown>),
       resourceType
     );
     const displayName =
@@ -231,8 +236,13 @@ export const updateRecordConfig: UniversalToolConfig<
       ? getSingularResourceType(resourceType)
       : 'record';
 
+    // For lists, fields are at top level (no values wrapper)
+    // For other records, fields are in values wrapper
+    const hasValues = record.values && Object.keys(record.values).length > 0;
     const name = extractDisplayName(
-      record.values as Record<string, unknown> | undefined,
+      hasValues
+        ? (record.values as Record<string, unknown>)
+        : (record as Record<string, unknown>),
       resourceType
     );
     const id = String(record.id?.record_id || 'unknown');

--- a/src/handlers/tool-configs/universal/core/crud-operations.ts
+++ b/src/handlers/tool-configs/universal/core/crud-operations.ts
@@ -134,8 +134,10 @@ export const createRecordConfig: UniversalToolConfig<
     const displayName =
       inferredName === 'Unnamed' ? `New ${resourceTypeName}` : inferredName;
 
+    // Issue #1068: Extract ID based on resource type (list_id for lists, record_id for others)
     const id = String(
-      record.id?.record_id ||
+      record.id?.list_id ||
+        record.id?.record_id ||
         (record as { record_id?: string }).record_id ||
         'unknown'
     );

--- a/src/handlers/tool-configs/universal/core/record-details-operations.ts
+++ b/src/handlers/tool-configs/universal/core/record-details-operations.ts
@@ -47,8 +47,11 @@ export const getRecordDetailsConfig: UniversalToolConfig<
     const resourceTypeName = resourceType
       ? getSingularResourceType(resourceType)
       : 'record';
+    // For lists, fields are at top level (no values wrapper)
+    // For other records, fields are in values wrapper
+    const hasValues = record.values && Object.keys(record.values).length > 0;
     const name = UniversalUtilityService.extractDisplayName(
-      record.values || {}
+      hasValues ? record.values : (record as Record<string, unknown>)
     );
     const id = String(record.id?.record_id || 'unknown');
 

--- a/src/handlers/tool-configs/universal/shared-handlers.ts
+++ b/src/handlers/tool-configs/universal/shared-handlers.ts
@@ -22,7 +22,7 @@ import {
   UniversalGetAttributeOptionsParams,
 } from './types.js';
 
-import { JsonObject } from '../../../types/attio.js';
+import { JsonObject, AttioRecord } from '../../../types/attio.js';
 
 // Import extracted services from Issue #489 Phase 2 & 3
 import { UniversalDeleteService } from '../../../services/UniversalDeleteService.js';
@@ -60,10 +60,9 @@ import {
 // Import Attio API client for direct note operations
 import { unwrapAttio, normalizeNotes } from '../../../utils/attio-response.js';
 
-import { AttioRecord } from '../../../types/attio.js';
-
 /**
  * Universal search handler - delegates to UniversalSearchService
+ * Issue #1068: Lists returned in list-native format (cast to AttioRecord[])
  */
 export async function handleUniversalSearch(
   params: UniversalSearchParams
@@ -73,6 +72,7 @@ export async function handleUniversalSearch(
 
 /**
  * Universal get record details handler with performance optimization
+ * Issue #1068: Lists returned in list-native format (cast to AttioRecord)
  */
 export async function handleUniversalGetDetails(
   params: UniversalRecordDetailsParams

--- a/src/objects/lists/base.ts
+++ b/src/objects/lists/base.ts
@@ -24,7 +24,9 @@ export async function getLists(
   limit: number = 20
 ): Promise<AttioList[]> {
   try {
-    return await getGenericLists(objectSlug, limit);
+    const lists = await getGenericLists(objectSlug, limit);
+    // Always normalize list shapes to extract workspace_id from id objects
+    return asListArray(lists);
   } catch (error: unknown) {
     const errorMessage = getErrorMessage(error) ?? 'Unknown error';
     if (process.env.NODE_ENV === 'development') {
@@ -51,7 +53,9 @@ export async function getLists(
  */
 export async function getListDetails(listId: string): Promise<AttioList> {
   try {
-    return await getGenericListDetails(listId);
+    const list = await getGenericListDetails(listId);
+    // Always normalize the list shape to extract workspace_id from id object
+    return ensureListShape(list);
   } catch (error: unknown) {
     const errorMessage = getErrorMessage(error) ?? 'Unknown error';
     if (process.env.NODE_ENV === 'development') {

--- a/src/objects/lists/shared.ts
+++ b/src/objects/lists/shared.ts
@@ -32,18 +32,29 @@ export function ensureListShape(raw: unknown): AttioList {
       : {};
 
   let listId: string | undefined;
+  let workspaceId: string | undefined;
   const rawId = value.id;
   if (typeof rawId === 'object' && rawId !== null && 'list_id' in rawId) {
     const candidate = (rawId as Record<string, unknown>).list_id;
     if (typeof candidate === 'string') {
       listId = candidate;
     }
+    // Also extract workspace_id from id object
+    const wsId = (rawId as Record<string, unknown>).workspace_id;
+    if (typeof wsId === 'string') {
+      workspaceId = wsId;
+    }
   }
   if (typeof value.list_id === 'string') {
     listId = value.list_id;
   }
+  // Check top-level workspace_id as well
+  if (typeof value.workspace_id === 'string') {
+    workspaceId = value.workspace_id;
+  }
 
   const resolvedListId = listId ?? crypto.randomUUID?.() ?? `tmp_${Date.now()}`;
+  const resolvedWorkspaceId = workspaceId || '';
   const resolvedTitle =
     typeof value.title === 'string'
       ? value.title
@@ -61,8 +72,7 @@ export function ensureListShape(raw: unknown): AttioList {
     description: typeof value.description === 'string' ? value.description : '',
     object_slug:
       typeof value.object_slug === 'string' ? value.object_slug : 'lists',
-    workspace_id:
-      typeof value.workspace_id === 'string' ? value.workspace_id : '',
+    workspace_id: resolvedWorkspaceId,
     created_at: typeof value.created_at === 'string' ? value.created_at : '',
     updated_at: typeof value.updated_at === 'string' ? value.updated_at : '',
     entry_count:

--- a/src/services/UniversalMetadataService.ts
+++ b/src/services/UniversalMetadataService.ts
@@ -322,6 +322,36 @@ export class UniversalMetadataService {
     return this.facade.getAttributes(params);
   }
 
+  /**
+   * Get record details by resource type and record ID
+   * Fix for Issue #1068: Enable get_record_details for lists
+   */
+  static async getRecordDetails(params: {
+    resource_type: UniversalResourceType;
+    record_id: string;
+  }): Promise<Record<string, unknown>> {
+    const { resource_type, record_id } = params;
+
+    // Import list service for lists
+    const { getListDetails } = await import('../objects/lists/base.js');
+
+    switch (resource_type) {
+      case UniversalResourceType.LISTS: {
+        // Return list details in proper format (not wrapped in values)
+        const list = await getListDetails(record_id);
+        return list as unknown as Record<string, unknown>;
+      }
+
+      // For other resource types, use existing attribute fetching
+      // (can be extended to other resources as needed)
+      default:
+        throw new Error(
+          `getRecordDetails not yet implemented for resource_type: ${resource_type}. ` +
+            `Use getAttributes() or getAttributesForRecord() instead.`
+        );
+    }
+  }
+
   static async discoverAttributes(
     resource_type: UniversalResourceType,
     options?: {

--- a/src/services/UniversalSearchService.ts
+++ b/src/services/UniversalSearchService.ts
@@ -32,10 +32,12 @@ import { SearchCoordinator } from './search/SearchCoordinator.js';
 /**
  * UniversalSearchService provides centralized record search functionality
  * Issue #935: Strategy initialization delegated to StrategyFactory via SearchCoordinator
+ * Issue #1068: Lists returned in list-native format (cast to AttioRecord[])
  */
 export class UniversalSearchService {
   /**
    * Universal search handler with performance tracking
+   * Issue #1068: Lists returned in list-native format (cast to AttioRecord[])
    */
   static async searchRecords(
     params: UniversalSearchParams

--- a/src/services/search-strategies/ListSearchStrategy.ts
+++ b/src/services/search-strategies/ListSearchStrategy.ts
@@ -144,12 +144,12 @@ export class ListSearchStrategy extends BaseSearchStrategy {
   private convertListsToRecords(lists: AttioList[]): AttioRecord[] {
     return lists.map((list) => {
       // Prioritize existing top-level workspace_id, fallback to id.workspace_id
-      // This prevents overwriting valid workspace_id with empty string
+      // Use ?? (nullish coalescing) to preserve empty strings as valid values
       const existingWorkspaceId = (list as { workspace_id?: string })
         .workspace_id;
       const idWorkspaceId = (list.id as { workspace_id?: string })
         ?.workspace_id;
-      const workspaceId = existingWorkspaceId || idWorkspaceId;
+      const workspaceId = existingWorkspaceId ?? idWorkspaceId;
 
       // Build result object without overwriting existing workspace_id
       const result: Record<string, unknown> = {
@@ -163,8 +163,9 @@ export class ListSearchStrategy extends BaseSearchStrategy {
         name: list.name || list.title,
       };
 
-      // Only set workspace_id if we found one (don't overwrite with empty string)
-      if (workspaceId) {
+      // Set workspace_id if we found one (null/undefined are excluded by ??)
+      // Empty strings are valid values and will be preserved
+      if (workspaceId !== undefined) {
         result.workspace_id = workspaceId;
       }
 

--- a/src/services/search-strategies/ListSearchStrategy.ts
+++ b/src/services/search-strategies/ListSearchStrategy.ts
@@ -3,7 +3,7 @@
  * Issue #574: Extract list search logic from UniversalSearchService
  */
 
-import { AttioRecord, AttioList } from '../../types/attio.js';
+import { AttioRecord, AttioList, AttioListRecord } from '../../types/attio.js';
 import {
   SearchType,
   MatchType,
@@ -115,6 +115,31 @@ export class ListSearchStrategy extends BaseSearchStrategy {
   /**
    * Convert Attio lists to AttioRecord format
    * Fix for Issue #1068: Return lists in proper format (not wrapped in values)
+   *
+   * Lists use `list_id` in the id object, while typical records use `record_id`.
+   * This method transforms lists to be compatible with universal record tools while
+   * maintaining the proper list ID structure. The returned objects are compatible
+   * with AttioRecord but have list-specific ID structure (AttioListRecord).
+   *
+   * @example Input (AttioList from API):
+   * {
+   *   id: { list_id: 'list-abc-123', workspace_id: 'ws-xyz' },
+   *   name: 'Sales Pipeline',
+   *   title: 'Sales Pipeline',
+   *   workspace_id: 'ws-xyz',
+   *   ...
+   * }
+   *
+   * @example Output (AttioListRecord):
+   * {
+   *   id: { list_id: 'list-abc-123' },
+   *   name: 'Sales Pipeline',
+   *   workspace_id: 'ws-xyz',
+   *   ...
+   * }
+   *
+   * @param lists - Array of AttioList objects from the API
+   * @returns Array of AttioRecord objects with list-specific ID structure (AttioListRecord)
    */
   private convertListsToRecords(lists: AttioList[]): AttioRecord[] {
     return lists.map((list) => {
@@ -143,7 +168,9 @@ export class ListSearchStrategy extends BaseSearchStrategy {
         result.workspace_id = workspaceId;
       }
 
-      return result as unknown as AttioRecord;
+      // Cast to AttioListRecord for type safety, which is compatible with AttioRecord
+      // The result has list_id in the id object, making it an AttioListRecord
+      return result as AttioListRecord;
     });
   }
 

--- a/src/services/search-utilities/SearchUtilities.ts
+++ b/src/services/search-utilities/SearchUtilities.ts
@@ -95,6 +95,13 @@ export class SearchUtilities {
    * Issue #598: Simplified with better type safety and helper methods
    */
   static getFieldValue(record: AttioRecord, field: string): string {
+    // Fix for #1068: Check top-level fields first (for lists)
+    const topLevelValue = (record as Record<string, unknown>)[field];
+    if (typeof topLevelValue === 'string') {
+      return topLevelValue;
+    }
+
+    // Check in values wrapper (for other record types)
     const values = record.values as Record<string, AttioFieldValue>;
     if (!values) return '';
 
@@ -161,6 +168,14 @@ export class SearchUtilities {
    * Helper method to extract field value from a list record for content search
    */
   static getListFieldValue(list: AttioRecord, field: string): string {
+    // Fix for #1068: Lists now have fields at top level (not wrapped in values)
+    // Check top-level field first (new format)
+    const topLevelValue = (list as Record<string, unknown>)[field];
+    if (typeof topLevelValue === 'string') {
+      return topLevelValue;
+    }
+
+    // Fall back to values wrapper for backwards compatibility (old format)
     const values = list.values as Record<string, unknown>;
     if (!values) return '';
 

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -240,6 +240,22 @@ export interface EnhancedAttioRecord extends AttioRecord {
 }
 
 /**
+ * AttioListRecord: Type for lists when treated as records in universal tools
+ *
+ * Lists use `list_id` in the id object, while typical records use `record_id`.
+ * This type extends AttioRecord to allow both ID formats, making lists compatible
+ * with universal record tools.
+ *
+ * @see Issue #1068 - Fix universal tools list format
+ * @see src/services/search-strategies/ListSearchStrategy.ts
+ */
+export type AttioListRecord = AttioRecord & {
+  id: AttioRecord['id'] & {
+    list_id: string;
+  };
+};
+
+/**
  * Interface for a batch request item
  */
 export interface BatchRequestItem<T> {

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -240,11 +240,26 @@ export interface EnhancedAttioRecord extends AttioRecord {
 }
 
 /**
- * AttioListRecord: Type for lists when treated as records in universal tools
+ * Universal record type for operations that handle both regular records and lists
+ * Issue #1068: Lists don't have a values wrapper (list-native format)
  *
- * Lists use `list_id` in the id object, while typical records use `record_id`.
- * This type extends AttioRecord to allow both ID formats, making lists compatible
- * with universal record tools.
+ * Use this union type in universal tool configs and services to support both:
+ * - AttioRecord: Regular records with values wrapper (companies, people, deals, tasks)
+ * - AttioList: Lists with top-level fields, no values wrapper
+ *
+ * This makes "lists don't have values" a first-class type contract.
+ *
+ * @see src/handlers/tool-configs/universal/core/*
+ * @see src/services/Universal*Service.ts
+ */
+export type UniversalRecord = AttioRecord | AttioList;
+
+/**
+ * @deprecated Use UniversalRecord instead
+ * AttioListRecord: Transitional type that extends AttioRecord (requires values)
+ *
+ * This type contradicts the list-native format goal and will be removed.
+ * Use UniversalRecord for code that needs to handle both records and lists.
  *
  * @see Issue #1068 - Fix universal tools list format
  * @see src/services/search-strategies/ListSearchStrategy.ts

--- a/test/handlers/tool-configs/universal/list-formatter-regression.test.ts
+++ b/test/handlers/tool-configs/universal/list-formatter-regression.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression test for list formatter issue
+ * Issue #1068 - Ensure list names are properly extracted in formatters
+ *
+ * After shifting lists to expose fields at the top level (no values wrapper),
+ * formatters must handle both wrapped (companies, people) and unwrapped (lists) formats.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AttioListRecord } from '@/types/attio.js';
+import { getRecordDetailsConfig } from '@/handlers/tool-configs/universal/core/record-details-operations.js';
+import { createRecordConfig } from '@/handlers/tool-configs/universal/core/crud-operations.js';
+import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
+
+describe('List Formatter Regression - Issue #1068', () => {
+  describe('get_record_details formatter', () => {
+    it('should extract list name from top-level fields (not values wrapper)', () => {
+      // List record with top-level fields (new format after #1068)
+      const listRecord: AttioListRecord = {
+        id: {
+          record_id: 'list-123',
+          list_id: 'list-123',
+        },
+        name: 'Sales Pipeline',
+        title: 'Sales Pipeline',
+        api_slug: 'sales-pipeline',
+        object_slug: 'deals',
+        workspace_id: 'ws-456',
+        values: {}, // Empty values object (not used for lists)
+      };
+
+      const formatted = getRecordDetailsConfig.formatResult(
+        listRecord,
+        UniversalResourceType.LISTS
+      );
+
+      // Should show list name, NOT "Unnamed"
+      expect(formatted).toContain('Sales Pipeline');
+      expect(formatted).not.toContain('Unnamed');
+      expect(formatted).toContain('List: Sales Pipeline');
+    });
+
+    it('should extract list title when name is not present', () => {
+      const listRecord: AttioListRecord = {
+        id: {
+          record_id: 'list-456',
+          list_id: 'list-456',
+        },
+        title: 'Prospecting List',
+        api_slug: 'prospecting-list',
+        object_slug: 'companies',
+        workspace_id: 'ws-789',
+        values: {},
+      };
+
+      const formatted = getRecordDetailsConfig.formatResult(
+        listRecord,
+        UniversalResourceType.LISTS
+      );
+
+      expect(formatted).toContain('Prospecting List');
+      expect(formatted).not.toContain('Unnamed');
+    });
+
+    it('should handle lists without values wrapper', () => {
+      // List record without values property at all
+      const listRecord = {
+        id: {
+          record_id: 'list-789',
+          list_id: 'list-789',
+        },
+        name: 'Customer Success',
+        api_slug: 'customer-success',
+        object_slug: 'companies',
+        workspace_id: 'ws-111',
+      } as AttioListRecord;
+
+      const formatted = getRecordDetailsConfig.formatResult(
+        listRecord,
+        UniversalResourceType.LISTS
+      );
+
+      expect(formatted).toContain('Customer Success');
+      expect(formatted).not.toContain('Unnamed');
+    });
+
+    it('should still work for regular records with values wrapper', () => {
+      // Company record with values wrapper (existing format)
+      const companyRecord = {
+        id: {
+          record_id: 'comp-123',
+        },
+        values: {
+          name: [{ value: 'Acme Corp' }],
+          domain: [{ value: 'acme.com' }],
+        },
+      };
+
+      const formatted = getRecordDetailsConfig.formatResult(
+        companyRecord,
+        UniversalResourceType.COMPANIES
+      );
+
+      expect(formatted).toContain('Acme Corp');
+      expect(formatted).not.toContain('Unnamed');
+    });
+  });
+
+  describe('create_record formatter', () => {
+    it('should extract list name from top-level fields in create response', () => {
+      const createdList: AttioListRecord = {
+        id: {
+          record_id: 'list-new-123',
+          list_id: 'list-new-123',
+        },
+        name: 'New Sales List',
+        title: 'New Sales List',
+        api_slug: 'new-sales-list',
+        object_slug: 'deals',
+        workspace_id: 'ws-456',
+        values: {},
+      };
+
+      const formatted = createRecordConfig.formatResult(
+        createdList,
+        UniversalResourceType.LISTS
+      );
+
+      expect(formatted).toContain('New Sales List');
+      expect(formatted).not.toContain('Unnamed');
+      expect(formatted).not.toContain('New list'); // Shouldn't use fallback
+      expect(formatted).toContain('✅');
+    });
+
+    it('should work for company creation with values wrapper', () => {
+      const createdCompany = {
+        id: {
+          record_id: 'comp-new-456',
+        },
+        values: {
+          name: [{ value: 'TechCorp' }],
+        },
+      };
+
+      const formatted = createRecordConfig.formatResult(
+        createdCompany,
+        UniversalResourceType.COMPANIES
+      );
+
+      expect(formatted).toContain('TechCorp');
+      expect(formatted).not.toContain('Unnamed');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle list with empty string name gracefully', () => {
+      const listRecord: AttioListRecord = {
+        id: {
+          record_id: 'list-empty',
+          list_id: 'list-empty',
+        },
+        name: '', // Empty string
+        title: 'Fallback Title',
+        api_slug: 'empty-list',
+        object_slug: 'companies',
+        workspace_id: 'ws-123',
+        values: {},
+      };
+
+      const formatted = getRecordDetailsConfig.formatResult(
+        listRecord,
+        UniversalResourceType.LISTS
+      );
+
+      // Should fall back to title
+      expect(formatted).toContain('Fallback Title');
+      expect(formatted).not.toContain('Unnamed');
+    });
+
+    it('should return "Unnamed" only when no name/title fields exist', () => {
+      const listRecord = {
+        id: {
+          record_id: 'list-no-name',
+          list_id: 'list-no-name',
+        },
+        api_slug: 'no-name-list',
+        object_slug: 'companies',
+        workspace_id: 'ws-123',
+        values: {},
+      } as AttioListRecord;
+
+      const formatted = getRecordDetailsConfig.formatResult(
+        listRecord,
+        UniversalResourceType.LISTS
+      );
+
+      // Should show Unnamed when genuinely no name
+      expect(formatted).toContain('Unnamed');
+    });
+  });
+});

--- a/test/handlers/tool-configs/universal/list-formatter-regression.test.ts
+++ b/test/handlers/tool-configs/universal/list-formatter-regression.test.ts
@@ -6,19 +6,24 @@
  * formatters must handle both wrapped (companies, people) and unwrapped (lists) formats.
  */
 
-import { describe, it, expect } from 'vitest';
-import { AttioListRecord } from '@/types/attio.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AttioList } from '@/types/attio.js';
 import { getRecordDetailsConfig } from '@/handlers/tool-configs/universal/core/record-details-operations.js';
 import { createRecordConfig } from '@/handlers/tool-configs/universal/core/crud-operations.js';
+import { searchRecordsConfig } from '@/handlers/tool-configs/universal/core/search-operations.js';
 import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
+
+// Mock getListDetails for tool handler tests
+vi.mock('@/objects/lists.js', () => ({
+  getListDetails: vi.fn(),
+}));
 
 describe('List Formatter Regression - Issue #1068', () => {
   describe('get_record_details formatter', () => {
     it('should extract list name from top-level fields (not values wrapper)', () => {
       // List record with top-level fields (new format after #1068)
-      const listRecord: AttioListRecord = {
+      const listRecord = {
         id: {
-          record_id: 'list-123',
           list_id: 'list-123',
         },
         name: 'Sales Pipeline',
@@ -26,8 +31,7 @@ describe('List Formatter Regression - Issue #1068', () => {
         api_slug: 'sales-pipeline',
         object_slug: 'deals',
         workspace_id: 'ws-456',
-        values: {}, // Empty values object (not used for lists)
-      };
+      } as AttioList;
 
       const formatted = getRecordDetailsConfig.formatResult(
         listRecord,
@@ -41,17 +45,15 @@ describe('List Formatter Regression - Issue #1068', () => {
     });
 
     it('should extract list title when name is not present', () => {
-      const listRecord: AttioListRecord = {
+      const listRecord = {
         id: {
-          record_id: 'list-456',
           list_id: 'list-456',
         },
         title: 'Prospecting List',
         api_slug: 'prospecting-list',
         object_slug: 'companies',
         workspace_id: 'ws-789',
-        values: {},
-      };
+      } as AttioList;
 
       const formatted = getRecordDetailsConfig.formatResult(
         listRecord,
@@ -66,14 +68,13 @@ describe('List Formatter Regression - Issue #1068', () => {
       // List record without values property at all
       const listRecord = {
         id: {
-          record_id: 'list-789',
           list_id: 'list-789',
         },
         name: 'Customer Success',
         api_slug: 'customer-success',
         object_slug: 'companies',
         workspace_id: 'ws-111',
-      } as AttioListRecord;
+      } as AttioList;
 
       const formatted = getRecordDetailsConfig.formatResult(
         listRecord,
@@ -108,9 +109,8 @@ describe('List Formatter Regression - Issue #1068', () => {
 
   describe('create_record formatter', () => {
     it('should extract list name from top-level fields in create response', () => {
-      const createdList: AttioListRecord = {
+      const createdList = {
         id: {
-          record_id: 'list-new-123',
           list_id: 'list-new-123',
         },
         name: 'New Sales List',
@@ -118,8 +118,7 @@ describe('List Formatter Regression - Issue #1068', () => {
         api_slug: 'new-sales-list',
         object_slug: 'deals',
         workspace_id: 'ws-456',
-        values: {},
-      };
+      } as AttioList;
 
       const formatted = createRecordConfig.formatResult(
         createdList,
@@ -130,6 +129,9 @@ describe('List Formatter Regression - Issue #1068', () => {
       expect(formatted).not.toContain('Unnamed');
       expect(formatted).not.toContain('New list'); // Shouldn't use fallback
       expect(formatted).toContain('✅');
+      // Issue #1068: Should show list_id, not "unknown"
+      expect(formatted).toContain('list-new-123');
+      expect(formatted).not.toContain('unknown');
     });
 
     it('should work for company creation with values wrapper', () => {
@@ -154,9 +156,8 @@ describe('List Formatter Regression - Issue #1068', () => {
 
   describe('Edge cases', () => {
     it('should handle list with empty string name gracefully', () => {
-      const listRecord: AttioListRecord = {
+      const listRecord = {
         id: {
-          record_id: 'list-empty',
           list_id: 'list-empty',
         },
         name: '', // Empty string
@@ -164,8 +165,7 @@ describe('List Formatter Regression - Issue #1068', () => {
         api_slug: 'empty-list',
         object_slug: 'companies',
         workspace_id: 'ws-123',
-        values: {},
-      };
+      } as AttioList;
 
       const formatted = getRecordDetailsConfig.formatResult(
         listRecord,
@@ -180,14 +180,12 @@ describe('List Formatter Regression - Issue #1068', () => {
     it('should return "Unnamed" only when no name/title fields exist', () => {
       const listRecord = {
         id: {
-          record_id: 'list-no-name',
           list_id: 'list-no-name',
         },
         api_slug: 'no-name-list',
         object_slug: 'companies',
         workspace_id: 'ws-123',
-        values: {},
-      } as AttioListRecord;
+      } as AttioList;
 
       const formatted = getRecordDetailsConfig.formatResult(
         listRecord,
@@ -196,6 +194,255 @@ describe('List Formatter Regression - Issue #1068', () => {
 
       // Should show Unnamed when genuinely no name
       expect(formatted).toContain('Unnamed');
+    });
+  });
+
+  describe('Tool handler path - get_record_details (Issue #1068)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should return list-native format from tool handler (no values wrapper, no record_id)', async () => {
+      // Import getListDetails mock
+      const { getListDetails } = await import('@/objects/lists.js');
+
+      // Mock list response (list-native format from API)
+      // Use list_ prefix to pass validation in UniversalRetrievalService
+      const mockList = {
+        id: {
+          list_id: 'list_abc123def456',
+        },
+        name: 'Sales Pipeline',
+        title: 'Sales Pipeline',
+        api_slug: 'sales-pipeline',
+        object_slug: 'deals',
+        workspace_id: 'ws-test-456',
+        description: 'Main sales pipeline',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+      };
+
+      vi.mocked(getListDetails).mockResolvedValue(mockList as any);
+
+      // Call the tool handler (goes through UniversalRetrievalService)
+      const result = await getRecordDetailsConfig.handler({
+        resource_type: UniversalResourceType.LISTS,
+        record_id: 'list_abc123def456',
+      });
+
+      // Verify list-native format returned
+      expect(result.id).toHaveProperty('list_id', 'list_abc123def456');
+      expect(result.id).not.toHaveProperty('record_id');
+      expect(result).toHaveProperty('name', 'Sales Pipeline');
+      expect(result).toHaveProperty('api_slug', 'sales-pipeline');
+      expect(result).not.toHaveProperty('values');
+    });
+
+    it('should format list correctly (show list_id, not "unknown")', async () => {
+      const { getListDetails } = await import('@/objects/lists.js');
+
+      // Use list_ prefix to pass validation
+      const mockList = {
+        id: {
+          list_id: 'list_xyz789formatted',
+        },
+        name: 'Customer Success',
+        api_slug: 'customer-success',
+        object_slug: 'companies',
+        workspace_id: 'ws-formatted-123',
+      };
+
+      vi.mocked(getListDetails).mockResolvedValue(mockList as any);
+
+      const result = await getRecordDetailsConfig.handler({
+        resource_type: UniversalResourceType.LISTS,
+        record_id: 'list_xyz789formatted',
+      });
+
+      const formatted = getRecordDetailsConfig.formatResult(
+        result,
+        UniversalResourceType.LISTS
+      );
+
+      // Should show actual list ID, not "unknown"
+      expect(formatted).toContain('list_xyz789formatted');
+      expect(formatted).not.toContain('unknown');
+
+      // Should show list name
+      expect(formatted).toContain('Customer Success');
+      expect(formatted).not.toContain('Unnamed');
+    });
+
+    it('should always include id even when fields parameter excludes it (Issue #1 fix)', async () => {
+      const { getListDetails } = await import('@/objects/lists.js');
+
+      // Mock list response with all fields
+      const mockList = {
+        id: {
+          list_id: 'list_fields_test',
+        },
+        name: 'Test List',
+        title: 'Test List',
+        api_slug: 'test-list',
+        object_slug: 'companies',
+        workspace_id: 'ws-fields-test',
+        description: 'This is a test list',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+      };
+
+      vi.mocked(getListDetails).mockResolvedValue(mockList as any);
+
+      // Request only specific fields (excludes 'id')
+      const result = await getRecordDetailsConfig.handler({
+        resource_type: UniversalResourceType.LISTS,
+        record_id: 'list_fields_test',
+        fields: ['name', 'description'], // Explicitly excludes 'id'
+      });
+
+      // Verify id is still present despite being excluded from fields
+      expect(result.id).toBeDefined();
+      expect(result.id).toHaveProperty('list_id', 'list_fields_test');
+      expect(result).toHaveProperty('name', 'Test List');
+      expect(result).toHaveProperty('description', 'This is a test list');
+
+      // Should not have fields that weren't requested
+      expect(result).not.toHaveProperty('created_at');
+      expect(result).not.toHaveProperty('updated_at');
+    });
+  });
+
+  describe('search_records formatter (Issue #1068)', () => {
+    it('should extract list name from top-level fields in search results', () => {
+      const listRecords = [
+        {
+          id: {
+            list_id: 'list-search-1',
+          },
+          name: 'Marketing Campaigns',
+          title: 'Marketing Campaigns',
+          api_slug: 'marketing-campaigns',
+          object_slug: 'companies',
+          workspace_id: 'ws-456',
+        },
+        {
+          id: {
+            list_id: 'list-search-2',
+          },
+          name: 'Sales Pipeline',
+          api_slug: 'sales-pipeline',
+          object_slug: 'deals',
+          workspace_id: 'ws-456',
+        },
+      ] as AttioList[];
+
+      const formatted = searchRecordsConfig.formatResult(
+        listRecords,
+        UniversalResourceType.LISTS
+      );
+
+      // Should show list names from top-level fields
+      expect(formatted).toContain('Marketing Campaigns');
+      expect(formatted).toContain('Sales Pipeline');
+      expect(formatted).not.toContain('Unnamed');
+    });
+
+    it('should show list IDs correctly (not "unknown")', () => {
+      const listRecords = [
+        {
+          id: {
+            list_id: 'abc-123-def-456',
+          },
+          name: 'Test List',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          workspace_id: 'ws-789',
+        },
+      ] as AttioList[];
+
+      const formatted = searchRecordsConfig.formatResult(
+        listRecords,
+        UniversalResourceType.LISTS
+      );
+
+      // Should show actual list ID, not "unknown"
+      expect(formatted).toContain('abc-123-def-456');
+      expect(formatted).not.toContain('unknown');
+    });
+
+    it('should handle lists without values wrapper', () => {
+      const listRecord = {
+        id: {
+          list_id: 'list-no-values',
+        },
+        name: 'Prospecting List',
+        api_slug: 'prospecting-list',
+        object_slug: 'companies',
+        workspace_id: 'ws-111',
+        // NO values property at all (list-native format)
+      } as AttioList;
+
+      const formatted = searchRecordsConfig.formatResult(
+        [listRecord],
+        UniversalResourceType.LISTS
+      );
+
+      // Should show list name
+      expect(formatted).toContain('Prospecting List');
+      expect(formatted).not.toContain('Unnamed');
+    });
+
+    it('should include object_slug in formatter output', () => {
+      const listRecord = {
+        id: {
+          list_id: 'list-with-slug',
+        },
+        name: 'Customer Success',
+        api_slug: 'customer-success',
+        object_slug: 'companies',
+        workspace_id: 'ws-222',
+      } as AttioList;
+
+      const formatted = searchRecordsConfig.formatResult(
+        [listRecord],
+        UniversalResourceType.LISTS
+      );
+
+      // Should include object_slug for context
+      expect(formatted).toContain('Customer Success');
+      expect(formatted).toContain('[companies]');
+    });
+
+    it('should fall back to title when name is missing', () => {
+      const listRecord = {
+        id: {
+          list_id: 'list-title-fallback',
+        },
+        title: 'Title Only List',
+        api_slug: 'title-only',
+        object_slug: 'people',
+        workspace_id: 'ws-333',
+      } as AttioList;
+
+      const formatted = searchRecordsConfig.formatResult(
+        [listRecord],
+        UniversalResourceType.LISTS
+      );
+
+      // Should use title as fallback
+      expect(formatted).toContain('Title Only List');
+      expect(formatted).not.toContain('Unnamed');
+    });
+
+    it('should handle empty list array', () => {
+      const formatted = searchRecordsConfig.formatResult(
+        [],
+        UniversalResourceType.LISTS
+      );
+
+      // Should show "Found 0 lists"
+      expect(formatted).toContain('Found 0');
+      expect(formatted).toContain('lists');
     });
   });
 });

--- a/test/integration/universal-tools-lists.test.ts
+++ b/test/integration/universal-tools-lists.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Integration tests for universal tools with lists resource type.
+ * Verifies that universal tools can correctly replace list-specific tools.
+ *
+ * Issue #1059 - List tools consolidation
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { UniversalSearchService } from '@services/UniversalSearchService.js';
+import { UniversalMetadataService } from '@services/UniversalMetadataService.js';
+import { getLists, getListDetails } from '@src/objects/lists/base.js';
+import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
+
+describe('Universal Tools - Lists Integration', () => {
+  describe('search_records (resource_type="lists") vs get-lists', () => {
+    it('should return same data format as get-lists', async () => {
+      // Get lists using old tool
+      const listsOldTool = await getLists();
+
+      // Get lists using universal tool
+      const listsUniversalTool = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '', // Empty query returns all
+        limit: 100,
+      });
+
+      // Both should return arrays
+      expect(Array.isArray(listsOldTool)).toBe(true);
+      expect(Array.isArray(listsUniversalTool)).toBe(true);
+
+      // Should have same number of results (or close, accounting for pagination)
+      expect(listsUniversalTool.length).toBeGreaterThan(0);
+      expect(listsUniversalTool.length).toBeLessThanOrEqual(100);
+
+      // Verify data structure matches
+      if (listsUniversalTool.length > 0) {
+        const universalList = listsUniversalTool[0];
+        const oldToolList = listsOldTool.find(
+          (l: any) => l.id?.list_id === (universalList as any).id?.list_id
+        );
+
+        if (oldToolList) {
+          // Verify key fields exist in both
+          expect(universalList).toHaveProperty('id');
+          expect(universalList).toHaveProperty('name');
+          expect(oldToolList).toHaveProperty('id');
+          expect(oldToolList).toHaveProperty('name');
+        }
+      }
+    });
+
+    it('should include all list metadata', async () => {
+      const lists = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '',
+        limit: 10,
+      });
+
+      if (lists.length > 0) {
+        const list = lists[0] as any;
+
+        // Verify essential metadata fields
+        expect(list).toHaveProperty('id');
+        expect(list.id).toHaveProperty('list_id');
+        expect(list).toHaveProperty('name');
+        expect(list).toHaveProperty('api_slug');
+        expect(list).toHaveProperty('workspace_id');
+
+        // Should have ID structure
+        expect(typeof list.id.list_id).toBe('string');
+        expect(list.id.list_id.length).toBeGreaterThan(0);
+
+        // Should have valid name
+        expect(typeof list.name).toBe('string');
+        expect(list.name.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should support query filtering', async () => {
+      // First get all lists
+      const allLists = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '',
+        limit: 100,
+      });
+
+      if (allLists.length > 0) {
+        // Get a list name to search for
+        const targetList = allLists[0] as any;
+        const searchName = targetList.name;
+
+        // Search by name
+        const filteredLists = await UniversalSearchService.searchRecords({
+          resource_type: UniversalResourceType.LISTS,
+          query: searchName.substring(0, 5), // Search by first 5 chars
+          limit: 100,
+        });
+
+        // Should return results
+        expect(filteredLists.length).toBeGreaterThan(0);
+
+        // Should include the target list
+        const found = filteredLists.some(
+          (l: any) => l.id?.list_id === targetList.id.list_id
+        );
+        expect(found).toBe(true);
+      }
+    });
+
+    it('should support pagination', async () => {
+      // Get first page
+      const page1 = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '',
+        limit: 5,
+        offset: 0,
+      });
+
+      // Get second page
+      const page2 = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '',
+        limit: 5,
+        offset: 5,
+      });
+
+      // Both pages should have results (assuming >5 lists exist)
+      expect(Array.isArray(page1)).toBe(true);
+      expect(Array.isArray(page2)).toBe(true);
+
+      // Pages should not overlap (different IDs)
+      if (page1.length > 0 && page2.length > 0) {
+        const page1Ids = page1.map((l: any) => l.id?.list_id);
+        const page2Ids = page2.map((l: any) => l.id?.list_id);
+
+        const overlap = page1Ids.some((id) => page2Ids.includes(id));
+        expect(overlap).toBe(false);
+      }
+    });
+  });
+
+  describe('get_record_details (resource_type="lists") vs get-list-details', () => {
+    let testListId: string;
+    let testListSlug: string;
+
+    beforeAll(async () => {
+      // Get a list ID for testing
+      const lists = await getLists();
+      if (lists.length > 0) {
+        testListId = lists[0].id?.list_id || '';
+        testListSlug = lists[0].api_slug || '';
+      }
+    });
+
+    it('should return same data with UUID identifier', async () => {
+      if (!testListId) {
+        console.warn('No test list ID available, skipping test');
+        return;
+      }
+
+      // Get list details using old tool (UUID)
+      const detailsOld = await getListDetails(testListId);
+
+      // Get list details using universal tool (UUID)
+      const detailsUniversal = await UniversalMetadataService.getRecordDetails({
+        resource_type: UniversalResourceType.LISTS,
+        record_id: testListId,
+      });
+
+      // Both should return object
+      expect(typeof detailsOld).toBe('object');
+      expect(typeof detailsUniversal).toBe('object');
+      expect(detailsOld).not.toBeNull();
+      expect(detailsUniversal).not.toBeNull();
+
+      // Verify key fields match
+      expect((detailsOld as any).id?.list_id).toBe(
+        (detailsUniversal as any).id?.list_id
+      );
+      expect((detailsOld as any).name).toBe((detailsUniversal as any).name);
+      expect((detailsOld as any).api_slug).toBe(
+        (detailsUniversal as any).api_slug
+      );
+    });
+
+    it('should return same data with slug identifier', async () => {
+      if (!testListSlug) {
+        console.warn('No test list slug available, skipping test');
+        return;
+      }
+
+      // Get list details using old tool (slug)
+      const detailsOld = await getListDetails(testListSlug);
+
+      // Get list details using universal tool (slug)
+      const detailsUniversal = await UniversalMetadataService.getRecordDetails({
+        resource_type: UniversalResourceType.LISTS,
+        record_id: testListSlug,
+      });
+
+      // Both should return object
+      expect(typeof detailsOld).toBe('object');
+      expect(typeof detailsUniversal).toBe('object');
+
+      // Verify slug matches
+      expect((detailsOld as any).api_slug).toBe(
+        (detailsUniversal as any).api_slug
+      );
+    });
+
+    it('should include full list schema and configuration', async () => {
+      if (!testListId) {
+        console.warn('No test list ID available, skipping test');
+        return;
+      }
+
+      const details = (await UniversalMetadataService.getRecordDetails({
+        resource_type: UniversalResourceType.LISTS,
+        record_id: testListId,
+      })) as any;
+
+      // Verify essential metadata
+      expect(details).toHaveProperty('id');
+      expect(details).toHaveProperty('name');
+      expect(details).toHaveProperty('api_slug');
+      expect(details).toHaveProperty('workspace_id');
+
+      // Note: attributes field may not be returned by the basic list details API
+      // If attributes are needed, use a separate get-attributes call
+    });
+
+    it('should handle invalid list ID gracefully', async () => {
+      const invalidId = '00000000-0000-0000-0000-000000000000';
+
+      // Should throw error for non-existent list
+      await expect(
+        UniversalMetadataService.getRecordDetails({
+          resource_type: UniversalResourceType.LISTS,
+          record_id: invalidId,
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('Data format consistency', () => {
+    it('should return consistent data structures across old and new tools', async () => {
+      // Get data from both sources
+      const listsOld = await getLists();
+      const listsNew = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '',
+        limit: 100,
+      });
+
+      if (listsOld.length > 0 && listsNew.length > 0) {
+        const oldList = listsOld[0] as any;
+        const newList = listsNew.find(
+          (l: any) => l.id?.list_id === oldList.id?.list_id
+        ) as any;
+
+        if (newList) {
+          // Check that both have the same keys
+          const oldKeys = Object.keys(oldList).sort();
+          const newKeys = Object.keys(newList).sort();
+
+          // Core keys should be present in both
+          const coreKeys = ['id', 'name', 'api_slug', 'workspace_id'];
+          for (const key of coreKeys) {
+            expect(oldKeys).toContain(key);
+            expect(newKeys).toContain(key);
+          }
+
+          // Values should match for core fields
+          expect(oldList.id?.list_id).toBe(newList.id?.list_id);
+          expect(oldList.name).toBe(newList.name);
+          expect(oldList.api_slug).toBe(newList.api_slug);
+        }
+      }
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle empty query gracefully', async () => {
+      const lists = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '',
+        limit: 10,
+      });
+
+      // Should return array (even if empty)
+      expect(Array.isArray(lists)).toBe(true);
+    });
+
+    it('should handle pagination edge cases', async () => {
+      // Offset beyond available records
+      const lists = await UniversalSearchService.searchRecords({
+        resource_type: UniversalResourceType.LISTS,
+        query: '',
+        limit: 10,
+        offset: 10000,
+      });
+
+      // Should return empty array
+      expect(Array.isArray(lists)).toBe(true);
+      expect(lists.length).toBe(0);
+    });
+
+    it('should handle invalid resource type gracefully', async () => {
+      // Invalid/non-existent resource types are treated as custom object slugs
+      // and should return empty array rather than throwing an error
+      const lists = await UniversalSearchService.searchRecords({
+        resource_type: 'invalid_type' as any,
+        query: '',
+        limit: 10,
+      });
+
+      // Should return empty array for non-existent custom objects
+      expect(Array.isArray(lists)).toBe(true);
+      expect(lists.length).toBe(0);
+    });
+  });
+});

--- a/test/objects/lists-shared.test.ts
+++ b/test/objects/lists-shared.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for list shared utilities
+ * Tests for ensureListShape() workspace_id extraction
+ * Issue #1068 - Fix universal tools list format
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ensureListShape } from '@src/objects/lists/shared.js';
+
+describe('ensureListShape - workspace_id extraction', () => {
+  it('should extract workspace_id from nested id object', () => {
+    const raw = {
+      id: { list_id: 'list-123', workspace_id: 'ws-456' },
+      name: 'Test List',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    expect(result.workspace_id).toBe('ws-456');
+    expect(result.id.list_id).toBe('list-123');
+    expect(result.name).toBe('Test List');
+  });
+
+  it('should prioritize top-level workspace_id over nested', () => {
+    const raw = {
+      id: { list_id: 'list-123', workspace_id: 'ws-nested' },
+      workspace_id: 'ws-toplevel',
+      name: 'Test List',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    // Top-level should take precedence
+    expect(result.workspace_id).toBe('ws-toplevel');
+    expect(result.id.list_id).toBe('list-123');
+  });
+
+  it('should handle missing workspace_id gracefully', () => {
+    const raw = {
+      id: { list_id: 'list-123' },
+      name: 'Test List',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    // workspace_id defaults to empty string when not present
+    expect(result.workspace_id).toBe('');
+    expect(result.id.list_id).toBe('list-123');
+  });
+
+  it('should handle empty string workspace_id from nested id', () => {
+    const raw = {
+      id: { list_id: 'list-123', workspace_id: '' },
+      name: 'Test List',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    // Empty string workspace_id should not be overridden
+    expect(result.workspace_id).toBe('');
+    expect(result.id.list_id).toBe('list-123');
+  });
+
+  it('should extract workspace_id even when other id fields are present', () => {
+    const raw = {
+      id: {
+        list_id: 'list-123',
+        workspace_id: 'ws-789',
+        object_id: 'obj-456',
+        some_other_field: 'value',
+      },
+      name: 'Test List',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    expect(result.workspace_id).toBe('ws-789');
+    expect(result.id.list_id).toBe('list-123');
+  });
+
+  it('should preserve all list fields while extracting workspace_id', () => {
+    const raw = {
+      id: { list_id: 'list-123', workspace_id: 'ws-456' },
+      name: 'Test List',
+      title: 'Test List Title',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+      description: 'A test list',
+      entry_count: 42,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+      custom_field: 'custom_value',
+    };
+
+    const result = ensureListShape(raw);
+
+    // All fields should be preserved
+    expect(result.workspace_id).toBe('ws-456');
+    expect(result.name).toBe('Test List');
+    expect(result.title).toBe('Test List Title');
+    expect(result.api_slug).toBe('test-list');
+    expect(result.object_slug).toBe('companies');
+    expect(result.description).toBe('A test list');
+    expect(result.entry_count).toBe(42);
+    expect(result.created_at).toBe('2024-01-01T00:00:00Z');
+    expect(result.updated_at).toBe('2024-01-02T00:00:00Z');
+    expect((result as Record<string, unknown>).custom_field).toBe(
+      'custom_value'
+    );
+  });
+
+  it('should handle null workspace_id from nested id', () => {
+    const raw = {
+      id: { list_id: 'list-123', workspace_id: null },
+      name: 'Test List',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    // null workspace_id defaults to empty string (due to || '' fallback)
+    expect(result.workspace_id).toBe('');
+    expect(result.id.list_id).toBe('list-123');
+  });
+});
+
+describe('ensureListShape - general functionality', () => {
+  it('should ensure name field is set from title when name is missing', () => {
+    const raw = {
+      id: { list_id: 'list-123' },
+      title: 'Test List Title',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    // name should be set from title
+    expect(result.name).toBe('Test List Title');
+    expect(result.title).toBe('Test List Title');
+  });
+
+  it('should preserve name when both name and title are present', () => {
+    const raw = {
+      id: { list_id: 'list-123' },
+      name: 'Custom Name',
+      title: 'Different Title',
+      api_slug: 'test-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    // Both should be preserved
+    expect(result.name).toBe('Custom Name');
+    expect(result.title).toBe('Different Title');
+  });
+
+  it('should handle list with minimal required fields', () => {
+    const raw = {
+      id: { list_id: 'list-min' },
+      name: 'Minimal List',
+      api_slug: 'minimal-list',
+      object_slug: 'companies',
+    };
+
+    const result = ensureListShape(raw);
+
+    expect(result.id.list_id).toBe('list-min');
+    expect(result.name).toBe('Minimal List');
+    expect(result.api_slug).toBe('minimal-list');
+    expect(result.object_slug).toBe('companies');
+  });
+});

--- a/test/services/UniversalRetrievalService-core-operations.test.ts
+++ b/test/services/UniversalRetrievalService-core-operations.test.ts
@@ -56,7 +56,7 @@ vi.mock('../../src/objects/companies/index.js', () => ({
 vi.mock('../../src/objects/people/index.js', () => ({
   getPersonDetails: vi.fn(),
 }));
-vi.mock('../../src/objects/lists.js', () => ({ getListDetails: vi.fn() }));
+vi.mock('@/objects/lists.js', () => ({ getListDetails: vi.fn() }));
 vi.mock('../../src/objects/records/index.js', () => ({
   getObjectRecord: vi.fn(),
 }));
@@ -74,7 +74,7 @@ import { CachingService } from '../../src/services/CachingService.js';
 import { UniversalUtilityService } from '../../src/services/UniversalUtilityService.js';
 import { getCompanyDetails } from '../../src/objects/companies/index.js';
 import { getPersonDetails } from '../../src/objects/people/index.js';
-import * as lists from '../../src/objects/lists.js';
+import * as lists from '@/objects/lists.js';
 import { getObjectRecord } from '../../src/objects/records/index.js';
 import * as tasks from '../../src/objects/tasks.js';
 import { shouldUseMockData } from '../../src/services/create/index.js';
@@ -143,20 +143,20 @@ describe('UniversalRetrievalService', () => {
       });
 
       expect(lists.getListDetails).toHaveBeenCalledWith('list_789');
+      // Issue #1068: Lists returned in list-native format (no values wrapper, no record_id)
       expect(result).toEqual({
         id: {
-          record_id: 'list_789',
           list_id: 'list_789',
         },
-        values: {
-          name: 'Test List',
-          description: 'Test description',
-          parent_object: 'companies',
-          api_slug: 'test-list',
-          workspace_id: 'ws_123',
-          workspace_member_access: 'read',
-          created_at: '2024-01-01T00:00:00Z',
-        },
+        name: 'Test List',
+        title: 'Test List',
+        description: 'Test description',
+        object_slug: 'companies',
+        api_slug: 'test-list',
+        workspace_id: 'ws_123',
+        workspace_member_access: 'read',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
       });
     });
 

--- a/test/services/UniversalRetrievalService-validation.test.ts
+++ b/test/services/UniversalRetrievalService-validation.test.ts
@@ -64,7 +64,7 @@ vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
 vi.mock('../../src/objects/companies/index.js', () => ({
   getCompanyDetails: vi.fn(),
 }));
-vi.mock('../../src/objects/lists.js', () => ({ getListDetails: vi.fn() }));
+vi.mock('@/objects/lists.js', () => ({ getListDetails: vi.fn() }));
 vi.mock('../../src/objects/tasks.js', () => ({ getTask: vi.fn() }));
 vi.mock('../../src/objects/notes.js', () => ({ getNote: vi.fn() }));
 import { UniversalRetrievalService } from '../../src/services/UniversalRetrievalService.js';
@@ -76,7 +76,7 @@ import { createRecordNotFoundError } from '../../src/utils/validation/uuid-valid
 import { enhancedPerformanceTracker } from '../../src/middleware/performance-enhanced.js';
 import { getCompanyDetails } from '../../src/objects/companies/index.js';
 import * as tasks from '../../src/objects/tasks.js';
-import * as lists from '../../src/objects/lists.js';
+import * as lists from '@/objects/lists.js';
 import * as companies from '../../src/objects/companies/index.js';
 import * as notes from '../../src/objects/notes.js';
 

--- a/test/services/UniversalSearchService-companies-people-lists.test.ts
+++ b/test/services/UniversalSearchService-companies-people-lists.test.ts
@@ -133,9 +133,12 @@ describe('UniversalSearchService', () => {
 
       expect(searchLists).toHaveBeenCalledWith('Prospects', 10, 0);
       expect(result).toHaveLength(1);
+      // Fix for #1068: Lists now returned in proper format (not wrapped in values)
       expect(result[0]).toMatchObject({
-        id: { record_id: 'list_1', list_id: 'list_1' },
-        values: { name: 'Prospects' },
+        id: { list_id: 'list_1' },
+        name: 'Prospects',
+        title: 'Prospects',
+        description: 'Prospect list',
       });
     });
   });

--- a/test/services/content-search.test.ts
+++ b/test/services/content-search.test.ts
@@ -688,7 +688,8 @@ describe('Content Search Functionality', () => {
 
       expect(searchLists).toHaveBeenCalledWith('', 100, 0);
       expect(result).toHaveLength(1);
-      expect(result[0].values?.name).toContain('Customer');
+      // Fix for #1068: Lists now have fields at top level (not in values)
+      expect((result[0] as any).name).toContain('Customer');
     });
 
     it('should search across custom list fields', async () => {
@@ -714,7 +715,8 @@ describe('Content Search Functionality', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0].values?.description).toContain('Important test data');
+      // Fix for #1068: Lists now have fields at top level (not in values)
+      expect((result[0] as any).description).toContain('Important test data');
     });
 
     it('should handle exact match for lists', async () => {
@@ -747,7 +749,8 @@ describe('Content Search Functionality', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0].values?.name).toBe('test');
+      // Fix for #1068: Lists now have fields at top level (not in values)
+      expect((result[0] as any).name).toBe('test');
     });
 
     it('should apply relevance ranking for lists', async () => {
@@ -806,7 +809,8 @@ describe('Content Search Functionality', () => {
       });
 
       expect(result).toHaveLength(5);
-      expect(result[0].values?.name).toBe('Customer List 1');
+      // Fix for #1068: Lists now have fields at top level (not in values)
+      expect((result[0] as any).name).toBe('Customer List 1');
     });
   });
 });

--- a/test/services/search-strategies/ListSearchStrategy.test.ts
+++ b/test/services/search-strategies/ListSearchStrategy.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for ListSearchStrategy workspace_id prioritization
+ * Issue #1068 - Fix universal tools list format
+ * Addresses critical review feedback on operator semantics
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ListSearchStrategy } from '@/services/search-strategies/ListSearchStrategy.js';
+import { AttioList } from '@/types/attio.js';
+
+describe('ListSearchStrategy - workspace_id prioritization', () => {
+  let strategy: ListSearchStrategy;
+
+  beforeEach(() => {
+    // Create strategy with minimal dependencies for unit testing
+    strategy = new ListSearchStrategy({
+      listFunction: vi.fn(),
+    });
+  });
+
+  describe('convertListsToRecords - workspace_id extraction', () => {
+    it('should prioritize top-level workspace_id over nested when both exist', () => {
+      const mockLists: AttioList[] = [
+        {
+          id: {
+            list_id: 'list-123',
+            workspace_id: 'ws-nested',
+          },
+          workspace_id: 'ws-toplevel',
+          name: 'Test List',
+          title: 'Test List',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      // Access private method via type assertion for testing
+      const result = (strategy as any).convertListsToRecords(mockLists);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].workspace_id).toBe('ws-toplevel');
+      expect(result[0].id.list_id).toBe('list-123');
+    });
+
+    it('should preserve empty string workspace_id when top-level is empty string', () => {
+      const mockLists: AttioList[] = [
+        {
+          id: {
+            list_id: 'list-123',
+            workspace_id: 'ws-nested',
+          },
+          workspace_id: '', // Empty string should be preserved
+          name: 'Test List',
+          title: 'Test List',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      const result = (strategy as any).convertListsToRecords(mockLists);
+
+      expect(result).toHaveLength(1);
+      // Empty string should be preserved, NOT overwritten by nested value
+      expect(result[0].workspace_id).toBe('');
+      expect(result[0].id.list_id).toBe('list-123');
+    });
+
+    it('should fall back to nested workspace_id when top-level is null', () => {
+      const mockLists: AttioList[] = [
+        {
+          id: {
+            list_id: 'list-123',
+            workspace_id: 'ws-nested',
+          },
+          workspace_id: null as any, // null should trigger fallback
+          name: 'Test List',
+          title: 'Test List',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      const result = (strategy as any).convertListsToRecords(mockLists);
+
+      expect(result).toHaveLength(1);
+      // null should fall back to nested value
+      expect(result[0].workspace_id).toBe('ws-nested');
+      expect(result[0].id.list_id).toBe('list-123');
+    });
+
+    it('should fall back to nested workspace_id when top-level is undefined', () => {
+      const mockLists: AttioList[] = [
+        {
+          id: {
+            list_id: 'list-123',
+            workspace_id: 'ws-nested',
+          },
+          // workspace_id is undefined (not present)
+          name: 'Test List',
+          title: 'Test List',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      const result = (strategy as any).convertListsToRecords(mockLists);
+
+      expect(result).toHaveLength(1);
+      // undefined should fall back to nested value
+      expect(result[0].workspace_id).toBe('ws-nested');
+      expect(result[0].id.list_id).toBe('list-123');
+    });
+
+    it('should handle missing workspace_id in both locations', () => {
+      const mockLists: AttioList[] = [
+        {
+          id: {
+            list_id: 'list-123',
+            // No workspace_id in id
+          },
+          // No top-level workspace_id
+          name: 'Test List',
+          title: 'Test List',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      const result = (strategy as any).convertListsToRecords(mockLists);
+
+      expect(result).toHaveLength(1);
+      // When both are undefined, workspace_id should not be set
+      expect(result[0].workspace_id).toBeUndefined();
+      expect(result[0].id.list_id).toBe('list-123');
+    });
+
+    it('should preserve all other list fields during transformation', () => {
+      const mockLists: AttioList[] = [
+        {
+          id: {
+            list_id: 'list-123',
+            workspace_id: 'ws-nested',
+          },
+          workspace_id: 'ws-toplevel',
+          name: 'Test List',
+          title: 'Test List Title',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          description: 'Test description',
+          entry_count: 42,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          custom_field: 'custom_value',
+        },
+      ];
+
+      const result = (strategy as any).convertListsToRecords(mockLists);
+
+      expect(result).toHaveLength(1);
+      const list = result[0];
+
+      // Verify all fields are preserved
+      expect(list.workspace_id).toBe('ws-toplevel');
+      expect(list.name).toBe('Test List');
+      expect(list.title).toBe('Test List Title');
+      expect(list.api_slug).toBe('test-list');
+      expect(list.object_slug).toBe('companies');
+      expect(list.description).toBe('Test description');
+      expect(list.entry_count).toBe(42);
+      expect(list.created_at).toBe('2024-01-01T00:00:00Z');
+      expect(list.updated_at).toBe('2024-01-02T00:00:00Z');
+      expect((list as any).custom_field).toBe('custom_value');
+    });
+
+    it('should use name field with fallback to title', () => {
+      const mockListsWithName: AttioList[] = [
+        {
+          id: { list_id: 'list-1' },
+          name: 'Custom Name',
+          title: 'Different Title',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      const mockListsWithoutName: AttioList[] = [
+        {
+          id: { list_id: 'list-2' },
+          title: 'Title Only',
+          api_slug: 'test-list',
+          object_slug: 'companies',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      const resultWithName = (strategy as any).convertListsToRecords(
+        mockListsWithName
+      );
+      const resultWithoutName = (strategy as any).convertListsToRecords(
+        mockListsWithoutName
+      );
+
+      // When name exists, use it
+      expect(resultWithName[0].name).toBe('Custom Name');
+
+      // When name is undefined, fall back to title
+      expect(resultWithoutName[0].name).toBe('Title Only');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1068 - Universal tools (`search_records`, `get_record_details`) now return lists in the same format as list-specific tools (`get-lists`, `get-list-details`), with fields at the top level instead of wrapped in a `values` object.

## Changes

### Core Fixes
- Modified `ListSearchStrategy.convertListsToRecords()` to preserve list format without wrapping fields
- Added `UniversalMetadataService.getRecordDetails()` method for lists support  
- Updated `ensureListShape()` to extract `workspace_id` from `id.workspace_id` to top level
- Fixed `getLists()` and `getListDetails()` to always normalize list shapes via `ensureListShape()`
- Fixed `ListSearchStrategy` to respect offset parameter for pagination (was hardcoded to 0)

### Search Utilities Updates
- Updated `SearchUtilities.getListFieldValue()` to check top-level fields first (new format), then fall back to `values` wrapper (old format)
- Updated `SearchUtilities.getFieldValue()` to check top-level fields first for lists compatibility

### Test Updates
- Added comprehensive integration tests (12 tests, all passing)
- Updated unit tests to expect unwrapped list format
- All offline tests passing (3182 passed)

## Testing
- ✅ Integration tests: 12/12 passing
- ✅ Offline tests: 3182 passed  
- ✅ No breaking changes to other resource types

## Related Issues
- Part of #1059 (List tools consolidation - 11 → 4 tools)
- Blocks #1069, #1070, #1071 (subsequent PRs)

Fixes #1068