### PR TITLE
Fix: PR #1113 follow-up - tighten linked_records validation

### DIFF
--- a/src/services/create/creators/task-creator.ts
+++ b/src/services/create/creators/task-creator.ts
@@ -51,7 +51,9 @@ export class TaskCreator extends BaseCreator {
       dueDate: input.dueDate,
       recordId: input.recordId,
       targetObject: input.targetObject,
-      linked_records: input.linked_records,
+      linked_records_count: Array.isArray(input.linked_records)
+        ? input.linked_records.length
+        : 0,
     } as JsonObject);
 
     if (typeof input.content !== 'string' || input.content.trim() === '') {

--- a/src/services/create/strategies/TaskCreateStrategy.ts
+++ b/src/services/create/strategies/TaskCreateStrategy.ts
@@ -67,10 +67,12 @@ export class TaskCreateStrategy implements CreateStrategy<AttioRecord> {
       if (Array.isArray(lr)) {
         const first = lr[0] as unknown;
         // Detect Attio API format: { target_object, target_record_id }
+        // Require BOTH fields to be present to avoid sending invalid payloads
         if (
           first &&
           typeof first === 'object' &&
-          'target_record_id' in (first as Record<string, unknown>)
+          'target_record_id' in (first as Record<string, unknown>) &&
+          'target_object' in (first as Record<string, unknown>)
         ) {
           // Forward the entire array for multi-record linking support
           out.linked_records = lr;

--- a/test/unit/services/create/TaskCreateStrategy.test.ts
+++ b/test/unit/services/create/TaskCreateStrategy.test.ts
@@ -109,6 +109,23 @@ describe('TaskCreateStrategy - Issue #1098: linked_records forwarding', () => {
     expect(call.linked_records).toBeUndefined();
   });
 
+  it('falls back to recordId when only target_record_id provided (missing target_object)', async () => {
+    const strategy = new TaskCreateStrategy();
+
+    await strategy.create({
+      resourceType: 'tasks' as any,
+      values: {
+        content: 'Incomplete API format task',
+        linked_records: [{ target_record_id: 'person-uuid-456' }], // missing target_object
+      },
+    });
+
+    const call = mockCreateTask.mock.calls[0][0];
+    // Should extract as recordId since target_object is missing
+    expect(call.recordId).toBe('person-uuid-456');
+    expect(call.linked_records).toBeUndefined();
+  });
+
   it('does not inject linked_records when not provided', async () => {
     const strategy = new TaskCreateStrategy();
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1113 addressing review feedback.

## Changes

1. **Stricter format validation**: Now requires BOTH `target_object` AND `target_record_id` before treating as Attio API format. Prevents sending invalid payloads if `target_object` is missing.

2. **Reduced logging data volume**: TaskCreator now logs only `linked_records_count` instead of full `linked_records` array to avoid PII exposure and keep structured logs lean (per CLAUDE.md logging rules).

3. **New test**: Added regression test for edge case where only `target_record_id` is provided (missing `target_object`) — should fall back to legacy `recordId` extraction rather than forwarding as `linked_records`.

## Validation

- TypeScript: ✅ 
- Lint: ✅ 
- Tests: ✅ 3,351 passed (3376 total)
- Pre-push hooks: ✅ All passed