### PR TITLE
Fix: search translation regressions

### DIFF
--- a/src/handlers/tool-configs/universal/operations/advanced-search.ts
+++ b/src/handlers/tool-configs/universal/operations/advanced-search.ts
@@ -17,6 +17,7 @@ import { validateUniversalToolParams } from '@/handlers/tool-configs/universal/s
 import { formatResourceType } from '@/handlers/tool-configs/universal/shared-handlers.js';
 import { getPluralResourceType } from '@/handlers/tool-configs/universal/core/utils.js';
 import { ErrorService } from '@/services/ErrorService.js';
+import { normalizeFilterCondition } from '@/types/attio.js';
 
 /**
  * Universal advanced search tool
@@ -38,57 +39,10 @@ export const advancedSearchConfig: UniversalToolConfig<
 
       const { resource_type } = sanitizedParams;
 
-      // Advanced search uses Attio's non-$ operator dialect (equals, contains, gte/lte, is_not_empty, ...).
-      // Perform a light de-normalization: translate any $-prefixed operators to the expected strings
-      // and coerce is_not_empty value to true when omitted.
+      // Normalize public operator aliases before downstream validation so the
+      // tool schema, docs, and translation layer accept the same vocabulary.
       let filters = sanitizedParams.filters as Record<string, unknown>;
       try {
-        const deDollar = (cond: string): string => {
-          if (!cond) return cond;
-          if (cond.startsWith('$')) {
-            const raw = cond.slice(1);
-            switch (raw) {
-              case 'eq':
-                return 'equals';
-              case 'contains':
-                return 'contains';
-              case 'starts_with':
-                return 'starts_with';
-              case 'ends_with':
-                return 'ends_with';
-              case 'gt':
-                return 'gt';
-              case 'gte':
-                return 'gte';
-              case 'lt':
-                return 'lt';
-              case 'lte':
-                return 'lte';
-              case 'not_empty':
-                return 'is_not_empty';
-              case 'empty':
-                return 'is_empty';
-              default:
-                return raw; // fallback
-            }
-          }
-          // Also accept already-correct tokens and legacy typos
-          if (
-            cond === 'is_not_empty' ||
-            cond === 'is_empty' ||
-            cond === 'equals' ||
-            cond === 'contains' ||
-            cond === 'starts_with' ||
-            cond === 'ends_with' ||
-            cond === 'gt' ||
-            cond === 'gte' ||
-            cond === 'lt' ||
-            cond === 'lte'
-          )
-            return cond;
-          return cond;
-        };
-
         if (
           filters &&
           typeof filters === 'object' &&
@@ -105,11 +59,14 @@ export const advancedSearchConfig: UniversalToolConfig<
               if (!f || typeof f !== 'object') return f;
               const next = { ...f } as Record<string, unknown>;
               if (typeof next.condition === 'string') {
-                next.condition = deDollar(next.condition);
+                next.condition =
+                  normalizeFilterCondition(next.condition) ?? next.condition;
               }
               if (
                 (next.condition === 'is_not_empty' ||
-                  next.condition === 'is_empty') &&
+                  next.condition === 'is_empty' ||
+                  next.condition === 'is_set' ||
+                  next.condition === 'is_not_set') &&
                 (next.value == null || next.value === '')
               ) {
                 next.value = true;

--- a/src/handlers/tool-configs/universal/operations/timeframe-search.ts
+++ b/src/handlers/tool-configs/universal/operations/timeframe-search.ts
@@ -23,6 +23,36 @@ import { getPluralResourceType } from '@/handlers/tool-configs/universal/core/ut
 import { normalizeOperator } from '@/utils/AttioFilterOperators.js';
 import { mapFieldName } from '@/utils/AttioFieldMapper.js';
 
+function resolveTimeframeAttribute(
+  timeframeType?: TimeframeType,
+  dateField?: TimeframeSearchParams['date_field']
+): string {
+  if (dateField) {
+    switch (dateField) {
+      case 'created_at':
+        return mapFieldName('created_at');
+      case 'updated_at':
+      case 'modified_at':
+        return mapFieldName('modified_at');
+      case 'last_interaction':
+        return 'last_interaction';
+      default:
+        throw new Error(`Unsupported date_field: ${dateField}`);
+    }
+  }
+
+  switch (timeframeType || TimeframeType.MODIFIED) {
+    case TimeframeType.CREATED:
+      return mapFieldName('created_at');
+    case TimeframeType.MODIFIED:
+      return mapFieldName('modified_at');
+    case TimeframeType.LAST_INTERACTION:
+      return 'last_interaction';
+    default:
+      throw new Error(`Unsupported timeframe type: ${timeframeType}`);
+  }
+}
+
 export const searchByTimeframeConfig: UniversalToolConfig<
   TimeframeSearchParams,
   UniversalRecordResult[]
@@ -80,41 +110,10 @@ export const searchByTimeframeConfig: UniversalToolConfig<
 
       // Determine the timestamp field to filter on (Issue #475)
       // Use date_field if provided, otherwise fall back to timeframe_type logic
-      let timestampField: string;
-      if (date_field) {
-        // Map date_field directly to proper field name
-        switch (date_field) {
-          case 'created_at':
-            timestampField = mapFieldName('created_at');
-            break;
-          case 'updated_at':
-            timestampField = mapFieldName('modified_at'); // Map updated_at to modified_at
-            break;
-          case 'modified_at':
-            timestampField = mapFieldName('modified_at');
-            break;
-          default:
-            throw new Error(`Unsupported date_field: ${date_field}`);
-        }
-      } else {
-        // Fallback to original timeframe_type logic
-        const effectiveTimeframeType = timeframe_type || TimeframeType.MODIFIED;
-        switch (effectiveTimeframeType) {
-          case TimeframeType.CREATED:
-            timestampField = mapFieldName('created_at');
-            break;
-          case TimeframeType.MODIFIED:
-            timestampField = mapFieldName('modified_at');
-            break;
-          case TimeframeType.LAST_INTERACTION:
-            timestampField = mapFieldName('modified_at');
-            break;
-          default:
-            throw new Error(
-              `Unsupported timeframe type: ${effectiveTimeframeType}`
-            );
-        }
-      }
+      const timestampField = resolveTimeframeAttribute(
+        timeframe_type,
+        date_field
+      );
 
       // Build the date filter using proper Attio API v2 filter syntax
       // Use normalized operators with $ prefix

--- a/src/handlers/tool-configs/universal/schemas/advanced-schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas/advanced-schemas.ts
@@ -59,7 +59,8 @@ Examples:
 - Deals by owner+stage: {"filters": [{"attribute": {"slug": "owner"}, "condition": "equals", "value": "workspace-member-uuid"}, {"attribute": {"slug": "stage"}, "condition": "equals", "value": "Demo"}]}
 - OR logic: {"filters": [...], "matchAny": true}
 
-Supported conditions: contains, equals, starts_with, ends_with, greater_than, less_than, is_empty, is_not_empty`,
+Supported canonical conditions: contains, equals, starts_with, ends_with, gt, gte, lt, lte, is_empty, is_not_empty
+Also accepted aliases: eq, greater_than, greater_than_or_equals, less_than, less_than_or_equals, not_empty, $gt, $gte, $lt, $lte`,
       additionalProperties: true,
     },
     sort_by: {
@@ -174,6 +175,11 @@ export const searchByTimeframeSchema = {
       type: 'string' as const,
       format: 'date',
       description: 'End date (ISO 8601 format)',
+    },
+    date_field: {
+      type: 'string' as const,
+      enum: ['created_at', 'updated_at', 'modified_at', 'last_interaction'],
+      description: 'Optional explicit date field override',
     },
     ...paginationProperties,
   },

--- a/src/handlers/tool-configs/universal/schemas/core-schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas/core-schemas.ts
@@ -44,7 +44,8 @@ export const searchRecordsSchema = {
         '- Stage + Owner: {"filters": [{"attribute": {"slug": "stage"}, "condition": "equals", "value": "Demo"}, {"attribute": {"slug": "owner"}, "condition": "equals", "value": "uuid-or-name"}]}\n' +
         '- OR logic: {"filters": [...], "matchAny": true}\n' +
         '- Complex: {"filters": [{"attribute": {"slug": "stage"}, "condition": "equals", "value": "Qualified"}, {"attribute": {"slug": "value"}, "condition": "greater_than", "value": 25000}, {"attribute": {"slug": "owner"}, "condition": "equals", "value": "Martin Kessler"}]}\n\n' +
-        'Supported conditions: equals, contains, starts_with, ends_with, greater_than, greater_than_or_equals, less_than, less_than_or_equals, is_empty, is_not_empty',
+        'Supported canonical conditions: equals, contains, starts_with, ends_with, gt, gte, lt, lte, is_empty, is_not_empty\n' +
+        'Also accepted aliases: eq, greater_than, greater_than_or_equals, less_than, less_than_or_equals, not_empty, $gt, $gte, $lt, $lte',
       additionalProperties: true,
     },
     search_type: {
@@ -115,7 +116,7 @@ export const searchRecordsSchema = {
     },
     date_field: {
       type: 'string' as const,
-      enum: ['created_at', 'updated_at'] as const,
+      enum: ['created_at', 'updated_at', 'last_interaction'] as const,
       default: 'created_at',
       description: 'Which date field to filter on',
     },

--- a/src/handlers/tool-configs/universal/types.ts
+++ b/src/handlers/tool-configs/universal/types.ts
@@ -172,7 +172,12 @@ export type RelativeTimeframe =
 /**
  * Date field options for timeframe filtering
  */
