### PR TITLE
Fix: Ensure Build Verification status is always reported for branch protection

### DIFF
--- a/.github/workflows/smart-ci.yml
+++ b/.github/workflows/smart-ci.yml
@@ -308,6 +308,32 @@ jobs:
           chmod +x dist/cli/discover.js
           node dist/index.js --help || echo "CLI help test completed"
 
+  # Job 5b: Build Verification Status Reporter (always runs to satisfy branch protection)
+  build-verification-status:
+    name: Build Verification
+    runs-on: ubuntu-latest
+    needs: [change-analysis, build]
+    if: always()
+    steps:
+      - name: Report Build Verification Status
+        run: |
+          docs_only="${{ needs.change-analysis.outputs.docs-only }}"
+          build_result="${{ needs.build.result }}"
+
+          echo "Docs only: $docs_only"
+          echo "Build result: $build_result"
+
+          if [ "$docs_only" = "true" ]; then
+            echo "✅ Docs-only changes - Build Verification passed (skipped)"
+            exit 0
+          elif [ "$build_result" = "success" ]; then
+            echo "✅ Build Verification passed"
+            exit 0
+          else
+            echo "❌ Build Verification failed"
+            exit 1
+          fi
+
   # Job 6: Performance Tests (main branch only)
   performance:
     name: Performance Tests
@@ -353,7 +379,13 @@ jobs:
   smart-summary:
     name: Smart CI Summary
     runs-on: ubuntu-latest
-    needs: [change-analysis, lint-and-typecheck, smart-tests, build]
+    needs:
+      [
+        change-analysis,
+        lint-and-typecheck,
+        smart-tests,
+        build-verification-status,
+      ]
     if: always() && github.event_name == 'pull_request'
 
     steps:
@@ -389,7 +421,7 @@ jobs:
             const jobs = {
               'Lint & Type Check': '${{ needs.lint-and-typecheck.result }}',
               'Smart Tests': '${{ needs.smart-tests.result }}',
-              'Build Verification': '${{ needs.build.result || 'skipped' }}'
+              'Build Verification': '${{ needs.build-verification-status.result }}'
             };
 
             summary += '\n## 🔍 Job Results\n\n';


### PR DESCRIPTION
## Problem
The Smart CI skips the 'Build Verification' job for docs-only changes (e.g., changelog PRs), but the branch protection ruleset requires this status check to pass. This creates a blocker where trivial PRs cannot be merged without temporarily disabling the ruleset.

## Solution
Add a companion job 'build-verification-status' that:
1. Always runs (via `if: always()`)
2. Reports success when the actual build was skipped (docs-only changes)
3. Reports success when the actual build passed
4. Reports failure when the actual build failed

This satisfies the branch protection requirement while maintaining the efficiency of skipping unnecessary builds for documentation-only PRs.

## Changes
- Added `build-verification-status` job that depends on both `change-analysis` and `build`
- Updated `smart-summary` job to reference the new status reporter
- The job uses the same name 'Build Verification' so it satisfies the existing branch protection rule

## Testing
- For docs-only PRs: Build Verification will show ✅ (skipped intentionally)
- For code PRs: Build Verification will show ✅ (actual build passed) or ❌ (build failed)

Closes the issue where PR #1103 (daily changelog) could not be merged due to skipped Build Verification check.