### PR TITLE
Feature: Complete custom object parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Universal record tools now accept config-discovered custom object slugs for details, create, update, and delete operations instead of limiting custom objects to search-only flows (#1161)
 - Fixed `get-workspace-member` so valid `workspace_member_id` values returned by `list-workspace-members` are passed to Attio as UUID path segments instead of malformed argument objects (#1173)
 
 ## [1.5.0] - 2026-04-09

--- a/docs/plans/2026-05-05-001-feat-custom-object-crud-parity-plan.md
+++ b/docs/plans/2026-05-05-001-feat-custom-object-crud-parity-plan.md
@@ -1,0 +1,405 @@
+---
+title: feat: Complete custom object parity for universal record tools
+type: feat
+status: active
+date: 2026-05-05
+---
+
+# feat: Complete custom object parity for universal record tools
+
+## Summary
+
+Complete issue #1161 by extending the config-discovered custom object support already used by search tools into `get_record_details`, `create_record`, `update_record`, and `delete_record`. The implementation should reuse the existing dynamic resource-type validation and route validated custom object slugs through the generic Attio records API while preserving specialized behavior for standard objects.
+
+---
+
+## Problem Frame
+
+Custom object slugs discovered into the mapping config are searchable after #1138, but the non-search universal record tools still reject or mishandle those same slugs. This creates partial support: a user can find custom records like `funds` or `orders`, then cannot reliably retrieve, create, update, or delete them through the same universal tool family.
+
+---
+
+## Assumptions
+
+_This plan was authored in LFG pipeline mode without synchronous scope confirmation. The items below are agent inferences that should be reviewed before implementation proceeds._
+
+- Direct custom-object parity means callers may pass a config-discovered custom object slug directly as `resource_type`, for example `resource_type: "funds"`, rather than only using `resource_type: "records"` plus an embedded object slug.
+- Standard objects must keep their current specialized service paths where they exist; the generic custom-object path should only handle validated non-standard slugs.
+- Relationship-field parity is limited to the existing create/update payload and value-transformer behavior. New relationship discovery or custom relationship tooling remains out of scope.
+- Real Attio API validation is useful but not required for local implementation if credentials or safe test data are unavailable; offline tests should prove validation, routing, formatting, and failure handling.
+
+---
+
+## Requirements
+
+- R1. `get_record_details` accepts config-discovered custom object slugs and retrieves the requested record from the matching Attio object.
+- R2. `create_record` accepts config-discovered custom object slugs and creates records with custom object field payloads.
+- R3. `update_record` accepts config-discovered custom object slugs and updates records with custom object field payloads.
+- R4. `delete_record` accepts config-discovered custom object slugs and deletes records from the matching Attio object.
+- R5. Validation distinguishes unknown resource types from config-discovered custom object slugs and preserves useful suggestions.
+- R6. Create/update field mapping handles custom object attributes without requiring a static `UniversalResourceType` enum entry.
+- R7. User-facing formatting and errors use the actual custom object slug instead of falling back to generic `records` or broken singular/plural labels.
+- R8. Tests cover validation, routing, formatting, and failure paths for non-search custom object flows.
+- R9. Docs and changelog describe the true custom-object support level without overstating unsupported edge cases.
+
+---
+
+## Scope Boundaries
+
+- Do not reopen or re-scope the closed #918 umbrella issue.
+- Do not add a new custom object discovery mechanism; this plan depends on existing mapping config discovery.
+- Do not alter search-family behavior except for regression coverage where shared helpers change.
+- Do not add custom-object batch parity in this PR.
+- Do not add new scoped tools for individual custom object names.
+- Do not change Attio object schema management; this is record CRUD/detail parity, not object creation/update support.
+
+### Deferred to Follow-Up Work
+
+- Batch custom-object parity for `batch_records`, if users need it after the core CRUD/detail surface is complete.
+- Relationship-specific custom object workflows beyond existing field payload handling.
+- Live smoke automation for a workspace-owned disposable custom object, if recurring real-API coverage becomes practical.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/handlers/tools/dispatcher/utils.ts` already exposes `canonicalizeResourceType()` and `getValidResourceTypes()`, merging standard resources with custom object slugs from `loadMappingConfig()`.
+- `src/handlers/tool-configs/universal/validators/schema-validator.ts` currently limits dynamic resource-type validation to `search_records`, `search_records_advanced`, and `search_records_by_timeframe`. The non-search tools still use the enum-only validator.
+- `test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts` contains the #1138 regression coverage and currently asserts that `create_record` rejects custom object slugs.
+- `src/handlers/tool-configs/universal/core/search-operations.ts` formats custom object result labels through string-aware helpers in `src/handlers/tool-configs/universal/core/utils.ts`.
+- `src/handlers/tools/dispatcher/core.ts` can pass the full original argument object into `formatResult`; search already handles that with `extractResourceTypeFromFormatArgs()`, while CRUD/detail formatters still assume the first format arg is a raw resource-type string.
+- `src/services/UniversalRetrievalService.ts`, `src/services/UniversalCreateService.ts`, `src/services/UniversalUpdateService.ts`, and `src/services/UniversalDeleteService.ts` still branch on `UniversalResourceType` enum values and use generic object operations only through `records` or `deals` paths.
+- `src/objects/records/index.ts` already has generic `createObjectRecord`, `getObjectRecord`, `updateObjectRecord`, and `deleteObjectRecord` helpers that accept object slugs and call Attio `/objects/{object}/records` endpoints.
+- `src/services/update/MetadataResolver.ts` and `src/services/update/UpdateOrchestrator.ts` currently assume custom object slugs arrive through `records` object-slug context, not as direct `resource_type` values.
+- `docs/universal-tools/user-guide.md` and `docs/universal-tools/api-reference.md` still describe mostly fixed enum-style `resource_type` values and need custom object guidance.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory exists in this checkout, so there are no repo-local solution notes to carry forward.
+- Existing repo guidance requires `bun`, focused tests, structured logging, no secret/PII exposure, and `formatResult` functions that always return strings.
+- Prior #1138 search work intentionally kept non-search custom-object support out of scope; this plan is the narrow follow-on.
+
+### External References
+
+- Attio REST docs for [Create a record](https://docs.attio.com/rest-api/endpoint-reference/records/create-a-record) document `POST /v2/objects/{object}/records`, where `{object}` is a UUID or slug.
+- Attio REST docs for [Get a record](https://docs.attio.com/rest-api/endpoint-reference/records/get-a-record) document `GET /v2/objects/{object}/records/{record_id}` for people, companies, and other records.
+- Attio REST docs for [Update a record](https://docs.attio.com/rest-api/endpoint-reference/records/update-a-record-append-multiselect-values) document `PATCH /v2/objects/{object}/records/{record_id}` for appending multiselect values.
+- Attio REST docs for [Delete a record](https://docs.attio.com/rest-api/endpoint-reference/records/delete-a-record) document `DELETE /v2/objects/{object}/records/{record_id}`.
+
+---
+
+## Key Technical Decisions
+
+- Extend dynamic validation to the #1161 tools: use the same config-discovered slug acceptance for `get_record_details`, `create_record`, `update_record`, and `delete_record` that #1138 introduced for search.
+- Treat validated non-standard `resource_type` values as direct Attio object slugs: custom object CRUD/detail should call generic record operations with the custom slug, not coerce the operation into the generic `records` enum branch.
+- Preserve standard resource paths: companies, people, deals, tasks, lists, notes, and records should continue using existing specialized branches and tests unless shared helper typing needs broadening.
+- Keep static field mapping as an enhancement, not a requirement: custom object field payloads should pass through when no static mapping exists, while available-attribute discovery can still support collision detection and display-name resolution.
+- Use string-aware display labels for user-facing messages: custom object slugs should remain visible as `funds`, `orders`, or `investment_opportunities` instead of being singularized incorrectly or hidden behind `record`.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the solution depend on a fresh Attio API object-list call at runtime? No. Existing search support already uses the mapping config as the dynamic source of truth; CRUD/detail parity should use the same mechanism.
+- Should callers keep using `resource_type: "records"` plus `object` for custom objects? That path may remain compatible, but #1161 asks for first-class direct custom object slugs across the universal record tools.
+- Is external research warranted? Yes. The work touches Attio REST API contracts; current docs confirm the generic `/objects/{object}/records` endpoints support "other records" by object slug.
+
+### Deferred to Implementation
+
+- Exact type alias names for dynamic resource strings: implementation should choose the smallest type change that avoids unsafe enum casts while keeping existing tool params readable.
+- Whether post-update field verification can run unchanged for direct custom object slugs: implementation should verify `FieldPersistenceHandler` and metadata fetching behavior under targeted tests and disable only if an existing helper cannot support custom object metadata safely.
+- Whether docs should list every custom-object-capable tool in one new section or patch existing schemas inline: choose the smaller doc edit that makes current support clear.
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+flowchart TD
+  A["Universal tool params"] --> B["validateUniversalToolParams"]
+  B --> C{"resource_type standard enum?"}
+  C -->|yes| D["Existing specialized service branch"]
+  C -->|no, but config-discovered| E["Custom object slug branch"]
+  C -->|unknown| F["Validation error with valid types"]
+  E --> G["Generic records API helper"]
+  G --> H["/objects/{custom_slug}/records[/record_id]"]
+  D --> I["Existing output and structuredOutput behavior"]
+  E --> J["String-aware formatting and errors using custom slug"]
+```
+
+---
+
+## Implementation Units
+
+- U1. **Unify dynamic resource-type validation for target tools**
+
+**Goal:** Allow config-discovered custom object slugs through validation for `get_record_details`, `create_record`, `update_record`, and `delete_record` without weakening unknown-resource rejection.
+
+**Requirements:** R1, R2, R3, R4, R5, R8
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `src/handlers/tool-configs/universal/validators/schema-validator.ts`
+- Modify: `test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts`
+- Review: `src/handlers/tools/dispatcher/utils.ts`
+
+**Approach:**
+
+- Replace the search-only dynamic validation set with a clearly named set of universal tools that accept config-discovered object slugs.
+- Reuse `canonicalizeResourceType()` and `getValidResourceTypes()` so the dispatcher and tool-handler validation layers share one source of truth.
+- Update the existing negative test that says non-search tools reject custom objects; after #1161, it should assert acceptance for the four target tools and rejection only for unknown slugs.
+- Keep non-target tools on their current validation rules unless implementation shows they already depend on the same shared validator path and would otherwise regress.
+
+**Execution note:** Start with failing validation tests for all four #1161 tools before changing the validator.
+
+**Patterns to follow:**
+
+- #1138 tests in `test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts`.
+- `canonicalizeResourceType()` and `getValidResourceTypes()` in `src/handlers/tools/dispatcher/utils.ts`.
+
+**Test scenarios:**
+
+- Happy path: `get_record_details` accepts `resource_type: "FUNDS"` from mapping config and returns canonical `funds`.
+- Happy path: `create_record`, `update_record`, and `delete_record` each accept `resource_type: "channels"` from mapping config.
+- Edge case: standard enum resource types still pass unchanged for all target tools.
+- Error path: `resource_type: "unknown_object"` still throws `Invalid resource_type` and includes known standard plus config-discovered values.
+- Regression: search-family custom object validation still passes after the shared set is renamed or expanded.
+
+**Verification:**
+
+- Validation tests prove the second validation gate no longer undoes dispatcher acceptance for the #1161 tools.
+
+- U2. **Route custom object details and delete through generic record operations**
+
+**Goal:** Make `get_record_details` and `delete_record` execute against `/objects/{custom_slug}/records/{record_id}` when `resource_type` is a validated custom object slug.
+
+**Requirements:** R1, R4, R7, R8
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `src/services/UniversalRetrievalService.ts`
+- Modify: `src/services/UniversalDeleteService.ts`
+- Modify: `src/handlers/tool-configs/universal/core/record-details-operations.ts`
+- Modify: `src/handlers/tool-configs/universal/core/crud-operations.ts`
+- Modify: `test/services/UniversalRetrievalService-core-operations.test.ts`
+- Modify: `test/services/UniversalDeleteService.test.ts`
+- Test: `test/handlers/tool-configs/universal/core-operations-crud.test.ts`
+
+**Approach:**
+
+- Add a small custom-object detection boundary after validation: if the resource is not a known `UniversalResourceType` but is known to the dynamic validator, route it as an object slug.
+- For details, call `getObjectRecord(customSlug, recordId)` and keep field filtering compatible with the returned Attio record shape.
+- For delete, call `deleteObjectRecord(customSlug, recordId)` and return the existing `{ success, record_id }` shape.
+- Update formatting to use string-aware labels so custom object details and deletion messages include the custom slug.
+- Avoid broad refactors in standard retrieval/delete branches.
+
+**Patterns to follow:**
+
+- Generic object helpers in `src/objects/records/index.ts`.
+- String-aware label helpers in `src/handlers/tool-configs/universal/core/utils.ts`.
+- Existing list-specific preservation in `src/services/UniversalRetrievalService.ts` as a model for keeping standard special cases intact.
+
+**Test scenarios:**
+
+- Happy path: `UniversalRetrievalService.getRecordDetails({ resource_type: "funds", record_id })` calls the generic object-record helper with `funds` and returns the Attio record.
+- Happy path: `UniversalDeleteService.deleteRecord({ resource_type: "funds", record_id })` calls the generic delete helper with `funds` and returns success.
+- Edge case: details field filtering still returns only requested `values` fields for a custom object record.
+- Error path: a not-found error from the generic record helper surfaces as a not-found details/delete error that names `funds`, not generic `records`.
+- Regression: companies, people, deals, tasks, lists, notes, and `records` keep their existing branch behavior.
+
+**Verification:**
+
+- Details and delete service tests prove direct custom object slugs reach the generic `/objects/{slug}/records/{record_id}` path.
+
+- U3. **Route custom object create/update with field mapping and metadata support**
+
+**Goal:** Make `create_record` and `update_record` accept custom object field payloads and route them through generic records API helpers with the custom object slug.
+
+**Requirements:** R2, R3, R5, R6, R7, R8
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `src/services/UniversalCreateService.ts`
+- Modify: `src/services/UniversalUpdateService.ts`
+- Modify: `src/services/update/MetadataResolver.ts`
+- Modify: `src/services/update/UpdateOrchestrator.ts`
+- Modify: `src/services/update/strategies/RecordUpdateStrategy.ts`
+- Modify: `src/handlers/tool-configs/universal/field-mapper/transformers/record-transformer.ts`
+- Modify: `src/handlers/tool-configs/universal/field-mapper/validators/field-validator.ts`
+- Modify: `test/services/UniversalCreateService-objects-deals-tasks.test.ts`
+- Modify: `test/services/UniversalUpdateService-core-operations.test.ts`
+- Modify: `test/services/update/MetadataResolver.test.ts`
+
+**Approach:**
+
+- Broaden internal service typing where necessary from enum-only resource types to dynamic resource strings at the service boundary, while preserving enum-specific branches for standard objects.
+- For direct custom object creates, derive the object slug from `resource_type`, discover attributes for that slug when available, map/validate fields with graceful pass-through when no static mapping exists, and call the generic record create strategy/helper.
+- For direct custom object updates, derive the object slug from `resource_type`, fetch metadata for that slug, run existing mapping/normalization/value-transformer steps where they support dynamic attributes, and dispatch to the generic record update strategy with the custom slug.
+- Ensure custom object payloads do not require `record_data.object`, `record_data.object_slug`, or `record_data.object_api_slug` when the object slug is already supplied as `resource_type`.
+- Keep the current `records` compatibility path that extracts object slug from `record_data` for callers already using that shape.
+
+**Execution note:** Add characterization coverage for create and update routing before broadening service types; this area has multiple validation and value-transformation hooks.
+
+**Patterns to follow:**
+
+- `RecordCreateStrategy` and `RecordUpdateStrategy` for generic object operations.
+- Existing `records` object-slug extraction in `UniversalCreateService` and `MetadataResolver`.
+- `mapRecordFields()` pass-through behavior when no static mapping exists.
+
+**Test scenarios:**
+
+- Happy path: `UniversalCreateService.createRecord({ resource_type: "funds", record_data: { name: "Fund I" } })` calls generic create with object slug `funds` and a values payload.
+- Happy path: `UniversalUpdateService.updateRecord({ resource_type: "funds", record_id, record_data: { status: "Active" } })` calls generic update with object slug `funds`.
+- Edge case: custom object create/update with `record_data.values` and top-level `record_data` both map to the expected values envelope.
+- Edge case: no static field mapping for `funds` produces pass-through mapping, not validation failure.
+- Error path: field collision or Attio validation errors still surface through the existing CRUD error enhancer path with the custom slug label.
+- Regression: `resource_type: "records"` still requires or uses embedded object slug context as it does today.
+- Regression: deal-specific validation and task-specific content immutability remain unchanged for standard resources.
+
+**Verification:**
+
+- Create/update tests prove custom object slugs are used as object slugs and payloads are not forced through the `records` enum branch.
+
+- U4. **Normalize custom object formatting and error labels**
+
+**Goal:** Ensure success and failure messages for custom object details/create/update/delete use the actual custom object slug consistently.
+
+**Requirements:** R7, R8
+
+**Dependencies:** U2, U3
+
+**Files:**
+
+- Modify: `src/handlers/tool-configs/universal/core/utils.ts`
+- Modify: `src/handlers/tool-configs/universal/core/crud-error-handlers.ts`
+- Modify: `src/handlers/tool-configs/universal/shared-handlers.ts`
+- Modify: `src/services/UniversalUtilityService.ts`
+- Modify: `test/handlers/tool-configs/universal/core-operations-crud.test.ts`
+- Modify: `test/unit/handlers/tool-configs/universal/core/search-operations.test.ts`
+- Test: `test/unit/handlers/universal/crud-error-handlers.test.ts`
+
+**Approach:**
+
+- Prefer existing string-aware helpers such as `getSingularResourceLabel()` and `getPluralResourceLabel()` where user-facing labels can receive custom object slugs.
+- Use `extractResourceTypeFromFormatArgs()` or the same dispatcher-argument normalization pattern in CRUD/detail formatters so both raw string args and full params objects produce correct labels.
+- Avoid enum casts before formatting custom object labels; if a helper must remain enum-only for compatibility, add a string-aware wrapper at the caller.
+- Keep custom object slugs unchanged rather than applying naive singularization. `investment_opportunities` is a better label than a broken singular guess.
+- Preserve existing standard labels like `company`, `person`, `deal`, and `task`.
+
+**Patterns to follow:**
+
+- #1138 search formatting in `src/handlers/tool-configs/universal/core/search-operations.ts`.
+- `getPluralResourceLabel()` and `getSingularResourceLabel()` in `src/handlers/tool-configs/universal/core/utils.ts`.
+
+**Test scenarios:**
+
+- Happy path: create success for `resource_type: "funds"` says `funds` and includes the record display name/ID.
+- Happy path: update success and delete success for `resource_type: "orders"` say `orders`.
+- Happy path: details output for `resource_type: "investment_opportunities"` starts with that slug as the record label.
+- Edge case: CRUD/detail formatters receive `{ resource_type: "funds", ... }` as their first format arg and still resolve the label as `funds`, not `[object Object]`.
+- Error path: create/update/delete fallback errors say `Failed to create funds`, `Failed to update funds`, or `Failed to delete funds`, not `record` or `fundss`.
+- Regression: standard resources still format as `company`, `person`, `deal`, `task`, and `list`.
+
+**Verification:**
+
+- Formatter and error-handler tests prove custom object labels are stable and user-visible.
+
+- U5. **Document support level and update release notes**
+
+**Goal:** Update user-facing docs and changelog to describe custom object CRUD/detail parity accurately.
+
+**Requirements:** R9
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `docs/universal-tools/user-guide.md`
+- Modify: `docs/universal-tools/api-reference.md`
+- Modify if relevant: `docs/universal-tools/troubleshooting.md`
+- Modify if relevant: `docs/api/api-overview.md`
+
+**Approach:**
+
+- Add a concise `[Unreleased]` changelog entry tied to #1161.
+- Update universal tools docs to say config-discovered custom object slugs are accepted for search plus `get_record_details`, `create_record`, `update_record`, and `delete_record`.
+- Include one example using a custom object slug directly as `resource_type`.
+- Note the dependency on running object/attribute discovery so the mapping config contains the custom object slug.
+- Avoid claiming batch, relationship-specific, or object-schema management parity.
+
+**Patterns to follow:**
+
+- Existing #1138 changelog entry for custom object search support.
+- Existing universal tools examples in `docs/universal-tools/user-guide.md` and `docs/universal-tools/api-reference.md`.
+
+**Test scenarios:**
+
+- Test expectation: none -- documentation-only unit. Verification is by review against the final implemented support level.
+
+**Verification:**
+
+- Docs no longer describe custom objects as generic `records` only and do not overstate unsupported batch or relationship-specific behavior.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** MCP tool params flow through `validateUniversalToolParams()`, into core tool configs, then into universal services. The change affects validation, service routing, generic record helpers, formatting, and docs for the four non-search record tools.
+- **Error propagation:** Unknown slugs should fail at validation. Config-discovered slugs should reach Attio and surface Attio validation/not-found errors through existing CRUD/detail error paths with custom object context.
+- **State lifecycle risks:** Create/update/delete are write operations. Incorrect custom object slug routing could mutate or delete records from the wrong object, so tests must assert the exact object slug passed to generic helpers.
+- **API surface parity:** Standard resources keep existing behavior. Search-family custom object support remains unchanged. Direct custom object slugs become first-class for details/create/update/delete.
+- **Integration coverage:** Unit tests prove routing and formatting. A real API smoke is useful if safe custom object test data exists, but the plan does not require creating production custom object data.
+- **Unchanged invariants:** Tool names, schema names, MCP approval annotations, and scoped company/deal tools remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                                                            | Mitigation                                                                                                                         |
+| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Dynamic validation accepts slugs that downstream services still type as enum-only                               | Broaden the service boundary deliberately and test each target operation with a non-standard slug.                                 |
+| Custom object create/update accidentally routes through the generic `records` object instead of the actual slug | Assert generic helper calls receive the custom slug from `resource_type`.                                                          |
+| Field validation rejects valid custom object attributes because no static mapping exists                        | Preserve pass-through behavior when static mappings are absent and rely on available-attribute discovery when possible.            |
+| Error and formatter helpers hide custom object labels behind `record`                                           | Add string-label tests for all four target tool families.                                                                          |
+| Real API behavior differs from offline mocks                                                                    | Use official Attio records endpoint contracts in design and run live smoke only when credentials and safe test data are available. |
+
+---
+
+## Documentation / Operational Notes
+
+- This PR should target issue #1161 and mention related context from #918 and #1138.
+- If `ATTIO_API_KEY` is available and a disposable custom object exists, run a read/write smoke against that object only with explicit cleanup. Otherwise, state the live validation gap in the PR.
+- Update docs after implementation so they match the actual supported edge cases rather than the intended design.
+
+---
+
+## Sources & References
+
+- Related issue: [#1161](https://github.com/kesslerio/attio-mcp-server/issues/1161)
+- Related issue: [#918](https://github.com/kesslerio/attio-mcp-server/issues/918)
+- Related issue: [#1138](https://github.com/kesslerio/attio-mcp-server/issues/1138)
+- Related code: `src/handlers/tool-configs/universal/validators/schema-validator.ts`
+- Related code: `src/handlers/tools/dispatcher/utils.ts`
+- Related code: `src/services/UniversalCreateService.ts`
+- Related code: `src/services/UniversalUpdateService.ts`
+- Related code: `src/services/UniversalRetrievalService.ts`
+- Related code: `src/services/UniversalDeleteService.ts`
+- Related code: `src/objects/records/index.ts`
+- External docs: [Attio create a record](https://docs.attio.com/rest-api/endpoint-reference/records/create-a-record)
+- External docs: [Attio get a record](https://docs.attio.com/rest-api/endpoint-reference/records/get-a-record)
+- External docs: [Attio update a record](https://docs.attio.com/rest-api/endpoint-reference/records/update-a-record-append-multiselect-values)
+- External docs: [Attio delete a record](https://docs.attio.com/rest-api/endpoint-reference/records/delete-a-record)

--- a/docs/universal-tools/api-reference.md
+++ b/docs/universal-tools/api-reference.md
@@ -13,11 +13,14 @@ enum UniversalResourceType {
   COMPANIES = 'companies',
   PEOPLE = 'people',
   RECORDS = 'records',
+  DEALS = 'deals',
   TASKS = 'tasks',
   LISTS = 'lists',
   NOTES = 'notes',
 }
 ```
+
+`search_records`, `search_records_advanced`, `search_records_by_timeframe`, `get_record_details`, `create_record`, `update_record`, and `delete_record` also accept custom object slugs discovered into the mapping configuration, such as `funds` or `investment_opportunities`.
 
 ## formatResult Architecture (Updated PR #483)
 
@@ -48,7 +51,7 @@ formatResult: (data: AttioRecord | AttioRecord[], resourceType?: UniversalResour
 
 ```typescript
 {
-  resource_type: 'companies' | 'people' | 'records' | 'tasks', // Required
+  resource_type: 'companies' | 'people' | 'records' | 'deals' | 'tasks' | '<custom_object_slug>', // Required
   query?: string,                    // Smart query string (names, emails, phones, domains)
   filters?: object,                  // Advanced filter conditions
   search_type?: 'basic' | 'content', // Search type (default: 'basic')
@@ -124,7 +127,7 @@ await client.callTool('records.search', {
 
 ```typescript
 {
-  resource_type: 'companies' | 'people' | 'records' | 'tasks', // Required
+  resource_type: 'companies' | 'people' | 'records' | 'deals' | 'tasks' | '<custom_object_slug>', // Required
   record_id: string,                 // Required - Record identifier
   fields?: string[]                  // Optional - Specific fields to include
 }
@@ -137,6 +140,12 @@ await client.callTool('records.search', {
 await client.callTool('records.get_details', {
   resource_type: 'companies',
   record_id: 'comp_123',
+});
+
+// Get custom object details
+await client.callTool('records.get_details', {
+  resource_type: 'funds',
+  record_id: 'fund_123',
 });
 
 // Get person details with specific fields
@@ -157,7 +166,7 @@ await client.callTool('records.get_details', {
 
 ```typescript
 {
-  resource_type: 'companies' | 'people' | 'records' | 'tasks', // Required
+  resource_type: 'companies' | 'people' | 'records' | 'deals' | 'tasks' | '<custom_object_slug>', // Required
   record_data: object,               // Required - Record creation data
   return_details?: boolean           // Optional - Return full record details
 }
@@ -186,6 +195,15 @@ await client.callTool('create-record', {
   },
   return_details: true,
 });
+
+// Create a custom object record
+await client.callTool('create-record', {
+  resource_type: 'funds',
+  record_data: {
+    name: 'Fund I',
+    stage: 'Active',
+  },
+});
 ```
 
 ### 4. update-record
@@ -198,7 +216,7 @@ await client.callTool('create-record', {
 
 ```typescript
 {
-  resource_type: 'companies' | 'people' | 'records' | 'tasks', // Required
+  resource_type: 'companies' | 'people' | 'records' | 'deals' | 'tasks' | '<custom_object_slug>', // Required
   record_id: string,                 // Required - Record identifier
   record_data: object,               // Required - Update data
   return_details?: boolean           // Optional - Return full record details
@@ -217,6 +235,15 @@ await client.callTool('update-record', {
     employee_count: 50,
   },
 });
+
+// Update a custom object record
+await client.callTool('update-record', {
+  resource_type: 'funds',
+  record_id: 'fund_123',
+  record_data: {
+    stage: 'Closed',
+  },
+});
 ```
 
 ### 5. delete-record
@@ -229,7 +256,7 @@ await client.callTool('update-record', {
 
 ```typescript
 {
-  resource_type: 'companies' | 'people' | 'records' | 'tasks', // Required
+  resource_type: 'companies' | 'people' | 'records' | 'deals' | 'tasks' | '<custom_object_slug>', // Required
   record_id: string                  // Required - Record identifier
 }
 ```
@@ -241,6 +268,12 @@ await client.callTool('update-record', {
 await client.callTool('delete-record', {
   resource_type: 'companies',
   record_id: 'comp_123',
+});
+
+// Delete a custom object record
+await client.callTool('delete-record', {
+  resource_type: 'funds',
+  record_id: 'fund_123',
 });
 ```
 

--- a/docs/universal-tools/user-guide.md
+++ b/docs/universal-tools/user-guide.md
@@ -253,6 +253,12 @@ resource_type: 'people';
 resource_type: 'records';
 ```
 
+For custom objects already discovered into the mapping configuration, you can also use the custom object slug directly with search, details, create, update, and delete tools:
+
+```typescript
+resource_type: 'funds';
+```
+
 **Tasks**: Use for activities, to-dos, follow-ups, scheduled actions
 
 ```typescript

--- a/docs/usage/universal-tools-quick-reference.md
+++ b/docs/usage/universal-tools-quick-reference.md
@@ -6,24 +6,26 @@ _Validated prompts that work perfectly with the Attio MCP Server's universal too
 
 The Attio MCP Server uses **14 universal tools** (68% reduction from 40+ tools) that handle all CRM operations through `resource_type` parameters:
 
-| **Universal Tool**               | **Purpose**                        | **Resource Types**                  |
-| -------------------------------- | ---------------------------------- | ----------------------------------- |
-| `records.search`                 | Basic search with filters          | companies, people, tasks, deals     |
-| `records.search_advanced`        | Multi-condition complex queries    | companies, people, tasks, deals     |
-| `records.get_details`            | Complete record information        | companies, people, tasks, deals     |
-| `create-record`                  | Create new records                 | companies, people, tasks, deals     |
-| `update-record`                  | Modify existing records            | companies, people, tasks, deals     |
-| `delete-record`                  | Remove records                     | companies, people, tasks, deals     |
-| `records.get_attributes`         | Available fields for resource type | companies, people, tasks, deals     |
-| `records.discover_attributes`    | Dynamic field discovery            | companies, people, tasks, deals     |
-| `records.get_info`               | Structured info by type            | companies, people                   |
-| `records.search_by_relationship` | Find connected records             | companies ↔ people                 |
-| `records.search_by_content`      | Text-based matching                | notes, activities, content          |
-| `records.search_by_timeframe`    | Date-based filtering               | created, modified, last_interaction |
-| `records.batch`                  | Bulk processing                    | create, update, delete, search      |
-| `records.search_batch`           | Multi-criteria batch search        | All resource types                  |
+| **Universal Tool**               | **Purpose**                        | **Resource Types**                                   |
+| -------------------------------- | ---------------------------------- | ---------------------------------------------------- |
+| `records.search`                 | Basic search with filters          | companies, people, tasks, deals, custom object slugs |
+| `records.search_advanced`        | Multi-condition complex queries    | companies, people, tasks, deals, custom object slugs |
+| `records.get_details`            | Complete record information        | companies, people, tasks, deals, custom object slugs |
+| `create-record`                  | Create new records                 | companies, people, tasks, deals, custom object slugs |
+| `update-record`                  | Modify existing records            | companies, people, tasks, deals, custom object slugs |
+| `delete-record`                  | Remove records                     | companies, people, tasks, deals, custom object slugs |
+| `records.get_attributes`         | Available fields for resource type | companies, people, tasks, deals                      |
+| `records.discover_attributes`    | Dynamic field discovery            | companies, people, tasks, deals                      |
+| `records.get_info`               | Structured info by type            | companies, people                                    |
+| `records.search_by_relationship` | Find connected records             | companies ↔ people                                   |
+| `records.search_by_content`      | Text-based matching                | notes, activities, content                           |
+| `records.search_by_timeframe`    | Date-based filtering               | created, modified, last_interaction                  |
+| `records.batch`                  | Bulk processing                    | create, update, delete, search                       |
+| `records.search_batch`           | Multi-criteria batch search        | All resource types                                   |
 
 **Plus 11 Lists Tools**: Complete pipeline and list management functionality
+
+Custom object slugs must be present in the generated mapping configuration, for example `resource_type="funds"`.
 
 ---
 

--- a/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
+++ b/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
@@ -87,7 +87,6 @@ const createErrorResult = (
 };
 
 import { getSingularResourceType } from '@/handlers/tool-configs/universal/shared-handlers.js';
-import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import {
   getPluralResourceLabel,
   type ValidationMetadata,
@@ -258,9 +257,7 @@ export const handleCreateError = async (
       logger
     );
     if (enhancedMessage) {
-      const resourceName = getSingularResourceType(
-        resourceType as UniversalResourceType
-      );
+      const resourceName = getSingularResourceType(resourceType);
       throw createErrorResult(
         `Failed to create ${resourceName}: ${enhancedMessage}`,
         enhancer.errorName,
@@ -279,9 +276,7 @@ export const handleCreateError = async (
       ? `${baseError}. Details: ${attioMessage}`
       : baseError;
   const errorResult = createErrorResult(
-    `Failed to create ${getSingularResourceType(
-      resourceType as UniversalResourceType
-    )}: ${errorMessage}`,
+    `Failed to create ${getSingularResourceType(resourceType)}: ${errorMessage}`,
     'create_error',
     { context, original: error }
   );
@@ -318,9 +313,7 @@ export const handleUpdateError = async (
 
   // Handle validation-specific errors with enhanced context
   if (error instanceof Error && error.message.includes('validation')) {
-    const resourceName = getSingularResourceType(
-      resourceType as UniversalResourceType
-    );
+    const resourceName = getSingularResourceType(resourceType);
     let errorMessage = `Failed to update ${resourceName}: Validation failed.`;
 
     if (validationMetadata?.warnings?.length) {
@@ -351,9 +344,7 @@ export const handleUpdateError = async (
       logger
     );
     if (enhancedMessage) {
-      const resourceName = getSingularResourceType(
-        resourceType as UniversalResourceType
-      );
+      const resourceName = getSingularResourceType(resourceType);
       throw createErrorResult(
         `Failed to update ${resourceName}: ${enhancedMessage}`,
         enhancer.errorName,
@@ -364,9 +355,7 @@ export const handleUpdateError = async (
 
   // Handle record not found errors
   if (error instanceof Error && error.message.includes('not found')) {
-    const resourceName = getSingularResourceType(
-      resourceType as UniversalResourceType
-    );
+    const resourceName = getSingularResourceType(resourceType);
     const errorResult = createErrorResult(
       `Failed to update ${resourceName}: Record not found. Please verify the record ID: ${recordId}`,
       'not_found_error',
@@ -386,9 +375,7 @@ export const handleUpdateError = async (
       ? `${baseErrorMessage}. Details: ${attioMessage}`
       : baseErrorMessage;
   const errorResult = createErrorResult(
-    `Failed to update ${getSingularResourceType(
-      resourceType as UniversalResourceType
-    )}: ${errorMessage}`,
+    `Failed to update ${getSingularResourceType(resourceType)}: ${errorMessage}`,
     'update_error',
     { context, original: error }
   );
@@ -417,9 +404,7 @@ export const handleDeleteError = async (
 
   // Handle delete-specific error patterns
   if (error instanceof Error && error.message.includes('not found')) {
-    const resourceName = getSingularResourceType(
-      resourceType as UniversalResourceType
-    );
+    const resourceName = getSingularResourceType(resourceType);
     const errorResult = createErrorResult(
       `Failed to delete ${resourceName}: Record not found. The record may have already been deleted.`,
       'not_found_error',
@@ -429,9 +414,7 @@ export const handleDeleteError = async (
   }
 
   if (error instanceof Error && error.message.includes('referenced')) {
-    const resourceName = getSingularResourceType(
-      resourceType as UniversalResourceType
-    );
+    const resourceName = getSingularResourceType(resourceType);
     const errorResult = createErrorResult(
       `Failed to delete ${resourceName}: Record is referenced by other records and cannot be deleted.`,
       'reference_constraint_error',
@@ -443,9 +426,7 @@ export const handleDeleteError = async (
   // Fallback to general delete error handling
   const errorMessage = error instanceof Error ? error.message : String(error);
   const errorResult = createErrorResult(
-    `Failed to delete ${getSingularResourceType(
-      resourceType as UniversalResourceType
-    )}: ${errorMessage}`,
+    `Failed to delete ${getSingularResourceType(resourceType)}: ${errorMessage}`,
     'delete_error',
     { context, original: error }
   );

--- a/src/handlers/tool-configs/universal/core/crud-operations.ts
+++ b/src/handlers/tool-configs/universal/core/crud-operations.ts
@@ -3,7 +3,6 @@ import {
   UniversalCreateParams,
   UniversalUpdateParams,
   UniversalDeleteParams,
-  UniversalResourceType,
 } from '@/handlers/tool-configs/universal/types.js';
 import type { UniversalRecord } from '@/types/attio.js';
 import { isAttioRecord } from '@/types/attio.js';
@@ -25,6 +24,7 @@ import {
   handleDeleteError,
 } from '@/handlers/tool-configs/universal/core/error-utils.js';
 import {
+  extractResourceTypeFromFormatArgs,
   extractDisplayName,
   formatValidationDetails,
   ValidationMetadata,
@@ -114,7 +114,7 @@ export const createRecordConfig: UniversalToolConfig<
     }
   },
   formatResult: (record: UniversalRecord, ...args: unknown[]): string => {
-    const resourceType = args[0] as UniversalResourceType | undefined;
+    const resourceType = extractResourceTypeFromFormatArgs(args);
     if (!record) {
       return 'Record creation failed';
     }
@@ -191,7 +191,7 @@ export const updateRecordConfig: UniversalToolConfig<
               actualValues: enhancedResult.validation.actualValues,
             },
           };
-        } catch (error: unknown) {
+        } catch {
           const standardResult = await handleUniversalUpdate(sanitizedParams);
           result = { ...standardResult };
         }
@@ -223,7 +223,7 @@ export const updateRecordConfig: UniversalToolConfig<
     }
   },
   formatResult: (record: UniversalRecord, ...args: unknown[]): string => {
-    const resourceType = args[0] as UniversalResourceType | undefined;
+    const resourceType = extractResourceTypeFromFormatArgs(args);
     if (!record) {
       return 'Record update failed';
     }
@@ -290,7 +290,7 @@ export const deleteRecordConfig: UniversalToolConfig<
     result: { success: boolean; record_id: string },
     ...args: unknown[]
   ): string => {
-    const resourceType = args[0] as UniversalResourceType | undefined;
+    const resourceType = extractResourceTypeFromFormatArgs(args);
     if (!result.success) {
       return `❌ Failed to delete ${
         resourceType ? getSingularResourceType(resourceType) : 'record'

--- a/src/handlers/tool-configs/universal/core/record-details-operations.ts
+++ b/src/handlers/tool-configs/universal/core/record-details-operations.ts
@@ -10,9 +10,10 @@ import {
   validateUniversalToolParams,
 } from '@/handlers/tool-configs/universal/schemas.js';
 import {
-  handleUniversalGetDetails,
-  getSingularResourceType,
-} from '@/handlers/tool-configs/universal/shared-handlers.js';
+  extractResourceTypeFromFormatArgs,
+  getSingularResourceLabel,
+} from '@/handlers/tool-configs/universal/core/utils.js';
+import { handleUniversalGetDetails } from '@/handlers/tool-configs/universal/shared-handlers.js';
 import { handleSearchError } from '@/handlers/tool-configs/universal/core/error-utils.js';
 import { UniversalUtilityService } from '@/services/UniversalUtilityService.js';
 import { formatToolDescription } from '@/handlers/tools/standards/index.js';
@@ -43,14 +44,12 @@ export const getRecordDetailsConfig: UniversalToolConfig<
     }
   },
   formatResult: (record: UniversalRecordResult, ...args: unknown[]): string => {
-    const resourceType = args[0] as UniversalResourceType | undefined;
+    const resourceType = extractResourceTypeFromFormatArgs(args);
     if (!record) {
       return 'Record not found';
     }
 
-    const resourceTypeName = resourceType
-      ? getSingularResourceType(resourceType)
-      : 'record';
+    const resourceTypeName = getSingularResourceLabel(resourceType);
 
     // Issue #1068: Lists have top-level fields (no values wrapper)
     // Handle lists explicitly before checking values

--- a/src/handlers/tool-configs/universal/core/value-extractors.ts
+++ b/src/handlers/tool-configs/universal/core/value-extractors.ts
@@ -191,13 +191,15 @@ const RESOURCE_FIELD_PRIORITIES: Record<
  */
 export const extractDisplayName = (
   values: Record<string, unknown> | undefined,
-  resourceType?: UniversalResourceType
+  resourceType?: string
 ): string => {
   if (!values || typeof values !== 'object') return 'Unnamed';
 
-  const priority = resourceType
-    ? RESOURCE_FIELD_PRIORITIES[resourceType]
-    : RESOURCE_FIELD_PRIORITIES[UniversalResourceType.RECORDS];
+  const resourceKey =
+    resourceType && resourceType in RESOURCE_FIELD_PRIORITIES
+      ? (resourceType as UniversalResourceType)
+      : UniversalResourceType.RECORDS;
+  const priority = RESOURCE_FIELD_PRIORITIES[resourceKey];
 
   // Try primary fields first
   for (const fieldName of priority.primaryFields) {

--- a/src/handlers/tool-configs/universal/field-mapper/config.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/config.ts
@@ -26,5 +26,5 @@ export const MappingDefaults: Record<
  * Determines if strict mode validation should be applied for a resource type
  * In strict mode, field validation errors become blocking errors instead of warnings
  */
-export const strictModeFor = (rt: UniversalResourceType): boolean =>
-  MappingDefaults[rt]?.strictMode ?? false;
+export const strictModeFor = (rt: string): boolean =>
+  MappingDefaults[rt as UniversalResourceType]?.strictMode ?? false;

--- a/src/handlers/tool-configs/universal/field-mapper/transformers/field-mapper.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/transformers/field-mapper.ts
@@ -12,11 +12,11 @@ import { attrHas } from '../validators/helpers.js';
  * Now attribute-aware to prevent incorrect mappings like typpe->type
  */
 export async function mapFieldName(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   fieldName: string,
   availableAttributes?: string[]
 ): Promise<string> {
-  const mapping = FIELD_MAPPINGS[resourceType];
+  const mapping = FIELD_MAPPINGS[resourceType as UniversalResourceType];
   if (!mapping) {
     return fieldName;
   }

--- a/src/handlers/tool-configs/universal/field-mapper/transformers/record-transformer.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/transformers/record-transformer.ts
@@ -16,7 +16,7 @@ import { transformFieldValue } from './value-transformer.js';
  * field mapping, value transformation, and special handling for complex fields
  */
 export async function mapRecordFields(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   recordData: Record<string, unknown>,
   availableAttributes?: string[]
 ): Promise<{
@@ -24,7 +24,7 @@ export async function mapRecordFields(
   warnings: string[];
   errors?: string[];
 }> {
-  const mapping = FIELD_MAPPINGS[resourceType];
+  const mapping = FIELD_MAPPINGS[resourceType as UniversalResourceType];
   if (!mapping) {
     return { mapped: recordData, warnings: [] };
   }

--- a/src/handlers/tool-configs/universal/field-mapper/transformers/value-transformer.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/transformers/value-transformer.ts
@@ -39,7 +39,7 @@ function toBooleanish(v: unknown): boolean | undefined {
  * Handles complex field value transformations for each resource type
  */
 export async function transformFieldValue(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   fieldName: string,
   value: unknown
 ): Promise<unknown> {

--- a/src/handlers/tool-configs/universal/field-mapper/validators/category-validator.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/validators/category-validator.ts
@@ -146,7 +146,7 @@ export function validateCategories(input: string | string[]): {
  * Main processing function that integrates validation with transformation
  */
 export function processCategories(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   fieldName: string,
   value: unknown
 ): {

--- a/src/handlers/tool-configs/universal/field-mapper/validators/collision-detector.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/validators/collision-detector.ts
@@ -12,11 +12,11 @@ import { mapFieldName } from '../transformers/field-mapper.js';
  * Provides intelligent recommendations based on field characteristics
  */
 function getFieldCollisionSuggestion(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   targetField: string,
   conflictingFields: string[]
 ): string {
-  const mapping = FIELD_MAPPINGS[resourceType];
+  const mapping = FIELD_MAPPINGS[resourceType as UniversalResourceType];
   if (!mapping) return '';
 
   // Check if any of the conflicting fields is the actual target field
@@ -44,7 +44,7 @@ function getFieldCollisionSuggestion(
  * Essential for preventing data overwrites and API conflicts
  */
 export async function detectFieldCollisions(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   recordData: Record<string, unknown>,
   availableAttributes?: string[]
 ): Promise<{
@@ -52,7 +52,7 @@ export async function detectFieldCollisions(
   errors: string[];
   collisions: Record<string, string[]>;
 }> {
-  const mapping = FIELD_MAPPINGS[resourceType];
+  const mapping = FIELD_MAPPINGS[resourceType as UniversalResourceType];
   if (!mapping) {
     return { hasCollisions: false, errors: [], collisions: {} };
   }

--- a/src/handlers/tool-configs/universal/field-mapper/validators/field-validator.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/validators/field-validator.ts
@@ -13,7 +13,7 @@ import { findSimilarStrings } from './similarity-utils.js';
  * Provides concrete examples based on resource type
  */
 function getRequiredFieldErrorMessage(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   fieldName: string
 ): string {
   const baseMessage = `Required field "${fieldName}" is missing`;
@@ -56,10 +56,10 @@ function getRequiredFieldErrorMessage(
  * Provides context-aware error messages and suggestions
  */
 export function getFieldSuggestions(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   fieldName: string
 ): string {
-  const mapping = FIELD_MAPPINGS[resourceType];
+  const mapping = FIELD_MAPPINGS[resourceType as UniversalResourceType];
   if (!mapping) {
     return `Unable to provide suggestions for resource type ${resourceType}`;
   }
@@ -93,7 +93,7 @@ export function getFieldSuggestions(
  * Performs comprehensive field validation with error categorization
  */
 export function validateFields(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   recordData: Record<string, unknown>
 ): {
   valid: boolean;
@@ -101,7 +101,7 @@ export function validateFields(
   warnings: string[];
   suggestions: string[];
 } {
-  const mapping = FIELD_MAPPINGS[resourceType];
+  const mapping = FIELD_MAPPINGS[resourceType as UniversalResourceType];
   if (!mapping) {
     return {
       valid: true,
@@ -175,6 +175,8 @@ export function validateFields(
  * Get valid fields for a resource type
  * Used for error messages and validation
  */
-export function getValidFields(resourceType: UniversalResourceType): string[] {
-  return FIELD_MAPPINGS[resourceType]?.validFields || [];
+export function getValidFields(resourceType: string): string[] {
+  return (
+    FIELD_MAPPINGS[resourceType as UniversalResourceType]?.validFields || []
+  );
 }

--- a/src/handlers/tool-configs/universal/field-mapper/validators/uniqueness-validator.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/validators/uniqueness-validator.ts
@@ -13,11 +13,11 @@ import { createScopedLogger } from '../../../../../utils/logger.js';
  * Converts technical API errors into user-friendly explanations
  */
 export async function enhanceUniquenessError(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   errorMessage: string,
   recordData: Record<string, unknown>
 ): Promise<string> {
-  const mapping = FIELD_MAPPINGS[resourceType];
+  const mapping = FIELD_MAPPINGS[resourceType as UniversalResourceType];
   if (!mapping || !mapping.uniqueFields) {
     return errorMessage;
   }

--- a/src/handlers/tool-configs/universal/shared-handlers.ts
+++ b/src/handlers/tool-configs/universal/shared-handlers.ts
@@ -315,7 +315,7 @@ export async function handleUniversalGetAttributes(
  * Universal discover attributes handler
  */
 export async function handleUniversalDiscoverAttributes(
-  resource_type: UniversalResourceType,
+  resource_type: string,
   options?: {
     categories?: string[]; // NEW: Category filtering support
   }
@@ -703,9 +703,7 @@ export function formatResourceType(
 /**
  * Utility function to get singular form of resource type
  */
-export function getSingularResourceType(
-  resourceType: UniversalResourceType
-): string {
+export function getSingularResourceType(resourceType: string): string {
   return UniversalUtilityService.getSingularResourceType(resourceType);
 }
 

--- a/src/handlers/tool-configs/universal/types.ts
+++ b/src/handlers/tool-configs/universal/types.ts
@@ -219,7 +219,7 @@ export interface UniversalSearchParams {
  * Universal record details parameters
  */
 export interface UniversalRecordDetailsParams {
-  resource_type: UniversalResourceType;
+  resource_type: string;
   record_id: string;
   fields?: string[];
 }
@@ -236,7 +236,7 @@ export interface GetRecordInteractionsParams {
  * Universal create record parameters
  */
 export interface UniversalCreateParams {
-  resource_type: UniversalResourceType;
+  resource_type: string;
   record_data: Record<string, unknown>;
   return_details?: boolean;
 }
@@ -245,7 +245,7 @@ export interface UniversalCreateParams {
  * Universal update record parameters
  */
 export interface UniversalUpdateParams {
-  resource_type: UniversalResourceType;
+  resource_type: string;
   record_id: string;
   record_data: Record<string, unknown>;
   return_details?: boolean;
@@ -255,7 +255,7 @@ export interface UniversalUpdateParams {
  * Universal delete record parameters
  */
 export interface UniversalDeleteParams {
-  resource_type: UniversalResourceType;
+  resource_type: string;
   record_id: string;
 }
 

--- a/src/handlers/tool-configs/universal/validators/schema-validator.ts
+++ b/src/handlers/tool-configs/universal/validators/schema-validator.ts
@@ -503,10 +503,15 @@ const toolValidators: Record<string, ToolValidator> = {
   },
 };
 
-const SEARCH_TOOLS_WITH_DYNAMIC_RESOURCE_TYPES = new Set([
+const TOOLS_WITH_DYNAMIC_RESOURCE_TYPES = new Set([
   'search_records',
   'search_records_advanced',
   'search_records_by_timeframe',
+  'get_record_details',
+  'records_get_details',
+  'create_record',
+  'update_record',
+  'delete_record',
 ]);
 
 function validateStandardResourceType(resourceType: string): string {
@@ -539,7 +544,7 @@ function validateDynamicSearchResourceType(resourceType: string): string {
     const suggestion = suggestResourceType(resourceType);
     const validTypes = getValidResourceTypes().join(', ');
     throw new UniversalValidationError(
-      `Invalid resource_type: '${resourceType}'`,
+      `Invalid resource_type: '${resourceType}'. Expected one of: ${validTypes}`,
       ErrorType.USER_ERROR,
       {
         field: 'resource_type',
@@ -577,10 +582,11 @@ export function validateUniversalToolParams(
   validateIdFields(sanitizedParams);
   if (sanitizedParams.resource_type) {
     const resourceType = String(sanitizedParams.resource_type);
-    sanitizedParams.resource_type =
-      SEARCH_TOOLS_WITH_DYNAMIC_RESOURCE_TYPES.has(toolName)
-        ? validateDynamicSearchResourceType(resourceType)
-        : validateStandardResourceType(resourceType);
+    sanitizedParams.resource_type = TOOLS_WITH_DYNAMIC_RESOURCE_TYPES.has(
+      toolName
+    )
+      ? validateDynamicSearchResourceType(resourceType)
+      : validateStandardResourceType(resourceType);
   }
   const validator = toolValidators[toolName];
   if (validator) return validator(sanitizedParams);

--- a/src/handlers/tools/dispatcher/utils.ts
+++ b/src/handlers/tools/dispatcher/utils.ts
@@ -2,7 +2,11 @@
  * Dispatcher utilities
  */
 
-import { loadMappingConfig } from '@/utils/config-loader.js';
+export {
+  STANDARD_RESOURCE_TYPES,
+  getValidResourceTypes,
+  canonicalizeResourceType,
+} from '@/utils/resource-types.js';
 
 /**
  * Normalize error messages by stripping tool execution prefixes.
@@ -14,43 +18,3 @@ export function normalizeToolMsg(msg: string): string {
 /**
  * Standard resource types always available in the system
  */
-export const STANDARD_RESOURCE_TYPES = [
-  'records',
-  'lists',
-  'people',
-  'companies',
-  'tasks',
-  'deals',
-  'notes',
-] as const;
-
-export function getValidResourceTypes(): string[] {
-  // Load custom objects from mapping config (e.g., "funds", "investment_opportunities")
-  const config = loadMappingConfig();
-  const customObjects = Object.keys(config.mappings?.attributes?.objects || {});
-
-  // Merge standard + custom (deduplicated)
-  return [...new Set([...STANDARD_RESOURCE_TYPES, ...customObjects])];
-}
-
-/**
- * Canonicalize resource type to valid values and prevent mutations.
- * Supports both standard types and custom objects discovered via config.
- *
- * Custom objects require running `attio-discover attributes -a` first
- * to populate the mapping config.
- */
-export function canonicalizeResourceType(rt: unknown): string {
-  const value = String(rt ?? '').toLowerCase();
-  const validTypes = getValidResourceTypes();
-
-  if (!validTypes.includes(value)) {
-    throw new Error(
-      `Invalid resource_type: ${value}. Must be one of: ${validTypes.join(
-        ', '
-      )}`
-    );
-  }
-
-  return value;
-}

--- a/src/services/CachingService.ts
+++ b/src/services/CachingService.ts
@@ -9,7 +9,6 @@
 import { AttioRecord } from '../types/attio.js';
 import { enhancedPerformanceTracker } from '../middleware/performance-enhanced.js';
 import { generateIdCacheKey } from '../utils/validation/id-validation.js';
-import { UniversalResourceType } from '../handlers/tool-configs/universal/types.js';
 import {
   DEFAULT_TASKS_CACHE_TTL,
   DEFAULT_404_CACHE_TTL,
@@ -31,7 +30,7 @@ interface CacheEntry {
 interface AttributeCacheEntry {
   data: Record<string, unknown>;
   timestamp: number;
-  resourceType: UniversalResourceType;
+  resourceType: string;
   objectSlug?: string;
 }
 
@@ -198,7 +197,7 @@ export class CachingService {
    * @returns Cache key string
    */
   private static getAttributeCacheKey(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     objectSlug?: string
   ): string {
     return objectSlug
@@ -215,7 +214,7 @@ export class CachingService {
    * @returns Cached attributes if available and valid, undefined otherwise
    */
   static getCachedAttributes(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     objectSlug?: string,
     ttl: number = DEFAULT_ATTRIBUTES_CACHE_TTL
   ): Record<string, unknown> | undefined {
@@ -245,7 +244,7 @@ export class CachingService {
    * @param objectSlug - Optional object slug for records
    */
   static setCachedAttributes(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     data: Record<string, unknown>,
     objectSlug?: string
   ): void {
@@ -269,7 +268,7 @@ export class CachingService {
    * @param objectSlug - Optional object slug to invalidate specific records cache
    */
   static invalidateAttributeCache(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     objectSlug?: string
   ): void {
     if (objectSlug) {
@@ -303,7 +302,7 @@ export class CachingService {
    */
   static async getOrLoadAttributes(
     dataLoader: () => Promise<Record<string, unknown>>,
-    resourceType: UniversalResourceType,
+    resourceType: string,
     objectSlug?: string,
     ttl: number = DEFAULT_ATTRIBUTES_CACHE_TTL
   ): Promise<{ data: Record<string, unknown>; fromCache: boolean }> {

--- a/src/services/UniversalCreateService.ts
+++ b/src/services/UniversalCreateService.ts
@@ -49,6 +49,11 @@ import {
   MAX_VALIDATION_SUGGESTIONS,
   MAX_SUGGESTION_TEXT_LENGTH,
 } from '@/constants/universal.constants.js';
+import {
+  isConfiguredCustomObjectResourceType,
+  isStandardResourceType,
+} from '@/utils/resource-type-detection.js';
+import { createObjectRecord } from '@/objects/records/index.js';
 
 // Import enhanced types for better type safety
 //
@@ -131,6 +136,12 @@ export class UniversalCreateService {
       }
     }
     const { resource_type } = params;
+    const isCustomObjectResource =
+      isConfiguredCustomObjectResourceType(resource_type);
+    if (!isStandardResourceType(resource_type) && !isCustomObjectResource) {
+      return this.handleUnsupportedResourceType(resource_type, params);
+    }
+
     const record_data = params.record_data; // Use the potentially parsed record_data
     if (
       !record_data ||
@@ -175,8 +186,9 @@ export class UniversalCreateService {
 
     // Issue #984: Display name resolution integration
     // Attempt to resolve display names (e.g., "Deal stage" → "stage") before validation
-    const objectSlug =
-      resource_type === UniversalResourceType.RECORDS
+    const objectSlug = isCustomObjectResource
+      ? resource_type
+      : resource_type === UniversalResourceType.RECORDS
         ? typeof record_data.object === 'string'
           ? record_data.object
           : typeof record_data.object_api_slug === 'string'
@@ -255,7 +267,7 @@ export class UniversalCreateService {
 
           // Update fieldsToValidate with resolved names
           if (resource_type === UniversalResourceType.RECORDS) {
-            const { values, ...topLevelFields } = record_data;
+            const { values: _values, ...topLevelFields } = record_data;
             fieldsToValidate =
               Object.keys(topLevelFields).length > 0
                 ? (topLevelFields as Record<string, unknown>)
@@ -322,7 +334,7 @@ export class UniversalCreateService {
       }
 
       // List available fields for this resource type
-      const mapping = FIELD_MAPPINGS[resource_type];
+      const mapping = FIELD_MAPPINGS[resource_type as UniversalResourceType];
       if (mapping && mapping.validFields.length > 0) {
         errorMessage += `\n\nAvailable fields for ${resource_type}:\n  ${mapping.validFields.join(
           ', '
@@ -364,6 +376,8 @@ export class UniversalCreateService {
           if (objectSlug && typeof objectSlug === 'string') {
             options.objectSlug = objectSlug;
           }
+        } else if (isCustomObjectResource) {
+          options.objectSlug = resource_type;
         }
 
         const attributeResult =
@@ -433,6 +447,8 @@ export class UniversalCreateService {
       logger.debug('RECORDS objectSlug extracted', {
         recordsObjectSlug,
       });
+    } else if (isCustomObjectResource) {
+      recordsObjectSlug = resource_type;
     }
 
     // Map field names to correct ones with collision detection
@@ -591,6 +607,17 @@ export class UniversalCreateService {
         });
       }
 
+      default: {
+        if (isCustomObjectResource) {
+          return (await createObjectRecord(
+            resource_type,
+            transformedData
+          )) as UniversalRecord;
+        }
+
+        return this.handleUnsupportedResourceType(resource_type, params);
+      }
+
       case UniversalResourceType.DEALS: {
         const { DealCreateStrategy } =
           await import('@/services/create/strategies/DealCreateStrategy.js');
@@ -617,9 +644,6 @@ export class UniversalCreateService {
           values: transformedData,
         });
       }
-
-      default:
-        return this.handleUnsupportedResourceType(resource_type, params);
     }
   }
 

--- a/src/services/UniversalDeleteService.ts
+++ b/src/services/UniversalDeleteService.ts
@@ -26,6 +26,7 @@ import { deleteObjectRecord } from '../objects/records/index.js';
 import { deleteTask, getTask } from '../objects/tasks.js';
 import { deleteNote } from '../objects/notes.js';
 import { shouldUseMockData } from './create/index.js';
+import { isConfiguredCustomObjectResourceType } from '../utils/resource-type-detection.js';
 
 /**
  * UniversalDeleteService provides centralized record deletion functionality
@@ -218,6 +219,11 @@ export class UniversalDeleteService {
       }
 
       default:
+        if (isConfiguredCustomObjectResourceType(resource_type)) {
+          await deleteObjectRecord(resource_type, record_id);
+          return { success: true, record_id };
+        }
+
         throw new Error(
           `Unsupported resource type for delete: ${resource_type}`
         );

--- a/src/services/UniversalMetadataService.ts
+++ b/src/services/UniversalMetadataService.ts
@@ -26,6 +26,7 @@ import type {
   DiscoveryMetricsSummary,
   MetricsFilter,
 } from './metadata/index.js';
+import { isConfiguredCustomObjectResourceType } from '../utils/resource-type-detection.js';
 
 class UniversalMetadataFacade {
   constructor(private readonly deps: MetadataServicesDeps) {}
@@ -47,7 +48,7 @@ class UniversalMetadataFacade {
   }
 
   async discoverAttributesForResourceType(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     options?: {
       categories?: string[];
       objectSlug?: string;
@@ -73,7 +74,7 @@ class UniversalMetadataFacade {
   }
 
   async getAttributesForRecord(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordId: string
   ): Promise<JsonObject> {
     return this.recordService.getAttributesForRecord(resourceType, recordId);
@@ -173,7 +174,7 @@ class UniversalMetadataFacade {
   }
 
   async discoverAttributes(
-    resource_type: UniversalResourceType,
+    resource_type: string,
     options?: {
       categories?: string[];
       objectSlug?: string;
@@ -249,6 +250,13 @@ class UniversalMetadataFacade {
         return this.discoverAttributesForResourceType(resource_type, options);
 
       default:
+        if (isConfiguredCustomObjectResourceType(resource_type)) {
+          return this.discoverAttributesForResourceType(resource_type, {
+            ...options,
+            objectSlug: options?.objectSlug ?? resource_type,
+          });
+        }
+
         throw new Error(
           `Unsupported resource type for discover attributes: ${resource_type}`
         );
@@ -284,7 +292,7 @@ export class UniversalMetadataService {
   }
 
   static async discoverAttributesForResourceType(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     options?: {
       categories?: string[];
       objectSlug?: string;
@@ -302,7 +310,7 @@ export class UniversalMetadataService {
   }
 
   static async getAttributesForRecord(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordId: string
   ): Promise<Record<string, unknown>> {
     return this.facade.getAttributesForRecord(resourceType, recordId);
@@ -352,7 +360,7 @@ export class UniversalMetadataService {
   }
 
   static async discoverAttributes(
-    resource_type: UniversalResourceType,
+    resource_type: string,
     options?: {
       categories?: string[];
       objectSlug?: string;

--- a/src/services/UniversalRetrievalService.ts
+++ b/src/services/UniversalRetrievalService.ts
@@ -46,6 +46,7 @@ import { getListDetails } from '@/objects/lists.js';
 import { getObjectRecord } from '@/objects/records/index.js';
 import { getTask } from '@/objects/tasks.js';
 import { getNote, normalizeNoteResponse } from '@/objects/notes.js';
+import { isConfiguredCustomObjectResourceType } from '@/utils/resource-type-detection.js';
 
 /**
  * UniversalRetrievalService provides centralized record retrieval functionality
@@ -323,7 +324,7 @@ export class UniversalRetrievalService {
    * Retrieve record by resource type with type-specific handling
    */
   private static async retrieveRecordByType(
-    resource_type: UniversalResourceType,
+    resource_type: string,
     record_id: string
   ): Promise<UniversalRecord> {
     switch (resource_type) {
@@ -349,6 +350,10 @@ export class UniversalRetrievalService {
         return this.retrieveNoteRecord(record_id);
 
       default:
+        if (isConfiguredCustomObjectResourceType(resource_type)) {
+          return await getObjectRecord(resource_type, record_id);
+        }
+
         throw new Error(
           `Unsupported resource type for get details: ${resource_type}`
         );
@@ -658,7 +663,7 @@ export class UniversalRetrievalService {
    * Check if a record exists (lightweight check)
    */
   static async recordExists(
-    resource_type: UniversalResourceType,
+    resource_type: string,
     record_id: string
   ): Promise<boolean> {
     try {

--- a/src/services/UniversalUpdateService.ts
+++ b/src/services/UniversalUpdateService.ts
@@ -43,13 +43,12 @@ import {
   UniversalValidationError,
   ErrorType,
 } from '@/handlers/tool-configs/universal/schemas.js';
-import { debug, error as logError } from '@/utils/logger.js';
+import { debug } from '@/utils/logger.js';
 
 // Import shared type definitions for better type safety
 import {
   createNotFoundError,
   type DataPayload,
-  isAttributeObject,
 } from '@/types/universal-service-types.js';
 
 // Import services
@@ -91,6 +90,7 @@ import {
   getValidResourceTypes,
   mapTaskFields,
 } from '@/handlers/tool-configs/universal/field-mapper.js';
+import { isConfiguredCustomObjectResourceType } from '@/utils/resource-type-detection.js';
 
 // Import validation utilities
 import { validateRecordFields } from '@/utils/validation-utils.js';
@@ -151,7 +151,12 @@ export class UniversalUpdateService {
   ): Promise<EnhancedUpdateResult> {
     // Validate resource type is supported
     const validResourceTypes = Object.values(UniversalResourceType);
-    if (!validResourceTypes.includes(params.resource_type)) {
+    if (
+      !validResourceTypes.includes(
+        params.resource_type as UniversalResourceType
+      ) &&
+      !isConfiguredCustomObjectResourceType(params.resource_type)
+    ) {
       throw new UniversalValidationError(
         `Unsupported resource type: ${params.resource_type}`,
         ErrorType.USER_ERROR,
@@ -216,7 +221,12 @@ export class UniversalUpdateService {
   ): Promise<UniversalRecord> {
     // Validate resource type is supported
     const validResourceTypes = Object.values(UniversalResourceType);
-    if (!validResourceTypes.includes(params.resource_type)) {
+    if (
+      !validResourceTypes.includes(
+        params.resource_type as UniversalResourceType
+      ) &&
+      !isConfiguredCustomObjectResourceType(params.resource_type)
+    ) {
       throw new UniversalValidationError(
         `Unsupported resource type: ${params.resource_type}`,
         ErrorType.USER_ERROR,

--- a/src/services/UniversalUtilityService.ts
+++ b/src/services/UniversalUtilityService.ts
@@ -37,7 +37,7 @@ export class UniversalUtilityService {
   /**
    * Utility function to format resource type for display
    */
-  static formatResourceType(resourceType: UniversalResourceType): string {
+  static formatResourceType(resourceType: string): string {
     switch (resourceType) {
       case UniversalResourceType.COMPANIES:
         return 'company';
@@ -59,7 +59,7 @@ export class UniversalUtilityService {
   /**
    * Utility function to get singular form of resource type
    */
-  static getSingularResourceType(resourceType: UniversalResourceType): string {
+  static getSingularResourceType(resourceType: string): string {
     return this.formatResourceType(resourceType);
   }
 

--- a/src/services/create/strategies/BaseCreateStrategy.ts
+++ b/src/services/create/strategies/BaseCreateStrategy.ts
@@ -2,10 +2,9 @@
  * BaseCreateStrategy - Interface for resource-specific create strategies
  */
 import type { AttioTask, UniversalRecord } from '@/types/attio.js';
-import type { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 
 export interface CreateStrategyParams {
-  resourceType: UniversalResourceType;
+  resourceType: string;
   values: Record<string, unknown>;
   context?: Record<string, unknown>;
 }

--- a/src/services/metadata/MetadataDiscoveryService.ts
+++ b/src/services/metadata/MetadataDiscoveryService.ts
@@ -158,7 +158,7 @@ export class DefaultMetadataDiscoveryService implements MetadataDiscoveryService
   }
 
   private async performAttributeDiscovery(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     options?: { categories?: string[] }
   ): Promise<MetadataResult> {
     const client = getLazyAttioClient();

--- a/src/services/metadata/MetadataErrorService.ts
+++ b/src/services/metadata/MetadataErrorService.ts
@@ -38,7 +38,7 @@ export class DefaultMetadataErrorService implements MetadataErrorService {
   }
 
   toRecordFetchError(
-    resourceType: UniversalResourceType,
+    resourceType: UniversalResourceType | string,
     recordId: string,
     error: unknown
   ): never {

--- a/src/services/metadata/MetadataRecordService.ts
+++ b/src/services/metadata/MetadataRecordService.ts
@@ -1,6 +1,5 @@
 import { getLazyAttioClient } from '../../api/lazy-client.js';
 import { OBJECT_SLUG_MAP } from '../../constants/universal.constants.js';
-import type { UniversalResourceType } from '../../handlers/tool-configs/universal/types.js';
 import type { MetadataErrorService, MetadataRecordService } from './types.js';
 import { OperationType as OperationTypeEnum } from '../../utils/logger.js';
 import { createScopedLogger } from '../../utils/logger.js';
@@ -15,7 +14,7 @@ export class DefaultMetadataRecordService implements MetadataRecordService {
   constructor(private readonly errorService: MetadataErrorService) {}
 
   async getAttributesForRecord(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordId: string
   ): Promise<Record<string, unknown>> {
     const client = getLazyAttioClient();

--- a/src/services/metadata/discovery-runner.ts
+++ b/src/services/metadata/discovery-runner.ts
@@ -1,4 +1,3 @@
-import type { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import type {
   CachedMetadataResult,
   MetadataCacheKey,
@@ -8,7 +7,7 @@ import type {
 } from './types.js';
 
 interface DiscoveryMetricsContext {
-  resourceType: UniversalResourceType;
+  resourceType: string;
   objectSlug?: string;
 }
 
@@ -76,7 +75,7 @@ export class DiscoveryRunner {
     result,
     error,
   }: {
-    resourceType: UniversalResourceType;
+    resourceType: string;
     objectSlug?: string;
     duration: number;
     cacheHit: boolean;

--- a/src/services/metadata/types.ts
+++ b/src/services/metadata/types.ts
@@ -9,7 +9,7 @@ export interface MetadataResult extends Record<string, unknown> {
 }
 
 export interface DiscoverTypeOptions {
-  resourceType: UniversalResourceType;
+  resourceType: string;
   categories?: string[];
   objectSlug?: string;
   useCache?: boolean;
@@ -28,7 +28,7 @@ export interface DiscoverObjectOptions {
 }
 
 export interface MetadataCacheKey {
-  resourceType: UniversalResourceType;
+  resourceType: string;
   objectSlug?: string;
 }
 
@@ -112,7 +112,7 @@ export interface MetadataDiscoveryService {
 
 export interface MetadataRecordService {
   getAttributesForRecord(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordId: string
   ): Promise<Record<string, unknown>>;
 }
@@ -123,7 +123,7 @@ export interface MetadataErrorService {
     error: unknown
   ): never;
   toRecordFetchError(
-    resourceType: UniversalResourceType,
+    resourceType: UniversalResourceType | string,
     recordId: string,
     error: unknown
   ): never;

--- a/src/services/update/FieldPersistenceHandler.ts
+++ b/src/services/update/FieldPersistenceHandler.ts
@@ -20,7 +20,6 @@
  * @see PR #1006 Phase 3.2 - Enhanced JSDoc for verification behavior
  */
 
-import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import { UpdateValidation } from '@/services/update/UpdateValidation.js';
 import { debug, error as logError } from '@/utils/logger.js';
 import {
@@ -92,7 +91,7 @@ export class FieldPersistenceHandler {
    * @throws UniversalValidationError if strict mode enabled and verification fails
    */
   static async verifyPersistence(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordId: string,
     expectedData: Record<string, unknown>,
     actualRecord?: Record<string, unknown>,

--- a/src/services/update/FieldValidationHandler.ts
+++ b/src/services/update/FieldValidationHandler.ts
@@ -7,7 +7,6 @@
  * @see Issue #984 - Extend display name resolution to create/update operations
  */
 
-import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import { validateFields } from '@/handlers/tool-configs/universal/field-mapper.js';
 import { ValidationService } from '@/services/ValidationService.js';
 import { debug, OperationType } from '@/utils/logger.js';
@@ -45,7 +44,7 @@ export class FieldValidationHandler {
    * @returns Validation result with warnings, suggestions, and resolved field names
    */
   static async validateAndResolve(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     values: Record<string, unknown>,
     objectSlug?: string,
     enableDisplayNameResolution: boolean = true

--- a/src/services/update/MetadataResolver.ts
+++ b/src/services/update/MetadataResolver.ts
@@ -41,7 +41,7 @@ export class MetadataResolver {
    * @returns Metadata map and available attributes for field mapping
    */
   static async fetchMetadata(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordData?: Record<string, unknown>
   ): Promise<MetadataResolutionResult> {
     const objectSlug = this.extractObjectSlug(resourceType, recordData);
@@ -129,7 +129,7 @@ export class MetadataResolver {
    * Fetch fresh metadata from Attio API
    */
   private static async fetchFreshMetadata(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     objectSlug?: string
   ): Promise<Record<string, unknown>> {
     const { UniversalMetadataService } =
@@ -146,7 +146,7 @@ export class MetadataResolver {
    * Extract object slug from resource type and record data
    */
   public static extractObjectSlug(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordData?: Record<string, unknown>
   ): string | undefined {
     if (resourceType === UniversalResourceType.RECORDS) {
@@ -158,6 +158,13 @@ export class MetadataResolver {
     }
     if (resourceType === UniversalResourceType.DEALS) {
       return 'deals';
+    }
+    if (
+      !Object.values(UniversalResourceType).includes(
+        resourceType as UniversalResourceType
+      )
+    ) {
+      return resourceType;
     }
     return undefined;
   }

--- a/src/services/update/ResponseNormalizer.ts
+++ b/src/services/update/ResponseNormalizer.ts
@@ -4,7 +4,7 @@ import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.j
 
 export const ResponseNormalizer = {
   normalizeResponseFormat(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     record: UniversalRecord
   ): UniversalRecord {
     if (!record || typeof record !== 'object') {
@@ -46,8 +46,22 @@ export const ResponseNormalizer = {
       case UniversalResourceType.RECORDS:
         return this.normalizeGenericRecord(normalized);
       default:
-        return normalized;
+        return this.normalizeCustomObjectRecord(resourceType, normalized);
     }
+  },
+
+  normalizeCustomObjectRecord(
+    resourceType: string,
+    record: AttioRecord
+  ): AttioRecord {
+    const idObj = (record.id as unknown as Record<string, unknown>) || {};
+    return {
+      ...record,
+      id: {
+        ...record.id,
+        object_id: (idObj.object_id as string) || resourceType,
+      },
+    } as AttioRecord;
   },
 
   normalizeCompanyRecord(record: AttioRecord): AttioRecord {

--- a/src/services/update/UpdateOrchestrator.ts
+++ b/src/services/update/UpdateOrchestrator.ts
@@ -8,6 +8,7 @@
  */
 
 import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
+import { isConfiguredCustomObjectResourceType } from '@/utils/resource-type-detection.js';
 import type { UniversalRecord } from '@/types/attio.js';
 import { debug } from '@/utils/logger.js';
 
@@ -16,7 +17,7 @@ import { debug } from '@/utils/logger.js';
  */
 export interface UpdateContext {
   /** Resource type being updated */
-  resourceType: UniversalResourceType;
+  resourceType: string;
   /** ID of the record to update */
   recordId: string;
   /** Sanitized values to update */
@@ -100,6 +101,17 @@ export class UpdateOrchestrator {
       }
 
       default: {
+        if (isConfiguredCustomObjectResourceType(resourceType)) {
+          const { RecordUpdateStrategy } =
+            await import('@/services/update/strategies/RecordUpdateStrategy.js');
+          return new RecordUpdateStrategy().update(
+            recordId,
+            sanitizedValues,
+            resourceType,
+            { objectSlug: objectSlug || resourceType }
+          );
+        }
+
         throw new Error(
           `Unsupported resource type for update: ${resourceType}`
         );

--- a/src/services/update/UpdateValidation.ts
+++ b/src/services/update/UpdateValidation.ts
@@ -11,7 +11,7 @@ import { getListDetails } from '@/objects/lists.js';
 import { getPersonDetails } from '@/objects/people/basic.js';
 import { getObjectRecord } from '@/objects/records/index.js';
 import { getTask } from '@/objects/tasks.js';
-import type { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
+import { isConfiguredCustomObjectResourceType } from '@/utils/resource-type-detection.js';
 import { createScopedLogger } from '@/utils/logger.js';
 
 export const UpdateValidation = {
@@ -53,7 +53,7 @@ export const UpdateValidation = {
   },
 
   async verifyFieldPersistence(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordId: string,
     expectedUpdates: Record<string, unknown>
   ): Promise<{
@@ -137,29 +137,33 @@ export const UpdateValidation = {
   },
 
   async fetchRecordForVerification(
-    resourceType: UniversalResourceType,
+    resourceType: string,
     recordId: string
   ): Promise<UniversalRecord | null> {
     try {
       switch (resourceType) {
-        case 'companies' as unknown as UniversalResourceType:
+        case 'companies':
           return await getCompanyDetails(recordId);
-        case 'people' as unknown as UniversalResourceType:
+        case 'people':
           return await getPersonDetails(recordId);
-        case 'lists' as unknown as UniversalResourceType: {
+        case 'lists': {
           const list = await getListDetails(recordId);
           const resolvedName = list.name || list.title;
           return resolvedName ? { ...list, name: resolvedName } : list;
         }
-        case 'tasks' as unknown as UniversalResourceType: {
+        case 'tasks': {
           const task = await getTask(recordId);
           return UniversalUtilityService.convertTaskToRecord(task);
         }
-        case 'deals' as unknown as UniversalResourceType:
+        case 'deals':
           return await getObjectRecord('deals', recordId);
-        case 'records' as unknown as UniversalResourceType:
+        case 'records':
           return await getObjectRecord('records', recordId);
         default:
+          if (isConfiguredCustomObjectResourceType(resourceType)) {
+            return await getObjectRecord(resourceType, recordId);
+          }
+
           createScopedLogger(
             'update/UpdateValidation',
             'fetchRecordForVerification'

--- a/src/services/update/strategies/BaseUpdateStrategy.ts
+++ b/src/services/update/strategies/BaseUpdateStrategy.ts
@@ -6,14 +6,13 @@
  * mapping, sanitization, and post-update verification.
  */
 
-import type { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import type { UniversalRecord } from '@/types/attio.js';
 
 export interface UpdateStrategy {
   update(
     recordId: string,
     values: Record<string, unknown>,
-    resourceType: UniversalResourceType,
+    resourceType: string,
     context?: Record<string, unknown>
   ): Promise<UniversalRecord>;
 }

--- a/src/services/update/strategies/CompanyUpdateStrategy.ts
+++ b/src/services/update/strategies/CompanyUpdateStrategy.ts
@@ -5,7 +5,6 @@ import {
   UniversalValidationError,
   ErrorType,
 } from '../../../handlers/tool-configs/universal/schemas.js';
-import type { UniversalResourceType } from '../../../handlers/tool-configs/universal/types.js';
 import type { UpdateStrategy } from './BaseUpdateStrategy.js';
 
 /**
@@ -15,7 +14,7 @@ export class CompanyUpdateStrategy implements UpdateStrategy {
   async update(
     recordId: string,
     values: Record<string, unknown>,
-    resourceType: UniversalResourceType
+    resourceType: string
   ): Promise<AttioRecord> {
     try {
       // Extract values from Attio envelope for legacy updateCompany function

--- a/src/services/update/strategies/ListUpdateStrategy.ts
+++ b/src/services/update/strategies/ListUpdateStrategy.ts
@@ -3,7 +3,6 @@ import {
   UniversalValidationError,
   ErrorType,
 } from '@/handlers/tool-configs/universal/schemas.js';
-import type { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import { updateList } from '@/objects/lists.js';
 import type { AttioList } from '@/types/attio.js';
 import type { UpdateStrategy } from '@/services/update/strategies/BaseUpdateStrategy.js';
@@ -18,7 +17,7 @@ export class ListUpdateStrategy implements UpdateStrategy {
   async update(
     recordId: string,
     values: Record<string, unknown>,
-    resourceType: UniversalResourceType
+    resourceType: string
   ): Promise<AttioList> {
     try {
       const list = await updateList(recordId, values);

--- a/src/services/update/strategies/PersonUpdateStrategy.ts
+++ b/src/services/update/strategies/PersonUpdateStrategy.ts
@@ -6,7 +6,6 @@ import {
   UniversalValidationError,
   ErrorType,
 } from '../../../handlers/tool-configs/universal/schemas.js';
-import type { UniversalResourceType } from '../../../handlers/tool-configs/universal/types.js';
 import type { UpdateStrategy } from './BaseUpdateStrategy.js';
 import { ValidationService } from '../../ValidationService.js';
 
@@ -17,7 +16,7 @@ export class PersonUpdateStrategy implements UpdateStrategy {
   async update(
     recordId: string,
     values: Record<string, unknown>,
-    resourceType: UniversalResourceType
+    resourceType: string
   ): Promise<AttioRecord> {
     try {
       // Validate emails same as create operations

--- a/src/services/update/strategies/RecordUpdateStrategy.ts
+++ b/src/services/update/strategies/RecordUpdateStrategy.ts
@@ -1,6 +1,5 @@
 import type { AttioRecord } from '../../../types/attio.js';
 import { updateObjectRecord } from '../../../objects/records/index.js';
-import type { UniversalResourceType } from '../../../handlers/tool-configs/universal/types.js';
 import type { UpdateStrategy } from './BaseUpdateStrategy.js';
 
 /**
@@ -13,11 +12,11 @@ export class RecordUpdateStrategy implements UpdateStrategy {
   async update(
     recordId: string,
     values: Record<string, unknown>,
-    resourceType: UniversalResourceType,
+    resourceType: string,
     context?: Record<string, unknown>
   ): Promise<AttioRecord> {
     // For deals, use 'deals' as the object slug since validation is already handled upstream
-    if (resourceType === ('deals' as unknown as UniversalResourceType)) {
+    if (resourceType === 'deals') {
       return updateObjectRecord('deals', recordId, values);
     }
 

--- a/src/services/update/strategies/TaskUpdateStrategy.ts
+++ b/src/services/update/strategies/TaskUpdateStrategy.ts
@@ -1,5 +1,4 @@
 import type { AttioRecord } from '../../../types/attio.js';
-import type { UniversalResourceType } from '../../../handlers/tool-configs/universal/types.js';
 import type { UpdateStrategy } from './BaseUpdateStrategy.js';
 import { shouldUseMockData, getCreateService } from '../../create/index.js';
 import { getTask } from '../../../objects/tasks.js';
@@ -9,7 +8,7 @@ export class TaskUpdateStrategy implements UpdateStrategy {
   async update(
     recordId: string,
     values: Record<string, unknown>,
-    _resourceType: UniversalResourceType
+    _resourceType: string
   ): Promise<AttioRecord> {
     if (_resourceType !== 'tasks') {
       throw new Error(

--- a/src/services/value-transformer/index.ts
+++ b/src/services/value-transformer/index.ts
@@ -31,7 +31,6 @@ import {
   transformRecordReferenceValue,
   isCorrectRecordReferenceFormat,
 } from './record-reference-transformer.js';
-import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
 import { convertToMetadataMap } from '@/utils/metadata-utils.js';
 import { handleUniversalDiscoverAttributes } from '@/handlers/tool-configs/universal/shared-handlers.js';
 import { debug, error as logError, OperationType } from '@/utils/logger.js';
@@ -57,7 +56,7 @@ export function clearAllCaches(): void {
  * @see Issue #984 - Now uses CachingService with TTL and accepts provided metadata
  */
 async function getAttributeMetadata(
-  resourceType: UniversalResourceType,
+  resourceType: string,
   providedMetadata?: Map<string, AttributeMetadata>
 ): Promise<Map<string, AttributeMetadata>> {
   // Use provided metadata if available (avoid duplicate fetch)
@@ -323,7 +322,7 @@ export async function transformRecordValues(
  */
 export function mayNeedTransformation(
   recordData: Record<string, unknown>,
-  resourceType: UniversalResourceType
+  resourceType: string
 ): boolean {
   // Known status fields by resource type
   const statusFields: Record<string, string[]> = {

--- a/src/services/value-transformer/types.ts
+++ b/src/services/value-transformer/types.ts
@@ -3,14 +3,12 @@
  * Auto-transforms values before API calls to prevent common errors
  */
 
-import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
-
 /**
  * Context provided to transformers
  */
 export interface TransformContext {
   /** The resource type being operated on */
-  resourceType: UniversalResourceType;
+  resourceType: string;
   /** The operation type (create or update) */
   operation: 'create' | 'update';
   /** Optional record ID for updates */

--- a/src/utils/resource-type-detection.ts
+++ b/src/utils/resource-type-detection.ts
@@ -1,0 +1,26 @@
+import { UniversalResourceType } from '@/handlers/tool-configs/universal/types.js';
+import { getValidResourceTypes } from '@/utils/resource-types.js';
+
+export function isStandardResourceType(
+  resourceType: string
+): resourceType is UniversalResourceType {
+  return Object.values(UniversalResourceType).includes(
+    resourceType as UniversalResourceType
+  );
+}
+
+export function isConfiguredCustomObjectResourceType(
+  resourceType: string
+): boolean {
+  return (
+    !isStandardResourceType(resourceType) &&
+    getValidResourceTypes().includes(resourceType)
+  );
+}
+
+export function isSupportedResourceType(resourceType: string): boolean {
+  return (
+    isStandardResourceType(resourceType) ||
+    isConfiguredCustomObjectResourceType(resourceType)
+  );
+}

--- a/src/utils/resource-types.ts
+++ b/src/utils/resource-types.ts
@@ -1,0 +1,40 @@
+import { loadMappingConfig } from '@/utils/config-loader.js';
+
+/**
+ * Standard resource types always available in the system.
+ */
+export const STANDARD_RESOURCE_TYPES = [
+  'records',
+  'lists',
+  'people',
+  'companies',
+  'tasks',
+  'deals',
+  'notes',
+] as const;
+
+export function getValidResourceTypes(): string[] {
+  const config = loadMappingConfig();
+  const customObjects = Object.keys(config.mappings?.attributes?.objects || {});
+
+  return [...new Set([...STANDARD_RESOURCE_TYPES, ...customObjects])];
+}
+
+/**
+ * Canonicalize resource type to valid values and prevent mutations.
+ * Supports both standard types and custom objects discovered via config.
+ */
+export function canonicalizeResourceType(rt: unknown): string {
+  const value = String(rt ?? '').toLowerCase();
+  const validTypes = getValidResourceTypes();
+
+  if (!validTypes.includes(value)) {
+    throw new Error(
+      `Invalid resource_type: ${value}. Must be one of: ${validTypes.join(
+        ', '
+      )}`
+    );
+  }
+
+  return value;
+}

--- a/test/handlers/tool-configs/universal/core-operations-crud.test.ts
+++ b/test/handlers/tool-configs/universal/core-operations-crud.test.ts
@@ -106,6 +106,28 @@ describe('Universal Core Operations CRUD Tests', () => {
         '✅ Successfully created company: New Company (ID: comp-new)'
       );
     });
+
+    it('should format custom object create results from dispatcher-style args', async () => {
+      const mockRecord = {
+        id: { record_id: 'fund-new' },
+        values: {
+          name: 'Fund I',
+        },
+      };
+
+      const { getSingularResourceType } =
+        await import('../../../../src/handlers/tool-configs/universal/shared-handlers.js');
+      vi.mocked(getSingularResourceType).mockReturnValue('funds');
+
+      const formatted = (createRecordConfig.formatResult as any)(mockRecord, {
+        resource_type: 'funds',
+      });
+
+      expect(getSingularResourceType).toHaveBeenCalledWith('funds');
+      expect(formatted).toBe(
+        '✅ Successfully created funds: Fund I (ID: fund-new)'
+      );
+    });
   });
 
   describe('update-record tool', () => {
@@ -158,6 +180,28 @@ describe('Universal Core Operations CRUD Tests', () => {
         '✅ Successfully updated company: Updated Company (ID: comp-1)'
       );
     });
+
+    it('should format custom object update results from dispatcher-style args', async () => {
+      const mockRecord = {
+        id: { record_id: 'fund-1' },
+        values: {
+          name: [{ value: 'Updated Fund' }],
+        },
+      };
+
+      const { getSingularResourceType } =
+        await import('../../../../src/handlers/tool-configs/universal/shared-handlers.js');
+      vi.mocked(getSingularResourceType).mockReturnValue('funds');
+
+      const formatted = (updateRecordConfig.formatResult as any)(mockRecord, {
+        resource_type: 'funds',
+      });
+
+      expect(getSingularResourceType).toHaveBeenCalledWith('funds');
+      expect(formatted).toBe(
+        '✅ Successfully updated funds: Updated Fund (ID: fund-1)'
+      );
+    });
   });
 
   describe('delete-record tool', () => {
@@ -205,6 +249,20 @@ describe('Universal Core Operations CRUD Tests', () => {
         UniversalResourceType.COMPANIES
       );
       expect(formatted).toBe('❌ Failed to delete company with ID: comp-1');
+    });
+
+    it('should format custom object delete results from dispatcher-style args', async () => {
+      const mockResult = { success: true, record_id: 'fund-1' };
+      const { getSingularResourceType } =
+        await import('../../../../src/handlers/tool-configs/universal/shared-handlers.js');
+      vi.mocked(getSingularResourceType).mockReturnValue('funds');
+
+      const formatted = (deleteRecordConfig.formatResult as any)(mockResult, {
+        resource_type: 'funds',
+      });
+
+      expect(getSingularResourceType).toHaveBeenCalledWith('funds');
+      expect(formatted).toBe('✅ Successfully deleted funds with ID: fund-1');
     });
   });
 });

--- a/test/handlers/tool-configs/universal/core-operations-search.test.ts
+++ b/test/handlers/tool-configs/universal/core-operations-search.test.ts
@@ -268,6 +268,23 @@ describe('Universal Core Operations Search Tests', () => {
       expect(formatted).toContain('Domains: test.com');
       expect(formatted).toContain('Primary location: San Francisco, CA');
     });
+
+    it('should format custom object details from dispatcher-style args', () => {
+      const mockRecord = {
+        id: { record_id: 'fund-1' },
+        values: {
+          name: [{ value: 'Fund I' }],
+        },
+      };
+
+      const formatted = (getRecordDetailsConfig.formatResult as any)(
+        mockRecord,
+        { resource_type: 'funds' }
+      );
+
+      expect(formatted).toContain('Funds: Fund I');
+      expect(formatted).toContain('ID: fund-1');
+    });
   });
 
   describe('Cross-resource type validation', () => {

--- a/test/services/UniversalCreateService-objects-deals-tasks.test.ts
+++ b/test/services/UniversalCreateService-objects-deals-tasks.test.ts
@@ -65,6 +65,17 @@ vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
 vi.mock('../../src/objects/records/index.js', () => ({
   createObjectRecord: vi.fn(),
 }));
+vi.mock('@/utils/config-loader.js', () => ({
+  loadMappingConfig: vi.fn(() => ({
+    mappings: {
+      attributes: {
+        objects: {
+          funds: {},
+        },
+      },
+    },
+  })),
+}));
 // Mock the create service factory to return a mock service
 const mockCreateService = {
   createCompany: vi.fn(),
@@ -133,6 +144,29 @@ describe('UniversalCreateService', () => {
       });
       expect(createObjectRecord).toHaveBeenCalledWith('companies', {
         values: { name: 'Test Record' },
+      });
+      expect(result).toEqual(mockRecord);
+    });
+
+    it('should create a config-discovered custom object record', async () => {
+      const mockRecord: AttioRecord = {
+        id: { record_id: 'fund_123' },
+        values: { name: 'Fund I' },
+      } as any;
+      vi.mocked(createObjectRecord).mockResolvedValue(mockRecord);
+
+      const result = await UniversalCreateService.createRecord({
+        resource_type: 'funds',
+        record_data: { values: { name: 'Fund I' } },
+      });
+
+      expect(mapRecordFields).toHaveBeenCalledWith(
+        'funds',
+        { name: 'Fund I' },
+        []
+      );
+      expect(createObjectRecord).toHaveBeenCalledWith('funds', {
+        name: 'Fund I',
       });
       expect(result).toEqual(mockRecord);
     });

--- a/test/services/UniversalDeleteService.test.ts
+++ b/test/services/UniversalDeleteService.test.ts
@@ -38,6 +38,18 @@ vi.mock('../../src/services/create/index.js', () => ({
   shouldUseMockData: vi.fn(),
 }));
 
+vi.mock('@/utils/config-loader.js', () => ({
+  loadMappingConfig: vi.fn(() => ({
+    mappings: {
+      attributes: {
+        objects: {
+          funds: {},
+        },
+      },
+    },
+  })),
+}));
+
 import { deleteCompany } from '../../src/objects/companies/index.js';
 import { deletePerson } from '../../src/objects/people-write.js';
 import { deleteList } from '../../src/objects/lists.js';
@@ -120,6 +132,31 @@ describe('UniversalDeleteService', () => {
 
       expect(deleteObjectRecord).toHaveBeenCalledWith('deals', 'deal_def');
       expect(result).toEqual({ success: true, record_id: 'deal_def' });
+    });
+
+    it('should delete a config-discovered custom object record', async () => {
+      vi.mocked(deleteObjectRecord).mockResolvedValue(undefined);
+
+      const result = await UniversalDeleteService.deleteRecord({
+        resource_type: 'funds',
+        record_id: 'fund_123',
+      });
+
+      expect(deleteObjectRecord).toHaveBeenCalledWith('funds', 'fund_123');
+      expect(result).toEqual({ success: true, record_id: 'fund_123' });
+    });
+
+    it('should surface custom object slug in deletion failures', async () => {
+      vi.mocked(deleteObjectRecord).mockRejectedValue(
+        new Error('funds record not found')
+      );
+
+      await expect(
+        UniversalDeleteService.deleteRecord({
+          resource_type: 'funds',
+          record_id: 'fund_404',
+        })
+      ).rejects.toThrow('funds record not found');
     });
 
     it('should delete a task record in normal mode', async () => {

--- a/test/services/UniversalRetrievalService-core-operations.test.ts
+++ b/test/services/UniversalRetrievalService-core-operations.test.ts
@@ -22,7 +22,10 @@ vi.mock('../../src/middleware/performance-enhanced.js', () => ({
   },
 }));
 vi.mock('../../src/utils/validation/uuid-validation.js', () => ({
-  createRecordNotFoundError: vi.fn(() => new Error('Record not found')),
+  createRecordNotFoundError: vi.fn(
+    (recordId: string, resourceType: string) =>
+      new Error(`${resourceType} record not found: ${recordId}`)
+  ),
 }));
 vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
   ErrorEnhancer: {
@@ -64,6 +67,17 @@ vi.mock('../../src/objects/tasks.js', () => ({ getTask: vi.fn() }));
 vi.mock('../../src/objects/notes.js', () => ({ getNote: vi.fn() }));
 vi.mock('../../src/services/create/index.js', () => ({
   shouldUseMockData: vi.fn(),
+}));
+vi.mock('@/utils/config-loader.js', () => ({
+  loadMappingConfig: vi.fn(() => ({
+    mappings: {
+      attributes: {
+        objects: {
+          funds: {},
+        },
+      },
+    },
+  })),
 }));
 import { describe, it, expect, beforeEach } from 'vitest';
 import { UniversalRetrievalService } from '../../src/services/UniversalRetrievalService.js';
@@ -182,6 +196,54 @@ describe('UniversalRetrievalService', () => {
 
       expect(getObjectRecord).toHaveBeenCalledWith('deals', 'deal_def');
       expect(result).toEqual(mockRecord);
+    });
+
+    it('should retrieve a config-discovered custom object record', async () => {
+      vi.mocked(getObjectRecord).mockResolvedValue(mockRecord);
+
+      const result = await UniversalRetrievalService.getRecordDetails({
+        resource_type: 'funds',
+        record_id: 'record_fund_123',
+      });
+
+      expect(getObjectRecord).toHaveBeenCalledWith('funds', 'record_fund_123');
+      expect(result).toEqual(mockRecord);
+    });
+
+    it('should filter fields for a config-discovered custom object record', async () => {
+      vi.mocked(getObjectRecord).mockResolvedValue({
+        id: { record_id: 'record_fund_123' },
+        values: {
+          name: [{ value: 'Fund I' }],
+          stage: [{ value: 'Active' }],
+        },
+      } as any);
+
+      const result = await UniversalRetrievalService.getRecordDetails({
+        resource_type: 'funds',
+        record_id: 'record_fund_123',
+        fields: ['name'],
+      });
+
+      expect(result).toEqual({
+        id: { record_id: 'record_fund_123' },
+        created_at: undefined,
+        updated_at: undefined,
+        values: { name: 'Fund I' },
+      });
+    });
+
+    it('should surface custom object slug in retrieval failures', async () => {
+      vi.mocked(getObjectRecord).mockRejectedValue(
+        new Error('funds record not found')
+      );
+
+      await expect(
+        UniversalRetrievalService.getRecordDetails({
+          resource_type: 'funds',
+          record_id: 'record_fund_404',
+        })
+      ).rejects.toThrow('funds record not found');
     });
 
     it('should retrieve a task record and convert to AttioRecord', async () => {

--- a/test/services/UniversalUpdateService-core-operations.test.ts
+++ b/test/services/UniversalUpdateService-core-operations.test.ts
@@ -44,6 +44,17 @@ vi.mock('../../src/services/MockService.js', () => ({
     isUsingMockData: vi.fn().mockReturnValue(true),
   },
 }));
+vi.mock('@/utils/config-loader.js', () => ({
+  loadMappingConfig: vi.fn(() => ({
+    mappings: {
+      attributes: {
+        objects: {
+          funds: {},
+        },
+      },
+    },
+  })),
+}));
 import { UniversalUpdateService } from '../../src/services/UniversalUpdateService.js';
 import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
 import { AttioRecord } from '../../src/types/attio.js';
@@ -196,6 +207,35 @@ describe('UniversalUpdateService', () => {
         expect.any(Object) // Don't assert on exact data since validation logic has changed
       );
       expect(result.id.object_id).toBe('deals');
+    });
+
+    it('should update a config-discovered custom object record', async () => {
+      const mockRecord: AttioRecord = {
+        id: { record_id: 'fund_123' },
+        values: { name: 'Updated Fund' },
+      } as any;
+      vi.mocked(updateObjectRecord).mockResolvedValue(mockRecord);
+      vi.mocked(mapRecordFields).mockReturnValue({
+        mapped: { name: 'Updated Fund' },
+        warnings: [],
+        errors: [],
+      } as any);
+
+      const result = await UniversalUpdateService.updateRecord({
+        resource_type: 'funds',
+        record_id: 'fund_123',
+        record_data: { values: { name: 'Updated Fund' } },
+      });
+
+      expect(mapRecordFields).toHaveBeenCalledWith(
+        'funds',
+        { name: 'Updated Fund' },
+        expect.any(Array)
+      );
+      expect(updateObjectRecord).toHaveBeenCalledWith('funds', 'fund_123', {
+        name: 'Updated Fund',
+      });
+      expect(result.id.object_id).toBe('funds');
     });
 
     it('should update a task record with field transformation (excluding immutable content)', async () => {

--- a/test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts
+++ b/test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts
@@ -353,7 +353,7 @@ describe('validateUniversalToolParams', () => {
       ).toThrow("Invalid resource_type: 'unknown_object'");
     });
 
-    it('keeps non-search tools on standard enum validation', () => {
+    it('accepts config-discovered custom objects for detail and CRUD tools', () => {
       vi.mocked(loadMappingConfig).mockReturnValue({
         version: '1.0',
         mappings: {
@@ -370,12 +370,84 @@ describe('validateUniversalToolParams', () => {
         },
       });
 
-      expect(() =>
+      expect(
+        validateUniversalToolParams('get_record_details', {
+          resource_type: 'FUNDS',
+          record_id: 'record_123',
+        }).resource_type
+      ).toBe('funds');
+
+      expect(
         validateUniversalToolParams('create_record', {
           resource_type: 'funds',
           record_data: { name: 'Fund I' },
-        })
-      ).toThrow("Invalid resource_type: 'funds'");
+        }).resource_type
+      ).toBe('funds');
+
+      expect(
+        validateUniversalToolParams('update_record', {
+          resource_type: 'funds',
+          record_id: 'record_123',
+          record_data: { name: 'Fund II' },
+        }).resource_type
+      ).toBe('funds');
+
+      expect(
+        validateUniversalToolParams('delete_record', {
+          resource_type: 'funds',
+          record_id: 'record_123',
+        }).resource_type
+      ).toBe('funds');
+    });
+
+    it('rejects unknown custom objects for detail and CRUD tools with discovered options', () => {
+      vi.mocked(loadMappingConfig).mockReturnValue({
+        version: '1.0',
+        mappings: {
+          attributes: {
+            common: {},
+            objects: {
+              funds: { name: 'Name' },
+            },
+            custom: {},
+          },
+          objects: {},
+          lists: {},
+          relationships: {},
+        },
+      });
+
+      const cases = [
+        {
+          toolName: 'get_record_details',
+          params: { resource_type: 'unknown_object', record_id: 'record_123' },
+        },
+        {
+          toolName: 'create_record',
+          params: {
+            resource_type: 'unknown_object',
+            record_data: { name: 'Unknown' },
+          },
+        },
+        {
+          toolName: 'update_record',
+          params: {
+            resource_type: 'unknown_object',
+            record_id: 'record_123',
+            record_data: { name: 'Unknown' },
+          },
+        },
+        {
+          toolName: 'delete_record',
+          params: { resource_type: 'unknown_object', record_id: 'record_123' },
+        },
+      ];
+
+      for (const { toolName, params } of cases) {
+        expect(() => validateUniversalToolParams(toolName, params)).toThrow(
+          /unknown_object.*funds/
+        );
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: config-discovered custom object slugs worked for universal search but not consistently for universal detail/create/update/delete tools.
- Why it matters: users could find custom object records such as funds, then hit enum-only validation or standard-object routing when trying to act on them.
- What changed: dynamic resource type validation now covers get_record_details, create_record, update_record, and delete_record; validated custom slugs route through generic Attio object record helpers; formatting/errors preserve the actual slug; docs and tests cover the parity behavior.
- What did not change (scope boundary): no new discovery mechanism, no scoped tools for individual custom objects, and standard companies/people/lists/tasks/deals/notes routing remains specialized.

[size/exempt: focused #1161 parity across validation, CRUD routes, tests, docs, and required ce-plan artifact]

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Tool handlers/formatting
- [x] Attio API integration
- [x] Tests/mocks/fixtures
- [ ] Issue/PR templates or community files
- [ ] CI/workflows
- [x] Other

## Linked Issue/PR

- Closes #1161
- Related #1138

## User-visible / Behavior Changes

Universal record tools now accept config-discovered custom object slugs directly as resource_type values for detail, create, update, and delete operations. Example: resource_type: funds can now be used across the same universal record workflow as search.

## Security Impact (required)

- New permissions/capabilities? (Yes)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (Yes)
- Tool execution surface changed? (Yes)
- If any Yes, explain risk and mitigation: existing Attio record read/write/delete capabilities now apply to mapping-config-discovered custom object slugs through the existing generic /objects/{slug}/records paths. Unknown slugs are still rejected by dynamic validation, and service fallbacks are gated on config-discovered custom objects.

## Repro + Verification

### Environment

- OS: macOS
- Shell/runtime: zsh, Bun
- Relevant tool versions: repo-local bun/vitest/typescript tooling

### Steps

1. Discover custom object attributes so a slug such as funds exists in the mapping config.
2. Call search_records with resource_type: funds and capture a record id.
3. Call get_record_details, create_record, update_record, and delete_record with resource_type: funds.

### Expected

- Config-discovered custom object slugs validate and route to /objects/{custom_slug}/records APIs.
- Unknown custom slugs fail validation with discovered valid options.
- Standard resource types retain their existing specialized behavior.

### Actual

- Implemented as expected in unit/service coverage; no live Attio custom-object smoke was run in this PR.

## Evidence

Attach at least one:

- [x] Failing output before and passing output after
- [ ] Log snippets
- [ ] Screenshot/recording
- [ ] N/A (docs-only or template-only change)

Commands run:

- timeout -k5s 60s bun run typecheck: passed
- timeout -k5s 120s bun run test:single -- test/services/UniversalMetadataService.test.ts test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts test/services/UniversalRetrievalService-core-operations.test.ts test/services/UniversalDeleteService.test.ts test/services/UniversalCreateService-objects-deals-tasks.test.ts test/services/UniversalUpdateService-core-operations.test.ts test/handlers/tool-configs/universal/core-operations-crud.test.ts test/handlers/tool-configs/universal/core-operations-search.test.ts: 142 tests passed
- timeout -k5s 120s bun run lint:src: passed with existing warnings under threshold
- timeout -k5s 120s bun run lint:test: passed with existing warnings under threshold
- timeout -k5s 120s bun run build: passed
- git diff --cached --check: passed
- git push -u origin HEAD: pre-push ran TypeScript plus offline fast tests; 224 files passed, 3,472 tests passed, 25 skipped

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: validation accepts discovered funds for detail/create/update/delete; unknown_object is rejected for those tools with valid discovered options; detail/delete route to generic custom object helpers; create passes direct values without a nested values wrapper; update passes through mapped custom payloads; formatter output keeps custom object slugs visible.
- Edge cases checked: custom detail field filtering; custom retrieval/delete not-found paths; unsupported metadata discovery still rejects unknown slugs.
- What you did not verify: live Attio API mutation against a real disposable custom object.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: none. Custom object slugs must already be present in the generated mapping configuration.

## Failure Recovery

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: universal validation/routing helpers, custom object resource utilities, docs/changelog/test additions.
- Known bad symptoms reviewers should watch for: nested create payloads for custom objects, unknown slugs reaching generic object helpers, or custom object formatter output falling back to generic records labels.

## Risks and Mitigations

- Risk: expanding resource_type from enum-only to dynamic strings could let typos route too far into service code.
  - Mitigation: dynamic validation uses mapping config, and service-level custom-object branches gate on config-discovered slugs.
- Risk: custom object create payloads could be wrapped incorrectly.
  - Mitigation: direct custom create now calls createObjectRecord(resource_type, transformedData), with a regression test asserting no extra values wrapper.

## AI Assistance

- AI-assisted: yes
- Tools/agents/models used: Codex with CE planning/work/review sub-agents
- Testing level: fully tested locally for unit/service paths; live API custom-object smoke not run
- Human understanding confirmation: yes