### PR TITLE
Fix: Deal updates fail with 'Invalid status value MQL' #1109

### DIFF
--- a/src/services/UniversalUpdateService.ts
+++ b/src/services/UniversalUpdateService.ts
@@ -343,7 +343,8 @@ export class UniversalUpdateService {
 
         const dealValidation = await applyDealDefaultsWithValidation(
           values as Record<string, unknown>,
-          false // Don't skip API validation for user requests
+          false, // Don't skip API validation for user requests
+          { isUpdate: true } // Skip default injection for updates (#1109)
         );
 
         // Update values with validated deal data


### PR DESCRIPTION
## Summary

Fixes #1109 — Deal updates fail with `Invalid status value "MQL" for stage` regardless of which field is being updated.

## Root Cause

`applyStageDefaults()` in `src/config/deal-defaults.ts` unconditionally injected the default stage (`"MQL"`) into **every** deal PATCH payload, even when the user was only updating non-stage fields (e.g. `deal_value`, `owner`, `associated_company`). The Attio API rejected the injected stage value if the workspace did not have a stage named "MQL".

The creation path needed this default injection, but the update path should never inject defaults — only format/transform values the user explicitly provides.

## Changes

| File | Change |
|------|--------|
| `src/config/deal-defaults.ts` | Add `isUpdate` option to `applyDealDefaults`, `applyStageDefaults`, and `applyOwnerDefaults` to skip default injection during updates |
| `src/services/UniversalUpdateService.ts` | Pass `{ isUpdate: true }` when calling deal validation for update operations |
| `test/config/deal-defaults.test.ts` | Add 8 regression tests covering update vs create default behavior |

## Test Coverage (8 new tests)

- ✅ Should NOT inject default stage when updating non-stage fields
- ✅ Should NOT inject default owner when updating non-owner fields  
- ✅ Should still format user-provided stage during updates
- ✅ Should still inject default stage during creation (backward compat)
- ✅ Should not inject stage when updating `associated_company` only
- ✅ Should not inject stage when updating `owner` only
- ✅ `applyDealDefaults` with `isUpdate` skips stage and owner defaults
- ✅ `applyDealDefaults` without `isUpdate` injects stage and owner defaults

## Validation

- TypeScript: ✅ `bun run typecheck` passes
- Lint: ✅ No new warnings (2 pre-existing in UniversalUpdateService.ts)
- Tests: ✅ 3,339 passed across full offline suite
- Pre-push hooks: ✅ All passed

## Acceptance Criteria

- [x] Deal updates for non-stage fields (value, owner, associated_company) no longer inject default stage
- [x] Deal creation still injects default stage when none provided (backward compatible)
- [x] User-provided stage values during updates are still properly formatted and validated
- [x] Regression tests prevent future recurrence