### PR TITLE
Docs: tighten issue and PR hygiene guidance #1106

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,20 @@ RULE: Never mention hmk | WHEN: Creating issues/PRs/comments | DO: NEVER include
 RULE: Delete branch after merge | WHEN: PR merged | DO: Delete feature branch immediately via GitHub UI or `git push origin --delete branch-name` | ELSE: Repository clutter
 RULE: Update CHANGELOG before merge | WHEN: Merging any PR with user-facing changes | DO: Add entry to `[Unreleased]` section with category + issue ref `#123` | ELSE: Lost change history
 
+### Issue/PR Authoring Standard (Required)
+
+- Repo title override is intentional here:
+  - PR title: `Type: Description`
+  - Commit title: `Type: Description #issue-number`
+- Issue title defaults:
+  - Feature: `feat: <capability> (for <surface>)`
+  - Bug: `bug: <symptom> when <condition>`
+  - Tracking: `TODO: <cleanup> after <dependency>`
+- PR body required sections: `What`, `Why`, `Tests`, `AI Assistance`.
+- `What`: 3-6 concrete change bullets.
+- `Tests`: exact commands run (copy/pasteable).
+- `AI Assistance`: used/not used, testing level, prompt/session log link, and "I understand this code."
+
 ### ISSUE WORKFLOW [MANDATORY CHECKLIST]
 
 1. `git branch --show-current` - Verify location


### PR DESCRIPTION
## What
- Add a required Issue/PR authoring standard section to `CLAUDE.md`.
- Clarify repo-specific title overrides for PR and commit format.
- Define concise issue title defaults for feature, bug, and tracking issues.
- Require `What`, `Why`, `Tests`, and `AI Assistance` sections in PR bodies.
- Require exact test commands and explicit AI-assistance disclosure fields.

## Why
- Align contributions to a consistent, reviewer-friendly format.
- Reduce iteration churn by making testing and AI provenance explicit.

## Tests
- `rg "Issue/PR Authoring Standard \(Required\)" CLAUDE.md`
- `rg "PR body required sections" CLAUDE.md`

## AI Assistance
- AI-assisted: yes
- Testing level: lightly tested
- Prompt/session log: codex-cli local session (Feb 13, 2026)
- I understand what this code does: yes
