### PR TITLE
Test: Add E2E tests for manage-list-entry (TC-010) #1059

### DIFF
--- a/test/e2e/mcp/list-management/manage-list-entry-errors.mcp.test.ts
+++ b/test/e2e/mcp/list-management/manage-list-entry-errors.mcp.test.ts
@@ -53,7 +53,15 @@ class ManageListEntryErrorTest extends MCPTestBase {
       const lists = JSON.parse(listsText);
 
       if (Array.isArray(lists) && lists.length > 0) {
-        this.testListId = lists[0].id?.list_id || lists[0].api_slug;
+        // Prefer lists that support companies (parent_object check)
+        const companyList = lists.find(
+          (l: Record<string, unknown>) =>
+            l.parent_object === 'companies' || !l.parent_object
+        );
+        const selectedList = companyList || lists[0];
+        this.testListId =
+          (selectedList.id as Record<string, string>)?.list_id ||
+          (selectedList.api_slug as string);
       }
     } catch (error) {
       console.error('Failed to setup error test data:', error);

--- a/test/e2e/mcp/list-management/manage-list-entry.mcp.test.ts
+++ b/test/e2e/mcp/list-management/manage-list-entry.mcp.test.ts
@@ -63,8 +63,18 @@ class ManageListEntryTest extends MCPTestBase {
       const lists = JSON.parse(listsText);
 
       if (Array.isArray(lists) && lists.length > 0) {
-        this.testListId = lists[0].id?.list_id || lists[0].api_slug;
-        console.log(`Using existing list: ${this.testListId}`);
+        // Prefer lists that support companies (parent_object check)
+        const companyList = lists.find(
+          (l: Record<string, unknown>) =>
+            l.parent_object === 'companies' || !l.parent_object
+        );
+        const selectedList = companyList || lists[0];
+        this.testListId =
+          (selectedList.id as Record<string, string>)?.list_id ||
+          (selectedList.api_slug as string);
+        console.log(
+          `Using list: ${this.testListId} (parent: ${selectedList.parent_object || 'any'})`
+        );
       }
     } catch (error) {
       console.error('Failed to setup test data:', error);

--- a/test/e2e/mcp/shared/list-entry-helpers.ts
+++ b/test/e2e/mcp/shared/list-entry-helpers.ts
@@ -126,12 +126,11 @@ export function isRemoveSuccess(result: CallToolResult): boolean {
     return true;
   }
 
-  // Try JSON parsing for structured success response
+  // Try JSON parsing for explicit success field only
   try {
     const jsonData = JSON.parse(text);
     if (jsonData.success === true) return true;
-    // Entry data returned (has id field) indicates success
-    if (jsonData.id && !isErrorResponse(result)) return true;
+    // NOTE: Do NOT accept arbitrary JSON with id field - error payloads can have ids
   } catch {
     // Not valid JSON
   }


### PR DESCRIPTION
## Summary
Adds comprehensive E2E test coverage for the consolidated `manage-list-entry` tool (TC-010) with 10 test cases covering all 3 operation modes.

This addresses the E2E coverage gap identified after completing Epic #1059 (List Tools Consolidation).

## Test Cases (10 total, 100% pass rate)

### Happy Path (5 tests)
- **Mode 1 (Add)**: Add record to list with `recordId` + `objectType`
- **Mode 1 (Add)**: Add record with `initialValues`
- **Mode 2 (Remove)**: Remove entry from list
- **Mode 3 (Update)**: Update entry attributes
- **Full Lifecycle**: Complete add → update → remove cycle

### Error Handling (5 tests)
- No mode detected (only `listId` provided)
- Multiple modes detected (conflicting parameters)
- Invalid listId (non-existent UUID)
- Mode 1 missing `objectType`
- Mode 3 invalid `attributes` (string instead of object)

## Features
- ✅ Auto-cleanup of test entries and companies (workspace hygiene)
- ✅ P1 quality gate compliance (80%+ pass rate achieved: **100%**)
- ✅ Follows TC-007 (list-membership) patterns
- ✅ Entry tracking for reliable cleanup

## Test Plan
- [x] All 10 test cases implemented
- [x] Tests pass with real Attio API
- [x] 100% pass rate (exceeds P1 80% threshold)
- [x] Follows existing patterns from TC-007
- [x] No deprecated tool usage (`add-record-to-list`, etc.)
- [x] Pre-push validation passes (3279 tests)

## Related Issues
- Epic: #1059 (List Tools Consolidation)
- PR: #1076 (Entry Management consolidation)
- PR: #1077 (Deprecation warnings)