-export type DateField = 'created_at' | 'updated_at' | 'due_date';
+export type DateField =
+  | 'created_at'
+  | 'updated_at'
+  | 'modified_at'
+  | 'last_interaction'
+  | 'due_date';
 
 /**
  * Universal search parameters
@@ -207,7 +212,7 @@ export interface UniversalSearchParams {
   updated_after?: string;
   updated_before?: string;
   timeframe?: RelativeTimeframe;
-  date_field?: 'created_at' | 'updated_at';
+  date_field?: 'created_at' | 'updated_at' | 'last_interaction';
 }
 
 /**
@@ -329,7 +334,7 @@ export interface TimeframeSearchParams {
   // New parameters to support relative timeframe searches (Issue #475)
   relative_range?: string;
   invert_range?: boolean;
-  date_field?: 'created_at' | 'updated_at' | 'modified_at';
+  date_field?: 'created_at' | 'updated_at' | 'modified_at' | 'last_interaction';
   limit?: number;
   offset?: number;
 }

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -100,6 +100,47 @@ export enum FilterConditionType {
   IS_NOT_SET = 'is_not_set',
 }
 
+const FILTER_CONDITION_ALIASES: Record<string, FilterConditionType> = {
+  equals: FilterConditionType.EQUALS,
+  eq: FilterConditionType.EQUALS,
+  contains: FilterConditionType.CONTAINS,
+  not_contains: FilterConditionType.NOT_CONTAINS,
+  starts_with: FilterConditionType.STARTS_WITH,
+  ends_with: FilterConditionType.ENDS_WITH,
+  gt: FilterConditionType.GREATER_THAN,
+  greater_than: FilterConditionType.GREATER_THAN,
+  lt: FilterConditionType.LESS_THAN,
+  less_than: FilterConditionType.LESS_THAN,
+  gte: FilterConditionType.GREATER_THAN_OR_EQUALS,
+  greater_than_or_equals: FilterConditionType.GREATER_THAN_OR_EQUALS,
+  lte: FilterConditionType.LESS_THAN_OR_EQUALS,
+  less_than_or_equals: FilterConditionType.LESS_THAN_OR_EQUALS,
+  between: FilterConditionType.BETWEEN,
+  is_empty: FilterConditionType.IS_EMPTY,
+  empty: FilterConditionType.IS_EMPTY,
+  is_not_empty: FilterConditionType.IS_NOT_EMPTY,
+  not_empty: FilterConditionType.IS_NOT_EMPTY,
+  is_set: FilterConditionType.IS_SET,
+  is_not_set: FilterConditionType.IS_NOT_SET,
+  not_equals: FilterConditionType.NOT_EQUALS,
+  ne: FilterConditionType.NOT_EQUALS,
+  $eq: FilterConditionType.EQUALS,
+  $contains: FilterConditionType.CONTAINS,
+  $starts_with: FilterConditionType.STARTS_WITH,
+  $ends_with: FilterConditionType.ENDS_WITH,
+  $gt: FilterConditionType.GREATER_THAN,
+  $lt: FilterConditionType.LESS_THAN,
+  $gte: FilterConditionType.GREATER_THAN_OR_EQUALS,
+  $lte: FilterConditionType.LESS_THAN_OR_EQUALS,
+  $not_empty: FilterConditionType.IS_NOT_EMPTY,
+};
+
+export function normalizeFilterCondition(
+  condition: string
+): FilterConditionType | undefined {
+  return FILTER_CONDITION_ALIASES[condition];
+}
+
 /**
  * Type guard to check if a string is a valid filter condition
  *

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -141,7 +141,22 @@ const FILTER_CONDITION_ALIASES: Record<string, FilterConditionType> = {
 export function normalizeFilterCondition(
   condition: string
 ): FilterConditionType | undefined {
-  return FILTER_CONDITION_ALIASES[condition];
+  const normalizedCondition = FILTER_CONDITION_ALIASES[condition];
+  if (normalizedCondition) {
+    return normalizedCondition;
+  }
+
+  if (!condition.startsWith('$')) {
+    return undefined;
+  }
+
+  const unprefixedCondition = condition.slice(1);
+  return (
+    FILTER_CONDITION_ALIASES[unprefixedCondition] ??
+    (isValidFilterCondition(unprefixedCondition)
+      ? unprefixedCondition
+      : undefined)
+  );
 }
 
 /**

--- a/src/types/attio.ts
+++ b/src/types/attio.ts
@@ -132,6 +132,9 @@ const FILTER_CONDITION_ALIASES: Record<string, FilterConditionType> = {
   $lt: FilterConditionType.LESS_THAN,
   $gte: FilterConditionType.GREATER_THAN_OR_EQUALS,
   $lte: FilterConditionType.LESS_THAN_OR_EQUALS,
+  $empty: FilterConditionType.IS_EMPTY,
+  $is_empty: FilterConditionType.IS_EMPTY,
+  $is_not_empty: FilterConditionType.IS_NOT_EMPTY,
   $not_empty: FilterConditionType.IS_NOT_EMPTY,
 };
 

--- a/src/utils/filters/builders/query-api.ts
+++ b/src/utils/filters/builders/query-api.ts
@@ -11,6 +11,19 @@ import {
   TimeframeQuery,
 } from '../types.js';
 
+const INTERACTION_ATTRIBUTES = new Set([
+  'last_interaction',
+  'first_email_interaction',
+  'last_email_interaction',
+  'first_calendar_interaction',
+  'last_calendar_interaction',
+  'next_calendar_interaction',
+]);
+
+function isInteractionAttribute(attribute: string): boolean {
+  return INTERACTION_ATTRIBUTES.has(attribute);
+}
+
 /**
  * Creates a query API filter with proper path and constraints structure
  *
@@ -116,49 +129,58 @@ export function createTimeframeQuery(
     throw new Error('Timeframe query requires operator');
   }
 
-  // Build the proper path - use resourceType + attribute if resourceType is provided
-  // Note: Attio API expects path as nested array format: [[objectType, attribute]]
-  const path = resourceType ? [[resourceType, attribute]] : [[attribute]];
+  const createConstraints = (): Record<string, string> => {
+    if (operator === 'between') {
+      if (!startDate || !endDate) {
+        throw new Error('Between operator requires both startDate and endDate');
+      }
 
-  // For date range queries
-  if (operator === 'between') {
-    if (!startDate || !endDate) {
-      throw new Error('Between operator requires both startDate and endDate');
+      return {
+        $gte: startDate,
+        $lte: endDate,
+      };
     }
+
+    const value = startDate || endDate;
+    if (!value) {
+      throw new Error('Timeframe query requires either startDate or endDate');
+    }
+
+    const constraintMap: Record<string, string> = {
+      greater_than: '$gt',
+      less_than: '$lt',
+      greater_than_or_equals: '$gte',
+      less_than_or_equals: '$lte',
+      equals: isInteractionAttribute(attribute) ? '$eq' : 'value',
+    };
+
+    const constraintKey = constraintMap[operator] || 'value';
+
+    return {
+      [constraintKey]: value,
+    };
+  };
+
+  const constraints = createConstraints();
+
+  if (isInteractionAttribute(attribute)) {
     return {
       filter: {
-        path,
-        constraints: {
-          $gte: startDate,
-          $lte: endDate,
+        [attribute]: {
+          interacted_at: constraints,
         },
       },
     };
   }
 
-  // For single date comparisons
-  const value = startDate || endDate;
-  if (!value) {
-    throw new Error('Timeframe query requires either startDate or endDate');
-  }
-
-  // Map operators to constraint format (using Attio's $-prefixed operators)
-  const constraintMap: Record<string, string> = {
-    greater_than: '$gt',
-    less_than: '$lt',
-    greater_than_or_equals: '$gte',
-    less_than_or_equals: '$lte',
-    equals: 'value',
-  };
-
-  const constraintKey = constraintMap[operator] || 'value';
+  // Build the proper path - use resourceType + attribute if resourceType is provided
+  // Note: Attio API expects path as nested array format: [[objectType, attribute]]
+  const path = resourceType ? [[resourceType, attribute]] : [[attribute]];
 
   return {
     filter: {
       path,
-      constraints: {
-        [constraintKey]: value,
-      },
+      constraints,
     },
   };
 }

--- a/src/utils/filters/operators.ts
+++ b/src/utils/filters/operators.ts
@@ -9,6 +9,42 @@ import {
   FilterConditionType,
   FIELD_SPECIAL_HANDLING,
 } from './types.js';
+import { normalizeFilterCondition } from '../../types/attio.js';
+
+export function toAttioFilterOperator(condition: string): string {
+  const normalized = normalizeFilterCondition(condition);
+
+  switch (normalized) {
+    case FilterConditionType.EQUALS:
+      return '$eq';
+    case FilterConditionType.CONTAINS:
+      return '$contains';
+    case FilterConditionType.STARTS_WITH:
+      return '$starts_with';
+    case FilterConditionType.ENDS_WITH:
+      return '$ends_with';
+    case FilterConditionType.GREATER_THAN:
+      return '$gt';
+    case FilterConditionType.GREATER_THAN_OR_EQUALS:
+      return '$gte';
+    case FilterConditionType.LESS_THAN:
+      return '$lt';
+    case FilterConditionType.LESS_THAN_OR_EQUALS:
+      return '$lte';
+    case FilterConditionType.IS_NOT_EMPTY:
+      return '$not_empty';
+    case FilterConditionType.IS_EMPTY:
+      return 'is_empty';
+    case FilterConditionType.IS_SET:
+      return '$not_empty';
+    case FilterConditionType.IS_NOT_SET:
+      return 'is_empty';
+    case FilterConditionType.NOT_EQUALS:
+      return 'ne';
+    default:
+      return condition.startsWith('$') ? condition : `$${condition}`;
+  }
+}
 
 /**
  * Checks if an operator is supported for a specific field

--- a/src/utils/filters/timeframe-utils.ts
+++ b/src/utils/filters/timeframe-utils.ts
@@ -63,7 +63,6 @@ export interface TimeframeValidation {
  */
 export function getRelativeTimeframeRange(
   timeframe: RelativeTimeframe,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _timezone: string = 'UTC'
 ): DateRange {
   const now = new Date();
@@ -202,7 +201,7 @@ export function convertDateParamsToTimeframeQuery(params: {
   updated_after?: string;
   updated_before?: string;
   timeframe?: RelativeTimeframe;
-  date_field?: 'created_at' | 'updated_at';
+  date_field?: 'created_at' | 'updated_at' | 'last_interaction';
 }): {
   timeframe_attribute?: string;
   start_date?: string;

--- a/src/utils/filters/translators.ts
+++ b/src/utils/filters/translators.ts
@@ -39,6 +39,7 @@ import {
   ERROR_MESSAGES,
   getFilterExample,
 } from './validation-utils.js';
+import { toAttioFilterOperator } from './operators.js';
 import { isListSpecificAttribute } from './utils.js';
 import { createScopedLogger, OperationType } from '../logger.js';
 import {
@@ -467,8 +468,7 @@ async function createOrFilterStructure(
       }
 
       // List-specific attributes use direct field access
-      const operator =
-        filter.condition === 'equals' ? '$eq' : `$${filter.condition}`;
+      const operator = toAttioFilterOperator(filter.condition);
       condition[slug] = {
         [operator]: filter.value,
       };
@@ -485,8 +485,7 @@ async function createOrFilterStructure(
       condition[slug] = filter.value;
     } else {
       // Standard operator handling for normal fields
-      const operator =
-        filter.condition === 'equals' ? '$eq' : `$${filter.condition}`;
+      const operator = toAttioFilterOperator(filter.condition);
 
       // Check if this is a reference attribute that needs nested field specification
       const isReference = await isReferenceAttribute(
@@ -693,8 +692,7 @@ async function createAndFilterStructure(
     }
 
     const { slug } = filter.attribute;
-    const operator =
-      filter.condition === 'equals' ? '$eq' : `$${filter.condition}`;
+    const operator = toAttioFilterOperator(filter.condition);
 
     // Build condition object in Attio's expected format
     let fieldPath: string;

--- a/src/utils/filters/validation-utils.ts
+++ b/src/utils/filters/validation-utils.ts
@@ -218,7 +218,6 @@ export function collectInvalidFilters(
       });
       return;
     }
-
   });
 
   return invalidFilters;
@@ -331,8 +330,7 @@ export function validateFilters(
         ? normalizeFilterCondition(filter.condition)
         : undefined;
 
-    return normalizedCondition
-      && normalizedCondition !== filter.condition
+    return normalizedCondition && normalizedCondition !== filter.condition
       ? {
           ...filter,
           condition: normalizedCondition,

--- a/src/utils/filters/validation-utils.ts
+++ b/src/utils/filters/validation-utils.ts
@@ -11,7 +11,7 @@ import {
 } from '../../errors/api-errors.js';
 import { ListEntryFilter, ListEntryFilters } from './types.js';
 import { ValidatedListEntryFilters } from '../../api/operations/types.js';
-import { isValidFilterCondition } from '../../types/attio.js';
+import { normalizeFilterCondition } from '../../types/attio.js';
 
 /**
  * Error message templates for consistent error formatting
@@ -204,8 +204,13 @@ export function collectInvalidFilters(
       return;
     }
 
+    const normalizedCondition =
+      typeof filter.condition === 'string'
+        ? normalizeFilterCondition(filter.condition)
+        : undefined;
+
     // Validate condition if enabled
-    if (validateConditions && !isValidFilterCondition(filter.condition)) {
+    if (validateConditions && !normalizedCondition) {
       invalidFilters.push({
         index,
         reason: `Invalid condition '${filter.condition}'`,
@@ -213,6 +218,7 @@ export function collectInvalidFilters(
       });
       return;
     }
+
   });
 
   return invalidFilters;
@@ -319,6 +325,32 @@ export function validateFilters(
     throw new FilterValidationError(errorMessage, category);
   }
 
+  const normalizedFilters = validatedFilters.filters.map((filter) => {
+    const normalizedCondition =
+      typeof filter.condition === 'string'
+        ? normalizeFilterCondition(filter.condition)
+        : undefined;
+
+    return normalizedCondition
+      && normalizedCondition !== filter.condition
+      ? {
+          ...filter,
+          condition: normalizedCondition,
+        }
+      : filter;
+  });
+
+  const hasNormalizedConditions = normalizedFilters.some(
+    (filter, index) => filter !== validatedFilters.filters[index]
+  );
+
+  if (hasNormalizedConditions) {
+    return {
+      ...validatedFilters,
+      filters: normalizedFilters,
+    };
+  }
+
   return validatedFilters;
 }
 
@@ -347,7 +379,10 @@ export function getInvalidFilterReason(filter: unknown): string {
     return ERROR_MESSAGES.MISSING_CONDITION;
   }
 
-  if (!isValidFilterCondition(filterObj.condition as string)) {
+  if (
+    typeof filterObj.condition !== 'string' ||
+    !normalizeFilterCondition(filterObj.condition)
+  ) {
     return `invalid condition '${filterObj.condition as string}'`;
   }
 

--- a/src/utils/filters/validators.ts
+++ b/src/utils/filters/validators.ts
@@ -14,7 +14,10 @@
  */
 
 // External dependencies
-import { DateRangePreset, isValidFilterCondition } from '../../types/attio.js';
+import {
+  DateRangePreset,
+  normalizeFilterCondition,
+} from '../../types/attio.js';
 import { FilterValidationError } from '../../errors/api-errors.js';
 import { isValidISODateString } from '../date-utils.js';
 
@@ -402,8 +405,8 @@ export function validateFilterCondition(
     throw new FilterValidationError('Filter condition is required');
   }
 
-  // Use the isValidFilterCondition from types/attio.js
-  if (!isValidFilterCondition(condition)) {
+  const normalizedCondition = normalizeFilterCondition(condition);
+  if (!normalizedCondition) {
     const validConditions = Object.values(FilterConditionType);
     throw new FilterValidationError(
       `Invalid filter condition: "${condition}". ` +
@@ -411,7 +414,7 @@ export function validateFilterCondition(
     );
   }
 
-  return condition as FilterConditionType;
+  return normalizedCondition;
 }
 
 /**
@@ -463,7 +466,7 @@ export function validateFilterWithConditions(
 
   const { slug } = filter.attribute;
 
-  if (validateConditions && !isValidFilterCondition(filter.condition)) {
+  if (validateConditions && !normalizeFilterCondition(filter.condition)) {
     throw new FilterValidationError(
       `Invalid filter condition '${filter.condition}' for attribute '${slug}'. ` +
         `Valid conditions are: ${Object.values(FilterConditionType).join(', ')}`

--- a/test/handlers/tool-configs/universal/advanced-operations-content.test.ts
+++ b/test/handlers/tool-configs/universal/advanced-operations-content.test.ts
@@ -41,7 +41,7 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
         },
       ];
 
-      const { mockSearchService } = getMockInstances();
+      const { mockHandlers, mockSearchService } = getMockInstances();
       mockSearchService.searchRecords.mockResolvedValue(mockResults);
 
       const params: ContentSearchParams = {
@@ -66,7 +66,7 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
         },
       ];
 
-      const { mockSearchService } = getMockInstances();
+      const { mockHandlers, mockSearchService } = getMockInstances();
       mockSearchService.searchRecords.mockResolvedValue(mockResults);
 
       const params: ContentSearchParams = {
@@ -202,7 +202,7 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
         },
       ];
 
-      const { mockSearchService } = getMockInstances();
+      const { mockHandlers, mockSearchService } = getMockInstances();
       mockSearchService.searchRecords.mockResolvedValue(mockResults);
 
       const params: TimeframeSearchParams = {
@@ -214,7 +214,15 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
 
       const result = await searchByTimeframeConfig.handler(params);
       expect(result).toEqual(mockResults);
-      expect(mockSearchService.searchRecords).toHaveBeenCalled();
+      expect(mockHandlers.handleUniversalSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource_type: UniversalResourceType.PEOPLE,
+          timeframe_attribute: 'modified_at',
+          start_date: '2023-12-01T00:00:00Z',
+          end_date: '2023-12-31T23:59:59Z',
+          date_operator: 'between',
+        })
+      );
     });
 
     it('should search people by last interaction with date validation', async () => {
@@ -227,7 +235,7 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
         },
       ];
 
-      const { mockSearchService } = getMockInstances();
+      const { mockHandlers, mockSearchService } = getMockInstances();
       mockSearchService.searchRecords.mockResolvedValue(mockResults);
 
       const params: TimeframeSearchParams = {
@@ -239,7 +247,77 @@ describe('Universal Advanced Operations - Content & Timeframe Tests', () => {
 
       const result = await searchByTimeframeConfig.handler(params);
       expect(result).toEqual(mockResults);
-      expect(mockSearchService.searchRecords).toHaveBeenCalled();
+      expect(mockHandlers.handleUniversalSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource_type: UniversalResourceType.PEOPLE,
+          timeframe_attribute: 'last_interaction',
+          start_date: '2023-12-01T00:00:00Z',
+          end_date: '2023-12-31T23:59:59Z',
+          date_operator: 'between',
+        })
+      );
+    });
+
+    it('should accept last_interaction as an explicit date_field', async () => {
+      const mockResults = [
+        {
+          id: { record_id: 'person-2' },
+          values: {
+            name: [{ value: 'Interaction Date Field Person' }],
+          },
+        },
+      ];
+
+      const { mockHandlers, mockSearchService } = getMockInstances();
+      mockSearchService.searchRecords.mockResolvedValue(mockResults);
+
+      const params: TimeframeSearchParams = {
+        resource_type: UniversalResourceType.PEOPLE,
+        date_field: 'last_interaction',
+        start_date: '2023-12-01T00:00:00Z',
+        end_date: '2023-12-31T23:59:59Z',
+      };
+
+      const result = await searchByTimeframeConfig.handler(params);
+      expect(result).toEqual(mockResults);
+      expect(mockHandlers.handleUniversalSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeframe_attribute: 'last_interaction',
+          start_date: '2023-12-01T00:00:00Z',
+          end_date: '2023-12-31T23:59:59Z',
+        })
+      );
+    });
+
+    it('should map updated_at date_field overrides to modified_at', async () => {
+      const mockResults = [
+        {
+          id: { record_id: 'person-3' },
+          values: {
+            name: [{ value: 'Updated Date Field Person' }],
+          },
+        },
+      ];
+
+      const { mockHandlers, mockSearchService } = getMockInstances();
+      mockSearchService.searchRecords.mockResolvedValue(mockResults);
+
+      const params: TimeframeSearchParams = {
+        resource_type: UniversalResourceType.PEOPLE,
+        date_field: 'updated_at',
+        start_date: '2023-12-01T00:00:00Z',
+        end_date: '2023-12-31T23:59:59Z',
+      };
+
+      const result = await searchByTimeframeConfig.handler(params);
+      expect(result).toEqual(mockResults);
+      expect(mockHandlers.handleUniversalSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeframe_attribute: 'modified_at',
+          start_date: '2023-12-01T00:00:00Z',
+          end_date: '2023-12-31T23:59:59Z',
+        })
+      );
     });
 
     it('should handle missing date range for last interaction', async () => {

--- a/test/handlers/tool-configs/universal/advanced-operations-search.test.ts
+++ b/test/handlers/tool-configs/universal/advanced-operations-search.test.ts
@@ -71,6 +71,110 @@ describe('Universal Advanced Operations - Search Tests', () => {
       });
     });
 
+    it('should normalize documented filter aliases before search handling', async () => {
+      const mockResults = [
+        {
+          id: { record_id: 'person-1' },
+          values: {
+            name: 'Alias Normalized Person',
+          },
+        },
+      ];
+
+      const { mockHandlers } = getMockInstances();
+      mockHandlers.handleUniversalSearch.mockResolvedValue(mockResults);
+
+      const params: any = {
+        resource_type: UniversalResourceType.PEOPLE,
+        filters: {
+          filters: [
+            {
+              attribute: { slug: 'created_at' },
+              condition: 'greater_than',
+              value: '2024-01-01T00:00:00Z',
+            },
+            {
+              attribute: { slug: 'last_interaction' },
+              condition: 'not_empty',
+            },
+          ],
+        },
+      };
+
+      const result = await advancedSearchConfig.handler(params);
+      expect(result).toEqual(mockResults);
+      expect(mockHandlers.handleUniversalSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: {
+            filters: [
+              {
+                attribute: { slug: 'created_at' },
+                condition: 'gt',
+                value: '2024-01-01T00:00:00Z',
+              },
+              {
+                attribute: { slug: 'last_interaction' },
+                condition: 'is_not_empty',
+                value: true,
+              },
+            ],
+          },
+        })
+      );
+    });
+
+    it('should normalize prefixed and set-style aliases before search handling', async () => {
+      const mockResults = [
+        {
+          id: { record_id: 'person-2' },
+          values: {
+            name: 'Additional Alias Person',
+          },
+        },
+      ];
+
+      const { mockHandlers } = getMockInstances();
+      mockHandlers.handleUniversalSearch.mockResolvedValue(mockResults);
+
+      const params: any = {
+        resource_type: UniversalResourceType.PEOPLE,
+        filters: {
+          filters: [
+            {
+              attribute: { slug: 'created_at' },
+              condition: '$gt',
+              value: '2024-01-01T00:00:00Z',
+            },
+            {
+              attribute: { slug: 'last_interaction' },
+              condition: 'is_not_set',
+            },
+          ],
+        },
+      };
+
+      const result = await advancedSearchConfig.handler(params);
+      expect(result).toEqual(mockResults);
+      expect(mockHandlers.handleUniversalSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: {
+            filters: [
+              {
+                attribute: { slug: 'created_at' },
+                condition: 'gt',
+                value: '2024-01-01T00:00:00Z',
+              },
+              {
+                attribute: { slug: 'last_interaction' },
+                condition: 'is_not_set',
+                value: true,
+              },
+            ],
+          },
+        })
+      );
+    });
+
     it('should format advanced search results with context', async () => {
       const mockResults = [
         {

--- a/test/handlers/tool-configs/universal/advanced-operations-search.test.ts
+++ b/test/handlers/tool-configs/universal/advanced-operations-search.test.ts
@@ -146,8 +146,13 @@ describe('Universal Advanced Operations - Search Tests', () => {
               value: '2024-01-01T00:00:00Z',
             },
             {
+              attribute: { slug: 'description' },
+              condition: '$not_contains',
+              value: 'internal',
+            },
+            {
               attribute: { slug: 'last_interaction' },
-              condition: 'is_not_set',
+              condition: '$is_not_set',
             },
           ],
         },
@@ -163,6 +168,11 @@ describe('Universal Advanced Operations - Search Tests', () => {
                 attribute: { slug: 'created_at' },
                 condition: 'gt',
                 value: '2024-01-01T00:00:00Z',
+              },
+              {
+                attribute: { slug: 'description' },
+                condition: 'not_contains',
+                value: 'internal',
               },
               {
                 attribute: { slug: 'last_interaction' },

--- a/test/integration/api/IT-105-advanced-search-validation.integration.test.ts
+++ b/test/integration/api/IT-105-advanced-search-validation.integration.test.ts
@@ -98,5 +98,19 @@ describe.skipIf(!runIntegrationTests)(
         /missing condition property/i
       );
     });
+
+    it('IT-105.7: accepts documented greater_than alias on created_at', async () => {
+      await expect(
+        advancedSearchCompanies!({
+          filters: [
+            {
+              attribute: { slug: 'created_at' },
+              condition: 'greater_than',
+              value: '2020-01-01T00:00:00Z',
+            },
+          ],
+        } as never)
+      ).resolves.toBeDefined();
+    });
   }
 );

--- a/test/services/UniversalSearchService-query-api.test.ts
+++ b/test/services/UniversalSearchService-query-api.test.ts
@@ -259,9 +259,10 @@ describe('UniversalSearchService Query API Integration - Issue #523', () => {
         '/objects/people/records/query',
         expect.objectContaining({
           filter: {
-            path: [['people', 'last_interaction']],
-            constraints: {
-              $gt: '2024-06-01',
+            last_interaction: {
+              interacted_at: {
+                $gt: '2024-06-01',
+              },
             },
           },
         })

--- a/test/unit/services/search/QueryApiService.test.ts
+++ b/test/unit/services/search/QueryApiService.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/utils/filters/index.js', () => ({
 }));
 
 import * as AttioClientModule from '@/api/attio-client.js';
+import { createTimeframeQuery } from '@/utils/filters/index.js';
 
 describe('QueryApiService', () => {
   beforeEach(() => {
@@ -147,6 +148,13 @@ describe('QueryApiService', () => {
       );
 
       expect(results).toEqual(mockRecords);
+      expect(createTimeframeQuery).toHaveBeenCalledWith({
+        resourceType: UniversalResourceType.COMPANIES,
+        attribute: 'created_at',
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+        operator: 'between',
+      });
     });
 
     it('should return empty array on not found', async () => {

--- a/test/utils/filters/query-api.test.ts
+++ b/test/utils/filters/query-api.test.ts
@@ -174,9 +174,32 @@ describe('Query API Implementation - Issue #523', () => {
 
       expect(result).toEqual({
         filter: {
-          path: [['last_interaction']],
-          constraints: {
-            $lt: '2024-03-15',
+          last_interaction: {
+            interacted_at: {
+              $lt: '2024-03-15',
+            },
+          },
+        },
+      });
+    });
+
+    it('should create proper interaction date range query for between operator', () => {
+      const config: TimeframeQuery = {
+        attribute: 'last_interaction',
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+        operator: 'between',
+      };
+
+      const result = createTimeframeQuery(config);
+
+      expect(result).toEqual({
+        filter: {
+          last_interaction: {
+            interacted_at: {
+              $gte: '2024-01-01',
+              $lte: '2024-12-31',
+            },
           },
         },
       });

--- a/test/utils/filters/timeframe-utils.test.ts
+++ b/test/utils/filters/timeframe-utils.test.ts
@@ -159,6 +159,20 @@ describe('TimeframeUtils', () => {
       });
     });
 
+    it('should support last_interaction as a date_field', () => {
+      const result = convertDateParamsToTimeframeQuery({
+        timeframe: 'last_7_days',
+        date_field: 'last_interaction',
+      });
+
+      expect(result).toEqual({
+        timeframe_attribute: 'last_interaction',
+        start_date: '2023-08-08T00:00:00.000Z',
+        end_date: '2023-08-15T23:59:59.999Z',
+        date_operator: 'between',
+      });
+    });
+
     it('should handle single date bounds', () => {
       const startOnly = convertDateParamsToTimeframeQuery({
         date_from: '2023-08-01T00:00:00Z',

--- a/test/utils/filters/validation-utils.test.ts
+++ b/test/utils/filters/validation-utils.test.ts
@@ -227,6 +227,33 @@ describe('Filter Validation Utilities', () => {
       expect(validateFilters(filters)).toBe(filters);
     });
 
+    it('should normalize documented operator aliases before validation', () => {
+      const filters = {
+        filters: [
+          {
+            attribute: { slug: 'created_at' },
+            condition: 'greater_than',
+            value: '2024-01-01T00:00:00Z',
+          },
+          {
+            attribute: { slug: 'last_interaction' },
+            condition: 'not_empty',
+            value: true,
+          },
+        ],
+      };
+
+      const result = validateFilters(filters as any);
+
+      expect(result).not.toBe(filters);
+      expect(filters.filters[0].condition).toBe('greater_than');
+      expect(filters.filters[1].condition).toBe('not_empty');
+      expect(result.filters[0].condition).toBe(FilterConditionType.GREATER_THAN);
+      expect(result.filters[1].condition).toBe(
+        FilterConditionType.IS_NOT_EMPTY
+      );
+    });
+
     it('should throw detailed error when all filters are invalid with appropriate category', () => {
       const filters = {
         filters: [

--- a/test/utils/filters/validation-utils.test.ts
+++ b/test/utils/filters/validation-utils.test.ts
@@ -248,7 +248,9 @@ describe('Filter Validation Utilities', () => {
       expect(result).not.toBe(filters);
       expect(filters.filters[0].condition).toBe('greater_than');
       expect(filters.filters[1].condition).toBe('not_empty');
-      expect(result.filters[0].condition).toBe(FilterConditionType.GREATER_THAN);
+      expect(result.filters[0].condition).toBe(
+        FilterConditionType.GREATER_THAN
+      );
       expect(result.filters[1].condition).toBe(
         FilterConditionType.IS_NOT_EMPTY
       );

--- a/test/utils/filters/validation-utils.test.ts
+++ b/test/utils/filters/validation-utils.test.ts
@@ -256,6 +256,30 @@ describe('Filter Validation Utilities', () => {
       );
     });
 
+    it('should normalize dollar-prefixed emptiness aliases before validation', () => {
+      const filters = {
+        filters: [
+          {
+            attribute: { slug: 'description' },
+            condition: '$empty',
+            value: true,
+          },
+          {
+            attribute: { slug: 'last_interaction' },
+            condition: '$is_not_empty',
+            value: true,
+          },
+        ],
+      };
+
+      const result = validateFilters(filters as any);
+
+      expect(result.filters[0].condition).toBe(FilterConditionType.IS_EMPTY);
+      expect(result.filters[1].condition).toBe(
+        FilterConditionType.IS_NOT_EMPTY
+      );
+    });
+
     it('should throw detailed error when all filters are invalid with appropriate category', () => {
       const filters = {
         filters: [

--- a/test/utils/filters/validation-utils.test.ts
+++ b/test/utils/filters/validation-utils.test.ts
@@ -280,6 +280,30 @@ describe('Filter Validation Utilities', () => {
       );
     });
 
+    it('should normalize other dollar-prefixed canonical conditions before validation', () => {
+      const filters = {
+        filters: [
+          {
+            attribute: { slug: 'description' },
+            condition: '$not_contains',
+            value: 'internal',
+          },
+          {
+            attribute: { slug: 'last_interaction' },
+            condition: '$is_not_set',
+            value: true,
+          },
+        ],
+      };
+
+      const result = validateFilters(filters as any);
+
+      expect(result.filters[0].condition).toBe(
+        FilterConditionType.NOT_CONTAINS
+      );
+      expect(result.filters[1].condition).toBe(FilterConditionType.IS_NOT_SET);
+    });
+
     it('should throw detailed error when all filters are invalid with appropriate category', () => {
       const filters = {
         filters: [

--- a/test/utils/filters/validators.test.ts
+++ b/test/utils/filters/validators.test.ts
@@ -84,6 +84,12 @@ describe('Filter Validators', () => {
         FilterConditionType.GREATER_THAN
       );
       expect(validateFilterCondition('$eq')).toBe(FilterConditionType.EQUALS);
+      expect(validateFilterCondition('$is_empty')).toBe(
+        FilterConditionType.IS_EMPTY
+      );
+      expect(validateFilterCondition('$is_not_empty')).toBe(
+        FilterConditionType.IS_NOT_EMPTY
+      );
     });
 
     it('should throw error for empty condition', () => {

--- a/test/utils/filters/validators.test.ts
+++ b/test/utils/filters/validators.test.ts
@@ -84,6 +84,9 @@ describe('Filter Validators', () => {
         FilterConditionType.GREATER_THAN
       );
       expect(validateFilterCondition('$eq')).toBe(FilterConditionType.EQUALS);
+      expect(validateFilterCondition('$not_contains')).toBe(
+        FilterConditionType.NOT_CONTAINS
+      );
       expect(validateFilterCondition('$is_empty')).toBe(
         FilterConditionType.IS_EMPTY
       );
@@ -131,6 +134,18 @@ describe('Filter Validators', () => {
         attribute: { slug: 'created_at' },
         condition: 'greater_than' as FilterConditionType,
         value: '2024-01-01T00:00:00Z',
+      };
+
+      expect(() => {
+        validateFilterWithConditions(filter);
+      }).not.toThrow();
+    });
+
+    it('should accept dollar-prefixed canonical conditions', () => {
+      const filter: ListEntryFilter = {
+        attribute: { slug: 'description' },
+        condition: '$not_contains' as FilterConditionType,
+        value: 'internal',
       };
 
       expect(() => {

--- a/test/utils/filters/validators.test.ts
+++ b/test/utils/filters/validators.test.ts
@@ -79,6 +79,13 @@ describe('Filter Validators', () => {
       });
     });
 
+    it('should normalize supported aliases to canonical condition types', () => {
+      expect(validateFilterCondition('greater_than')).toBe(
+        FilterConditionType.GREATER_THAN
+      );
+      expect(validateFilterCondition('$eq')).toBe(FilterConditionType.EQUALS);
+    });
+
     it('should throw error for empty condition', () => {
       expect(() => {
         validateFilterCondition('');
@@ -106,6 +113,18 @@ describe('Filter Validators', () => {
         attribute: { slug: 'name' },
         condition: FilterConditionType.CONTAINS,
         value: 'test',
+      };
+
+      expect(() => {
+        validateFilterWithConditions(filter);
+      }).not.toThrow();
+    });
+
+    it('should accept supported alias conditions', () => {
+      const filter: ListEntryFilter = {
+        attribute: { slug: 'created_at' },
+        condition: 'greater_than' as FilterConditionType,
+        value: '2024-01-01T00:00:00Z',
       };
 
       expect(() => {


### PR DESCRIPTION
## Summary

- Problem: `search_records_by_timeframe` translated `modified` and `last_interaction` inconsistently, and `search_records_advanced` rejected documented operator aliases before translation.
- Why it matters: timeframe searches on people and companies could return no results, and valid advanced-search filters failed with validation errors despite matching the public tool contract.
- What changed: unified logical timeframe routing, added shared `last_interaction` date-field support, special-cased Query API interaction timeframe payloads, and centralized alias normalization so advanced-search validation returns canonical operators.
- What did not change (scope boundary): no tool names, response shapes, config flags, or unrelated search behavior changed.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Tool handlers/formatting
- [x] Attio API integration
- [x] Tests/mocks/fixtures
- [ ] Issue/PR templates or community files
- [ ] CI/workflows
- [x] Other

## Linked Issue/PR

- Closes #1126
- Related # N/A

## User-visible / Behavior Changes

- `search_records_by_timeframe` now routes `timeframe_type: "modified"` to `modified_at` consistently for people and companies.
- `search_records_by_timeframe` and shared universal date helpers now accept and route `last_interaction` consistently.
- Query API timeframe filters for `last_interaction` now emit interaction-aware `interacted_at` constraints instead of treating the field like a plain timestamp.
- `search_records_advanced` now accepts documented operator aliases such as `greater_than`, `less_than`, `greater_than_or_equals`, `is_not_empty`, `not_empty`, `eq`, and `$gt`, while still rejecting unknown operators.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Tool execution surface changed? (`Yes/No`): No
- If any `Yes`, explain risk and mitigation:

## Repro + Verification

### Environment

- OS: Darwin 24.6.0 (macOS)
- Shell/runtime: zsh, Bun 1.2.5, Node v22.14.0
- Relevant tool versions: Vitest via repo scripts, GitHub CLI for PR creation

### Steps

1. Reproduce issue #1126 by exercising universal timeframe search with `timeframe_type: "modified"` and `timeframe_type: "last_interaction"` against people or companies.
2. Reproduce the advanced-search failure by sending documented operators such as `greater_than`, `$gt`, or `is_not_empty` through `search_records_advanced`.
3. Run the targeted regression suites and typecheck listed below.

### Expected

- `modified` resolves to `modified_at` consistently.
- `last_interaction` resolves consistently through shared routing and builds the correct Query API payload.
- Documented operator aliases are accepted and normalized to canonical Attio operators.
- Truly unknown operators still fail explicitly.

### Actual

- Verified on this branch via targeted unit, handler, service, and integration coverage.
- The issue scenarios now pass in offline coverage, and alias-validation integration coverage passes.

## Evidence

- [x] Log snippets
- [ ] Failing output before and passing output after
- [ ] Screenshot/recording
- [ ] N/A (docs-only or template-only change)

Passing verification on this branch:

```text
bun run test:single -- test/utils/filters/validators.test.ts test/utils/filters/validation-utils.test.ts test/utils/filters/query-api.test.ts
bun run test:single -- test/handlers/tool-configs/universal/advanced-operations-search.test.ts test/handlers/tool-configs/universal/advanced-operations-content.test.ts
bun run test:single -- test/services/UniversalSearchService-query-api.test.ts test/unit/services/search/QueryApiService.test.ts
bunx vitest --config configs/vitest/vitest.config.integration.ts --run test/integration/api/IT-105-advanced-search-validation.integration.test.ts
bun run typecheck
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: timeframe routing for `modified` and `last_interaction`, shared `date_field: "last_interaction"` acceptance, advanced-search alias normalization, and issue-specific validation coverage.
- Edge cases checked: `updated_at` override routing to `modified_at`, interaction timeframe `between` payload shaping, non-mutating filter normalization, and unknown-operator rejection in validator-level coverage.
- What you did not verify: a live Attio API integration test for the `last_interaction` timeframe query path itself.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery

- How to disable/revert this change quickly: revert commit `3d7129df` or revert this PR.
- Files/config to restore: the touched universal search handler, filter translation, and validation files under `src/handlers/tool-configs/universal/` and `src/utils/filters/`.
- Known bad symptoms reviewers should watch for: timeframe searches returning empty results for `modified` or `last_interaction`, or advanced-search aliases being accepted by schemas but rejected at runtime.

## Risks and Mitigations

- Risk: Attio's live Query API may still have edge-case behavior on `last_interaction` interaction filters beyond what the current offline/query-builder coverage characterizes.
  - Mitigation: the special-case is intentionally narrow, covered by query-builder regressions, and easy to revert if live behavior diverges.

## AI Assistance

- AI-assisted: yes
- Tools/agents/models used: Codex (GPT-5) for implementation, plus internal review agents via the `ce:review-beta` workflow
- Testing level: fully tested
- Human understanding confirmation: yes

## Post-Deploy Monitoring & Validation

- Watch universal search failures for people/company timeframe queries involving `modified` or `last_interaction`.
- Spot-check the two issue #1126 scenarios in a live workspace after deploy.
