### PR TITLE
fix: bump response maxStringLength from 40KB to 500KB for bulk search results

### DIFF
--- a/src/utils/json-serializer.ts
+++ b/src/utils/json-serializer.ts
@@ -365,7 +365,7 @@ export function sanitizeMcpResponse(response: unknown): unknown {
   try {
     // Create safe copy with MCP-specific options optimized for Attio responses
     return createSafeCopy(response, {
-      maxStringLength: 40000, // 40KB for response content - reasonable limit
+      maxStringLength: 500000, // 500KB for response content - needed for bulk search results
       includeStackTraces: false,
     });
   } catch (error: unknown) {


### PR DESCRIPTION
## Problem

The JSON serializer in `src/utils/json-serializer.ts` truncates response strings at 40,000 characters (`maxStringLength: 40000`). This breaks bulk search/filter operations that return large result sets — for example, filtering 27+ deal records from Attio returns truncated JSON that can't be parsed.

## Fix

Bump `maxStringLength` from 40,000 to 500,000 in the `createBigIntReplacer` function. This allows the MCP server to return complete JSON responses for large filter/search operations without truncation.

## Testing

Verified with a real Attio filter query returning 27 deal records — response is now complete and parseable.

## Impact

One-line change in `src/utils/json-serializer.ts`. No API or behavior changes beyond allowing larger responses.