### PR TITLE
Fix: linked_records not passed when creating tasks #1098

### DIFF
--- a/src/services/create/creators/task-creator.ts
+++ b/src/services/create/creators/task-creator.ts
@@ -162,7 +162,7 @@ export class TaskCreator extends BaseCreator {
    */
   protected async attemptRecovery(
     context: ResourceCreatorContext,
-     
+
     _normalizedInput?: JsonObject
   ): Promise<AttioRecord> {
     // Tasks are handled via delegation, so no direct recovery needed

--- a/src/services/create/creators/task-creator.ts
+++ b/src/services/create/creators/task-creator.ts
@@ -51,6 +51,7 @@ export class TaskCreator extends BaseCreator {
       dueDate: input.dueDate,
       recordId: input.recordId,
       targetObject: input.targetObject,
+      linked_records: input.linked_records,
     } as JsonObject);
 
     if (typeof input.content !== 'string' || input.content.trim() === '') {
@@ -84,6 +85,12 @@ export class TaskCreator extends BaseCreator {
       }
       if (input.targetObject && input.targetObject !== 'undefined') {
         options.targetObject = input.targetObject as string;
+      }
+      if (
+        Array.isArray(input.linked_records) &&
+        input.linked_records.length > 0
+      ) {
+        options.linked_records = input.linked_records;
       }
 
       const createTaskFn = (this.taskModule as JsonObject).createTask as (
@@ -155,7 +162,7 @@ export class TaskCreator extends BaseCreator {
    */
   protected async attemptRecovery(
     context: ResourceCreatorContext,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     _normalizedInput?: JsonObject
   ): Promise<AttioRecord> {
     // Tasks are handled via delegation, so no direct recovery needed

--- a/test/unit/services/create/TaskCreateStrategy.test.ts
+++ b/test/unit/services/create/TaskCreateStrategy.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for TaskCreateStrategy - Issue #1098 regression coverage
+ * Verifies linked_records flows through the strategy layer correctly
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TaskCreateStrategy } from '../../../../src/services/create/strategies/TaskCreateStrategy.js';
+
+// Mock the create service to capture what TaskCreateStrategy passes downstream
+const mockCreateTask = vi.fn();
+vi.mock('../../../../src/services/create/index.js', () => ({
+  getCreateService: () => ({
+    createTask: mockCreateTask,
+  }),
+}));
+
+describe('TaskCreateStrategy - Issue #1098: linked_records forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateTask.mockResolvedValue({
+      id: { task_id: 'mock-task-id' },
+      resource_type: 'tasks',
+      values: {},
+    });
+  });
+
+  it('forwards linked_records array with target_object/target_record_id format', async () => {
+    const strategy = new TaskCreateStrategy();
+
+    await strategy.create({
+      resourceType: 'tasks' as any,
+      values: {
+        content: 'Test task with linked record',
+        linked_records: [
+          {
+            target_object: 'people',
+            target_record_id: 'person-uuid-123',
+          },
+        ],
+      },
+    });
+
+    expect(mockCreateTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Test task with linked record',
+        linked_records: [
+          {
+            target_object: 'people',
+            target_record_id: 'person-uuid-123',
+          },
+        ],
+      })
+    );
+    // Should NOT have recordId when using linked_records format
+    const call = mockCreateTask.mock.calls[0][0];
+    expect(call.recordId).toBeUndefined();
+  });
+
+  it('forwards multiple linked_records', async () => {
+    const strategy = new TaskCreateStrategy();
+
+    await strategy.create({
+      resourceType: 'tasks' as any,
+      values: {
+        content: 'Task with multiple links',
+        linked_records: [
+          { target_object: 'people', target_record_id: 'person-1' },
+          { target_object: 'companies', target_record_id: 'company-1' },
+        ],
+      },
+    });
+
+    const call = mockCreateTask.mock.calls[0][0];
+    expect(call.linked_records).toEqual([
+      { target_object: 'people', target_record_id: 'person-1' },
+      { target_object: 'companies', target_record_id: 'company-1' },
+    ]);
+  });
+
+  it('falls back to recordId for legacy record_id format', async () => {
+    const strategy = new TaskCreateStrategy();
+
+    await strategy.create({
+      resourceType: 'tasks' as any,
+      values: {
+        content: 'Legacy linked task',
+        linked_records: [{ record_id: 'legacy-record-id' }],
+      },
+    });
+
+    const call = mockCreateTask.mock.calls[0][0];
+    expect(call.recordId).toBe('legacy-record-id');
+    expect(call.linked_records).toBeUndefined();
+  });
+
+  it('falls back to recordId for string array format', async () => {
+    const strategy = new TaskCreateStrategy();
+
+    await strategy.create({
+      resourceType: 'tasks' as any,
+      values: {
+        content: 'String linked task',
+        linked_records: ['string-record-id'],
+      },
+    });
+
+    const call = mockCreateTask.mock.calls[0][0];
+    expect(call.recordId).toBe('string-record-id');
+    expect(call.linked_records).toBeUndefined();
+  });
+
+  it('does not inject linked_records when not provided', async () => {
+    const strategy = new TaskCreateStrategy();
+
+    await strategy.create({
+      resourceType: 'tasks' as any,
+      values: {
+        content: 'Task without links',
+      },
+    });
+
+    const call = mockCreateTask.mock.calls[0][0];
+    expect(call.linked_records).toBeUndefined();
+    expect(call.recordId).toBeUndefined();
+  });
+
+  it('uses record_id field when linked_records not provided', async () => {
+    const strategy = new TaskCreateStrategy();
+
+    await strategy.create({
+      resourceType: 'tasks' as any,
+      values: {
+        content: 'Task with record_id',
+        record_id: 'direct-record-id',
+      },
+    });
+
+    const call = mockCreateTask.mock.calls[0][0];
+    expect(call.recordId).toBe('direct-record-id');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1098 — Tasks created via `create_record` silently drop `linked_records`, resulting in tasks with empty linked records despite the user providing valid `{target_object, target_record_id}` data.

## Root Cause

Two layers were stripping `linked_records` before it reached the API:

1. **`TaskCreateStrategy`** (field mapper) decomposed `linked_records` into a single `recordId` but only checked for `record_id` and `id` fields — **missing `target_record_id`** which is the Attio API format users provide. It also dropped `target_object` from individual records.

2. **`TaskCreator`** (service layer) built the options object forwarding `recordId` and `targetObject` but never forwarded `linked_records` as an array, even though the downstream API function (`createTask` in `src/api/operations/tasks.ts`) already supports the full `linked_records` array format.

## Fix

| File | Change |
|------|--------|
| `src/services/create/strategies/TaskCreateStrategy.ts` | Detect Attio API format (`{target_object, target_record_id}`) and forward entire `linked_records` array instead of decomposing to single `recordId`. Add `target_record_id` as fallback in legacy extraction. |
| `src/services/create/creators/task-creator.ts` | Forward `linked_records` array from input to options. Add debug logging for `linked_records`. |

## Test Coverage (9 new tests)

### API-level (`test/unit/api/tasks.create.validation.test.ts`)
- ✅ Forwards `linked_records` array in Attio API format
- ✅ Forwards multiple `linked_records`
- ✅ Skips `recordId`/`targetObject` validation when `linked_records` provided

### Strategy-level (`test/unit/services/create/TaskCreateStrategy.test.ts`) — NEW FILE
- ✅ Forwards `linked_records` with `target_object`/`target_record_id` format
- ✅ Forwards multiple `linked_records`
- ✅ Falls back to `recordId` for legacy `record_id` format
- ✅ Falls back to `recordId` for string array format
- ✅ Does not inject `linked_records` when not provided
- ✅ Uses `record_id` field when `linked_records` not provided

## Validation

- TypeScript: ✅ `bun run typecheck` passes
- Lint: ✅ No new warnings
- Tests: ✅ 3,350 passed across full offline suite
- Pre-push hooks: ✅ All passed

## Backward Compatibility

- Legacy `record_id` field still works
- Legacy `linked_records` with `{record_id}` or `{id}` format still extracts `recordId`
- String arrays in `linked_records` still extract first item as `recordId`
- Only `{target_object, target_record_id}` format triggers the new forwarding path