### PR TITLE
Chore: prepare v1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-05-05
+
+**TL;DR for Users**: This release makes common company and deal writes easier, completes universal record support for custom objects, and fixes workspace-member lookups returned by list tools.
+
 ### Added
 
-- Added scoped `create_company`, `update_company`, `create_deal`, and `update_deal` tools so high-frequency company/deal writes no longer require model-selected `resource_type` values (#1175)
+- Scoped `create_company`, `update_company`, `create_deal`, and `update_deal` tools for high-frequency company/deal writes without manually selecting `resource_type` (#1175)
 
 ### Changed
 
-- Upgraded syncpack to v15 and migrated the syncpack validation/fix scripts to the new CLI commands (#1178)
+- Maintenance updates for npm trusted publishing reliability and current runtime/dependency compatibility (#1172, #1178)
 
 ### Fixed
 
-- Universal record tools now accept config-discovered custom object slugs for details, create, update, and delete operations instead of limiting custom objects to search-only flows (#1161)
-- Fixed `get-workspace-member` so valid `workspace_member_id` values returned by `list-workspace-members` are passed to Attio as UUID path segments instead of malformed argument objects (#1173)
+- Universal record tools now support config-discovered custom objects for details, create, update, and delete, matching existing search support (#1161)
+- `get-workspace-member` now accepts valid `workspace_member_id` values returned by `list-workspace-members` (#1173, #1176)
 
 ## [1.5.0] - 2026-04-09
 
@@ -934,7 +938,8 @@ Users upgrading from v0.1.x should note:
 - Troubleshooting guides
 - Development and contribution guidelines
 
-[Unreleased]: https://github.com/kesslerio/attio-mcp-server/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/kesslerio/attio-mcp-server/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.3.6...v1.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/kesslerio/attio-mcp-server",
     "source": "github"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "attio-mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/test/scripts/release-notes.test.ts
+++ b/test/scripts/release-notes.test.ts
@@ -23,15 +23,17 @@ describe('release notes builder', () => {
     );
 
     expect(releaseNotes).toContain(
-      'This release adds record interaction history'
+      'This release makes common company and deal writes easier'
     );
     expect(releaseNotes).toContain("## What's New");
     expect(releaseNotes).toContain('### Added');
     expect(releaseNotes).toContain('### Fixed');
+    expect(releaseNotes).toContain('create_company');
+    expect(releaseNotes).toContain('config-discovered custom objects');
     expect(releaseNotes).toContain('npm install -g attio-mcp');
     expect(releaseNotes).toContain('npm update -g attio-mcp');
     expect(releaseNotes).toContain(
-      '**Full Changelog**: https://github.com/kesslerio/attio-mcp-server/compare/v1.4.1...v1.5.0'
+      '**Full Changelog**: https://github.com/kesslerio/attio-mcp-server/compare/v1.5.0...v1.6.0'
     );
   });
 });


### PR DESCRIPTION
## What
- Bump package and MCP registry metadata to 1.6.0.
- Move the current Unreleased changelog entries into the v1.6.0 release section.
- Add user-facing release notes for scoped write tools, custom object CRUD parity, workspace-member lookup fixes, and maintenance reliability updates.
- Update the release-notes unit test for the new current release copy.

## Why
- Prepare a stable minor release for the merged user-facing workflow improvements and fixes.
- Keep GitHub release notes generated from the curated changelog.
- Publish through the repo's tag-triggered GitHub, npm, and MCP registry workflows after protected-branch checks pass.

## Tests
- timeout -k5s 120s bun run build
- timeout -k5s 60s bun run test:single -- test/scripts/release-notes.test.ts
- timeout -k5s 180s bun run test:offline
- timeout -k5s 180s bun run check
- node scripts/release-notes.cjs v1.6.0 --validate
- git push pre-push hook: tsc --noEmit and offline fast tests passed

## AI Assistance
- AI assistance used for release preparation, changelog copy, validation, and workflow coordination.
- Testing level: local build, release-note validation, focused release-notes test, full offline suite, repo check, and pre-push hook validation.
- I understand this code and release change.