### PR TITLE
Feature: Dedicated list configuration tools (create-list, update-list-configuration) #1195

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,40 @@
+# Backlog
+
+This backlog captures the currently triaged MCP surface improvements after the
+v1.6.0 release. It is ordered by practical user impact, implementation risk, and
+how much each item unlocks later work.
+
+## Current Priority Order
+
+| Order | Issue                                                                                                               | Priority | Status | Why this order                                                                                                                                                            | First PR shape                                                                                                                                   |
+| ----- | ------------------------------------------------------------------------------------------------------------------- | -------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1     | [#1189](https://github.com/kesslerio/attio-mcp-server/issues/1189) Prompt catalog references stale tool names       | P0       | Ready  | Broken prompt instructions can cause tool-call failures even when the server has the right capability. Fixing this protects every prompt-driven workflow.                 | Audit prompt definitions and docs, replace stale tool names, and add a regression test that verifies prompt-referenced tools resolve.            |
+| 2     | [#1188](https://github.com/kesslerio/attio-mcp-server/issues/1188) Compatibility wrappers for common MCP tool names | P1       | Ready  | Thin wrappers reduce model translation errors and make the tool surface easier to use without changing universal internals.                                               | Add wrapper/alias coverage for record, list, and task names; preserve safety annotations and structured output.                                  |
+| 3     | [#1190](https://github.com/kesslerio/attio-mcp-server/issues/1190) Identity and team lookup tools                   | P1       | Ready  | A `whoami` path improves trust, debugging, and approval flows before adding more write or activity tools.                                                                 | Implement `whoami` from `/v2/self`, then current workspace member lookup. Defer generic teams unless the API semantics are confirmed.            |
+| 4     | [#1192](https://github.com/kesslerio/attio-mcp-server/issues/1192) Note body retrieval and update tools             | P1       | Ready  | Full note readback is public-API-backed and high-value for CRM context. Note update should be split or deferred because no public update endpoint is currently confirmed. | Add `get_note` / note body retrieval with `content_plaintext` and `content_markdown`; document update as blocked unless an endpoint is verified. |
+| 5     | [#1193](https://github.com/kesslerio/attio-mcp-server/issues/1193) Agent-readable list tool responses               | P2       | Ready  | List tools work, but raw JSON-heavy formatting burns tokens and weakens conversational UX. This is a contained quality win before adding more list features.              | Add readable summaries plus structured output for active list tools, with formatter tests for empty, paginated, and error results.               |
+| 6     | [#1150](https://github.com/kesslerio/attio-mcp-server/issues/1150) Thread and comment lookup tools                  | P1       | Ready  | Collaboration context is public-API-backed and useful, but it should follow the response-formatting cleanup so outputs are consistent.                                    | Add read-only `list_threads`, `get_thread`, and `get_comment`; keep create/delete out of the first PR unless explicitly scoped.                  |
+| 7     | [#1151](https://github.com/kesslerio/attio-mcp-server/issues/1151) Meeting lookup tools                             | P1       | Ready  | Meeting reads are public-API-backed but beta. They unlock real activity context after the safer identity/notes/comments work is in place.                                 | Add read-only `list_meetings` and `get_meeting` with cursor pagination and linked-record filters. Keep create/find-or-create experimental.       |
+| 8     | [#1152](https://github.com/kesslerio/attio-mcp-server/issues/1152) Transcript and call recording lookup tools       | P2       | Ready  | Call recordings and transcripts are valuable, but depend on meeting IDs and beta surfaces, so they should follow meeting lookup.                                          | Add read-only `list_call_recordings`, `get_call_recording`, and `get_call_transcript`; skip upload/delete in the first PR.                       |
+| 9     | [#1191](https://github.com/kesslerio/attio-mcp-server/issues/1191) `upsert_record` support                          | P1       | Ready  | High-value for automation, but write semantics and duplicate prevention need careful design after the compatibility/readback layer is stable.                             | Implement dry-run first, exact match handling, ambiguous-match errors, and custom-object routing over universal search/create/update.            |
+| 10    | [#1153](https://github.com/kesslerio/attio-mcp-server/issues/1153) File lookup tools                                | P3       | Ready  | File metadata is useful but lower-frequency than notes, comments, meetings, and upsert workflows.                                                                         | Add read-only file metadata listing/get once higher-priority context tools are complete.                                                         |
+
+## Deferred For Now
+
+These are intentionally not implementation-ready until public API support is
+confirmed:
+
+- Email content lookup, email metadata search, and email semantic search.
+- Reporting or aggregate report execution.
+- Generic workspace teams, unless the intended API is confirmed as distinct
+  from SCIM group administration.
+- Note update, unless a public note update endpoint is verified.
+
+## Triage Notes
+
+- Prefer read-only slices first for collaboration and activity surfaces.
+- Keep beta or alpha upstream API status visible in tool descriptions and docs.
+- Add live API smoke checks before coding against newer endpoints.
+- Preserve universal tools as the internal implementation layer; wrappers should
+  be thin compatibility surfaces, not parallel business logic.
+- Every new tool must include MCP safety annotations and formatter tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`create-list` tool** (#1195, #1196) - Dedicated list creation with template expansion (`sales_pipeline`, `recruiting_tracker`, `support_queue`), parent-object validation against workspace objects, and dry-run preview
+- **`update-list-configuration` tool** (#1195, #1196) - Dedicated list update with immutable field detection (rejects `parent_object` changes), dry-run preview, and categorized error guidance
+- Shared `ListConfigurationValidator` for parent-object validation, immutable field detection, template expansion, and error categorization — consumed by both dedicated tools and universal create/update strategies (#1195)
+
+### Changed
+
+- Universal list create and update paths now validate `parent_object` and detect immutable fields before API calls (#1195)
+- List error categorization prefers HTTP status codes over fragile string matching (#1196)
+
 ## [1.6.0] - 2026-05-05
 
 **TL;DR for Users**: This release makes common company and deal writes easier, completes universal record support for custom objects, and fixes workspace-member lookups returned by list tools.

--- a/docs/brainstorms/list-configuration-tools-requirements.md
+++ b/docs/brainstorms/list-configuration-tools-requirements.md
@@ -1,0 +1,149 @@
+---
+date: 2026-05-13
+topic: list-configuration-tools
+---
+
+# List Configuration Tools
+
+## Summary
+
+Add opinionated `create-list` and `update-list-configuration` MCP tools with smart defaults (parent-object auto-resolution, list templates, response normalization, immutable-field detection) and dry-run support, plus harden the universal `create_record`/`update_record` path for lists. No list-attribute management tools in this iteration.
+
+---
+
+## Problem Frame
+
+Agents can manage entries on existing Attio lists through MCP tools, but cannot create new lists or modify list configuration. When a user asks an agent to set up a new sales pipeline or recruiting tracker, the agent must refuse or direct the user to the Attio UI — even when the service token has `list_configuration:read-write` scope. The universal `create_record`/`update_record` path technically supports lists but provides no list-specific validation, produces confusing errors for invalid parent objects or immutable fields, and returns raw Attio responses that are hard for agents to act on. This blocks operational workflows and forces manual list setup, inconsistent structures, and repeated agent refusals.
+
+---
+
+## Actors
+
+- A1. **Agent**: Calls the new tools to create or update list configurations on behalf of a user
+- A2. **Human operator**: Requests list setup through an agent, reviews dry-run output, or falls back to Attio UI for unsupported operations
+- A3. **Attio API**: The upstream service that validates and persists list configuration
+
+---
+
+## Key Flows
+
+- F1. **Create a new list**
+  - **Trigger:** Agent receives a request to set up a new list (e.g., sales pipeline)
+  - **Actors:** A1, A3
+  - **Steps:** Agent calls `create-list` with name, parent object type (or template). Tool auto-resolves valid parent objects, validates inputs, optionally runs dry-run. On confirm, creates list and returns normalized response.
+  - **Outcome:** A new Attio list exists with validated configuration; agent receives actionable response with list_id and field summary.
+  - **Covered by:** R1, R3, R5, R6, R9
+
+- F2. **Update list configuration**
+  - **Trigger:** Agent needs to rename a list, change description, or adjust settings
+  - **Actors:** A1, A3
+  - **Steps:** Agent calls `update-list-configuration` with list_id and fields to change. Tool detects immutable fields and rejects with guidance, validates mutable fields, optionally runs dry-run. On confirm, updates list and returns normalized response.
+  - **Outcome:** List configuration updated; agent receives confirmation with before/after for changed fields.
+  - **Covered by:** R2, R4, R5, R6, R7, R9
+
+- F3. **Create list from template**
+  - **Trigger:** Agent wants to create a common list type without specifying every field
+  - **Actors:** A1, A3
+  - **Steps:** Agent calls `create-list` with a template name (e.g., "sales_pipeline"). Tool expands template into full attributes, validates against workspace, optionally runs dry-run. On confirm, creates list.
+  - **Outcome:** A new list matching the template structure; agent doesn't need to know Attio schema details.
+  - **Covered by:** R1, R3, R8
+
+---
+
+## Requirements
+
+**Dedicated tools**
+
+- R1. MCP exposes a `create-list` tool that creates an Attio list for a supported parent object type, with required inputs (name, parent_object) and optional inputs (description, access-control fields, template selection).
+- R2. MCP exposes an `update-list-configuration` tool that updates mutable list configuration fields for an existing list, identified by list_id.
+
+**Smart defaults**
+
+- R3. `create-list` auto-resolves valid parent object types from the workspace before sending the create request, and rejects invalid parent_object values with a list of valid options.
+- R4. `update-list-configuration` detects immutable fields (e.g., parent_object) and rejects attempts to change them with a clear explanation, rather than letting Attio return a confusing error.
+- R5. Both tools normalize Attio responses into a consistent agent-friendly shape that always includes list_id, name, parent_object, and a summary of configured fields.
+
+**Dry-run**
+
+- R6. Both tools accept a `dry_run` boolean parameter (default: false). When true, the tool validates inputs, resolves parent objects, expands templates, and detects immutable fields — but does not write to Attio. Returns the same normalized shape with a "dry_run" flag indicating the result is a preview.
+
+**List templates**
+
+- R7. `create-list` accepts an optional `template` parameter with an initial catalog of three templates: `sales_pipeline`, `recruiting_tracker`, `support_queue`. When provided, the template supplies default attributes that the caller can override.
+- R8. When a template is selected, the tool expands it into concrete attributes before validation, so dry-run and error messages reference the actual values that would be sent.
+
+**Error handling**
+
+- R9. User-facing errors distinguish four categories: unsupported input (invalid parent_object, unknown template), insufficient token scope, Attio permission/access-control failure, and generic API failure. Each category includes a suggested next step.
+
+**Universal path hardening**
+
+- R10. The universal `create_record` path with `resource_type: "lists"` applies the same parent-object validation and immutable-field detection as the dedicated tools, producing consistent error messages rather than raw Attio errors.
+- R11. The universal `update_record` path with `resource_type: "lists"` applies immutable-field detection and returns consistent error messages for list-specific failures.
+
+**Access-control pass-through**
+
+- R12. Both dedicated tools accept `workspace_access` and `workspace_member_access` fields and pass them through to the Attio API without additional validation or transformation. Hardening of 403 handling for these fields is deferred to #1148.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R3, R9.** Given a workspace with parent objects [companies, people], when an agent calls `create-list` with `parent_object: "deals"`, the tool returns an error listing valid parent objects and suggesting one to use instead.
+- AE2. **Covers R4, R9.** Given an existing list with `parent_object: "companies"`, when an agent calls `update-list-configuration` attempting to change `parent_object` to "people", the tool rejects the update explaining that parent_object is immutable after creation.
+- AE3. **Covers R6.** Given valid inputs, when an agent calls `create-list` with `dry_run: true`, the tool returns the normalized response shape with a `dry_run: true` flag and no list is created in Attio.
+- AE4. **Covers R7, R8.** Given a template "sales_pipeline", when an agent calls `create-list` with that template and `dry_run: true`, the response shows the expanded attributes (stages, fields) that would be created, merged with any caller overrides.
+- AE5. **Covers R10.** Given the universal `create_record` path with `resource_type: "lists"` and an invalid `parent_object`, the error message matches the dedicated tool's format (lists valid objects, suggests next step) rather than a raw Attio API error.
+- AE6. **Covers R12.** Given `workspace_access: "read-only"` in a `create-list` call, the field is passed through to Attio unchanged. If Attio returns a 403, the error is surfaced as-is without additional interpretation (deferred to #1148).
+
+---
+
+## Success Criteria
+
+- An agent can create a new Attio list and update list configuration without falling back to the Attio UI or raw API calls.
+- Dry-run mode lets agents preview list creation/update before committing, reducing workspace clutter from bad schemas.
+- The universal path no longer produces confusing raw Attio errors for list operations — errors are consistent with the dedicated tools.
+- Downstream planning can implement this without inventing validation rules, error categories, or template structure.
+
+---
+
+## Scope Boundaries
+
+- List attribute (field/column) management tools (`create-list-attribute`, `update-list-attribute`) — deferred to a future iteration
+- Access-control hardening (403 distinction, plan/billing gating) — covered by #1148
+- List deletion tool — not requested; `deleteList()` exists in codebase but no MCP tool surface
+- Changes to existing entry-level list tools (`add-record-to-list`, `update-list-entry`, etc.)
+- Template management UI or dynamic template discovery — templates are a static code-level catalog
+
+---
+
+## Key Decisions
+
+- **Opinionated tools over minimal mirroring**: Chosen over Approach A (minimal) because the universal path already provides a raw pass-through; dedicated tools should add real value through smart defaults, not duplicate the universal surface.
+- **Both dedicated + universal hardening**: The universal path remains a valid entry point for lists; hardening it prevents confusing failures when agents use it instead of the dedicated tools.
+- **Pass-through for access-control fields**: Accepting and forwarding `workspace_access`/`workspace_member_access` without additional validation keeps this issue's scope separate from #1148's hardening work.
+- **Static template catalog**: Templates are defined in code rather than dynamically fetched, keeping the implementation simple and predictable at the cost of needing code changes to add new templates.
+
+---
+
+## Dependencies / Assumptions
+
+- The Attio list create API (`POST /lists`) accepts the attributes shape currently used by `createList()` in `src/objects/lists/base.ts`, including `name`, `parent_object`, and access-control fields.
+- The Attio list update API (`PATCH /lists/:id`) supports partial updates — only specified fields are changed.
+- A known set of immutable fields exists for lists (at minimum `parent_object`). The exact set will be validated against Attio docs during planning.
+- The workspace's available parent objects can be discovered at runtime (likely via the existing object discovery mechanism).
+- Issue #1148 will handle 403 error categorization and access-control hardening separately.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None — all resolved)
+
+### Deferred to Planning
+
+- [Affects R3][Needs research] How are valid parent objects discovered at runtime? The existing object discovery mechanism should be evaluated for reuse.
+- [Affects R4][Needs research] What is the complete set of immutable list fields that Attio rejects on update? Must be verified against Attio API docs.
+- [Affects R5][Technical] What does the normalized response shape look like? Planning should define the exact fields included.

--- a/docs/plans/2026-05-13-001-feat-list-configuration-tools-plan.md
+++ b/docs/plans/2026-05-13-001-feat-list-configuration-tools-plan.md
@@ -1,0 +1,432 @@
+---
+title: 'feat: List Configuration Tools'
+type: feat
+status: active
+date: 2026-05-13
+origin: docs/brainstorms/list-configuration-tools-requirements.md
+---
+
+# feat: List Configuration Tools
+
+## Summary
+
+Add `create-list` and `update-list-configuration` dedicated MCP tools with opinionated smart defaults (auto-resolve parent objects, list templates, response normalization, immutable-field detection) and dry-run support, plus harden the universal `create_record`/`update_record` path for lists via a shared validation module consumed by both dedicated and universal paths.
+
+---
+
+## Problem Frame
+
+Agents cannot create Attio lists or modify list configuration through MCP tools. The universal `create_record`/`update_record` path technically supports lists but provides no list-specific validation, produces confusing errors for invalid parent objects or immutable fields, and returns raw Attio responses. This blocks operational workflows and forces manual list setup. (See origin for full narrative.)
+
+---
+
+## Requirements
+
+- R1. MCP exposes a `create-list` tool with required inputs (name, parent_object) and optional inputs (description, access-control fields, template, dry_run).
+- R2. MCP exposes an `update-list-configuration` tool that updates mutable list configuration fields for an existing list by list_id, with optional dry_run.
+- R3. `create-list` auto-resolves valid parent object types from the workspace and rejects invalid values with a list of valid options.
+- R4. `update-list-configuration` detects immutable fields (e.g., parent_object) and rejects attempts to change them with clear guidance.
+- R5. Both tools normalize Attio responses into a consistent agent-friendly shape (list_id, name, parent_object, fields summary).
+- R6. Both tools accept a `dry_run` boolean parameter (default: false) that validates and previews without writing.
+- R7. `create-list` accepts an optional `template` parameter with three initial templates: `sales_pipeline`, `recruiting_tracker`, `support_queue`.
+- R8. Template expansion happens before validation so dry-run and error messages reference actual values.
+- R9. Errors distinguish four categories: unsupported input, insufficient token scope, Attio permission/access-control failure, generic API failure — each with a suggested next step.
+- R10. Universal `create_record` with `resource_type: "lists"` applies the same parent-object validation and immutable-field detection as dedicated tools.
+- R11. Universal `update_record` with `resource_type: "lists"` applies immutable-field detection and consistent error messages.
+- R12. Both dedicated tools accept `workspace_access` and `workspace_member_access` as pass-through fields; hardening deferred to #1148.
+
+**Origin actors:** A1 (Agent), A2 (Human operator), A3 (Attio API)
+**Origin flows:** F1 (Create list), F2 (Update list configuration), F3 (Create from template)
+**Origin acceptance examples:** AE1 (R3,R9), AE2 (R4,R9), AE3 (R6), AE4 (R7,R8), AE5 (R10), AE6 (R12)
+
+---
+
+## Scope Boundaries
+
+- List attribute (field/column) management tools (`create-list-attribute`, `update-list-attribute`) — deferred to a future iteration
+- Access-control hardening (403 distinction, plan/billing gating) — covered by #1148
+- List deletion tool — not requested; `deleteList()` exists in codebase but no MCP tool surface
+- Changes to existing entry-level list tools (`add-record-to-list`, `update-list-entry`, etc.)
+- Template management UI or dynamic template discovery — templates are a static code-level catalog
+
+### Deferred to Follow-Up Work
+
+- List attribute management tools: future iteration after this lands
+- Access-control 403 hardening: #1148
+- List deletion MCP tool: not in scope but `deleteList()` exists in `src/objects/lists/base.ts`
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/handlers/tool-configs/lists.ts` — existing list tool configs and definitions; new tools register here
+- `src/handlers/tools/dispatcher/operations/lists.ts` — existing list operation handlers; new dedicated-tool handlers go here
+- `src/handlers/tools/registry.ts` — tool registration; `listsToolConfigs`/`listsToolDefinitions` already imported
+- `src/handlers/tool-types.ts` — tool config interfaces; new `CreateListToolConfig`/`UpdateListToolConfig` types needed
+- `src/objects/lists/base.ts` — `createList()` and `updateList()` core API functions; dedicated tools call these
+- `src/services/create/strategies/ListCreateStrategy.ts` — universal create strategy for lists; will consume shared validation
+- `src/services/update/strategies/ListUpdateStrategy.ts` — universal update strategy for lists; will consume shared validation
+- `src/services/UniversalCreateService.ts` — routes `UniversalResourceType.LISTS` to `ListCreateStrategy`
+- `src/services/update/UpdateOrchestrator.ts` — routes `UniversalResourceType.LISTS` to `ListUpdateStrategy`
+- `src/api/attio-objects.ts` — `resolveObjectSlug()` already calls `GET /objects` via `getLazyAttioClient()` (line 51); pattern for new `getWorkspaceObjects()` function
+- `src/cli/commands/attributes.ts` — `getAvailableObjects()` calls `GET /objects` but requires explicit apiKey; NOT suitable for service-layer (CLI-only)
+- `src/utils/auto-discovery.ts` — uses `getAvailableObjects()` for attribute discovery; pattern reference
+- `src/handlers/tool-configs/universal/validators/schema-validator.ts` — existing immutable-field detection for tasks; pattern to follow
+- `src/handlers/tool-configs/universal/field-mapper/constants/lists.ts` — `LISTS_FIELD_MAPPING` for list field mapping
+- `src/handlers/tools/standards/index.ts` — `formatToolDescription()` for tool description formatting
+- `test/utils/mock-factories/ListMockFactory.ts` — mock factory for list test data
+
+### Institutional Learnings
+
+- Task immutable-field pattern (`schema-validator.ts`) provides a proven approach: detect forbidden fields before API call, throw `UniversalValidationError` with clear message
+- `resolveObjectSlug()` in `src/api/attio-objects.ts` already calls `GET /objects` via the lazy client — extract a `getWorkspaceObjects()` helper there rather than importing the CLI-layer `getAvailableObjects()` which requires an explicit API key
+- MCP servers must only write JSON-RPC to stdout; all logging to stderr via `logger.*`
+
+---
+
+## Key Technical Decisions
+
+- **Shared validation module over inline checks**: A new `ListConfigurationValidator` module in `src/services/lists/` provides auto-resolve, immutable detection, template expansion, and response normalization. Both the dedicated tools and the universal strategies import it, guaranteeing consistent error messages across both paths. (See origin: opinionated tools + universal hardening.)
+- **New `getWorkspaceObjects()` in `src/api/attio-objects.ts` for auto-resolve**: The existing `resolveObjectSlug()` in `src/api/attio-objects.ts` already calls `GET /objects` via `getLazyAttioClient()` (line 51) and iterates the response. A new `getWorkspaceObjects()` function in the same file extracts the object-slug list from that same API call, using the lazy client (no explicit API key). The validator wraps it with short-lived caching. This handles custom objects, not just a hardcoded set. Note: `getAvailableObjects()` in `src/cli/commands/attributes.ts` requires an explicit `apiKey` and creates its own Axios client — it is CLI-layer and not suitable for service-layer consumption.
+- **Static template catalog as a typed constant**: Three templates (`sales_pipeline`, `recruiting_tracker`, `support_queue`) defined as a `LIST_TEMPLATES` map in the shared module. Template expansion merges caller overrides onto template defaults before validation. Easy to extend by adding entries.
+- **Dedicated tools register alongside existing list tools**: New `create-list` and `update-list-configuration` tool configs and definitions are added to `listsToolConfigs`/`listsToolDefinitions` in `src/handlers/tool-configs/lists.ts`, following the existing pattern. They dispatch through the list operations dispatcher.
+- **Normalized response shape**: Both tools return `{ list_id, name, parent_object, fields_summary, dry_run? }` via a `normalizeListResponse()` helper in the shared module. The `formatResult` function renders this as a human-readable string.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- How are valid parent objects discovered at runtime? → New `getWorkspaceObjects()` in `src/api/attio-objects.ts` calling `GET /objects` via `getLazyAttioClient()`, following the existing `resolveObjectSlug()` pattern.
+- What is the complete set of immutable list fields? → At minimum `parent_object`; the validator will define a `IMMUTABLE_LIST_FIELDS` set that can be expanded after testing against Attio API.
+- What does the normalized response shape look like? → `{ list_id, name, parent_object, fields_summary, dry_run? }` where `fields_summary` lists configured fields and their values.
+
+### Deferred to Implementation
+
+- Exact Attio API behavior for partial-update rejection of immutable fields: the validator pre-filters, but the Attio API may reject additional fields. Implementation should test and expand `IMMUTABLE_LIST_FIELDS` accordingly.
+- Template attribute details (stages, fields, defaults) for each of the three templates: defined during implementation based on Attio API capabilities and common CRM patterns.
+
+---
+
+## Output Structure
+
+```
+src/services/lists/
+  ListConfigurationValidator.ts    # Shared validation: auto-resolve, immutable detection, template expansion, normalization
+  list-templates.ts                 # LIST_TEMPLATES catalog and expansion logic
+  types.ts                          # Shared types: NormalizedListResponse, ListTemplate, etc.
+test/services/lists/
+  ListConfigurationValidator.test.ts
+  list-templates.test.ts
+```
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```
+┌──────────────────┐     ┌──────────────────────────────┐
+│  create-list     │────▶│  ListConfigurationValidator   │
+│  (dedicated)     │     │  - validateParentObject()     │
+└──────────────────┘     │  - expandTemplate()           │
+                         │  - detectImmutableFields()    │
+┌──────────────────────┐ │  - normalizeResponse()        │
+│ update-list-config   │─▶│  - categorizeError()         │
+│  (dedicated)         │  └──────────────────────────────┘
+└──────────────────────┘           │
+         │                         │
+         ▼                         ▼
+┌──────────────────┐     ┌──────────────────┐
+│  ListCreate      │     │  ListUpdate      │
+│  Strategy        │     │  Strategy        │
+│  (universal)     │     │  (universal)     │
+└──────────────────┘     └──────────────────┘
+```
+
+Both dedicated tools and universal strategies call the same `ListConfigurationValidator` methods before hitting the Attio API, guaranteeing consistent validation and error messages.
+
+---
+
+## Implementation Units
+
+### U1. Shared List Configuration Validator
+
+**Goal:** Create the `ListConfigurationValidator` module with auto-resolve, immutable detection, template expansion, response normalization, and error categorization — the core logic that both dedicated tools and universal strategies consume.
+
+**Requirements:** R3, R4, R5, R7, R8, R9
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `src/services/lists/ListConfigurationValidator.ts`
+- Create: `src/services/lists/list-templates.ts`
+- Create: `src/services/lists/types.ts`
+- Modify: `src/api/attio-objects.ts` — add `getWorkspaceObjects()` function
+- Test: `test/services/lists/ListConfigurationValidator.test.ts`
+- Test: `test/services/lists/list-templates.test.ts`
+
+**Approach:**
+
+- `types.ts` defines `NormalizedListResponse`, `ListTemplate`, `ListErrorCategory`, and related interfaces
+- `list-templates.ts` defines the `LIST_TEMPLATES` catalog (3 entries) and `expandTemplate()` which merges caller overrides onto template defaults
+- `ListConfigurationValidator` provides static methods:
+  - `validateParentObject(parentObject)` — calls new `getWorkspaceObjects()` from `src/api/attio-objects.ts` (with short-lived in-memory cache), rejects invalid values listing valid options
+  - `detectImmutableFields(attributes, existingList?)` — checks against `IMMUTABLE_LIST_FIELDS` set, rejects with guidance
+  - `expandTemplate(templateName, overrides)` — delegates to `list-templates.ts`
+  - `normalizeResponse(rawAttioList, dryRun?)` — extracts list_id, name, parent_object, builds fields_summary
+  - `categorizeError(error)` — maps Attio API errors to `ListErrorCategory` enum with suggested next steps
+
+**Patterns to follow:**
+
+- `src/handlers/tool-configs/universal/validators/schema-validator.ts` — immutable-field detection pattern for tasks
+- `src/api/attio-objects.ts` — `resolveObjectSlug()` pattern for `GET /objects` via lazy client; new `getWorkspaceObjects()` function
+- `src/services/update/UpdateValidation.ts` — validation module structure
+
+**Test scenarios:**
+
+- Happy path: `validateParentObject("companies")` succeeds when "companies" is in workspace objects
+- Happy path: `expandTemplate("sales_pipeline", { name: "My Pipeline" })` merges name override onto template defaults
+- Happy path: `normalizeResponse(rawAttioList)` returns shape with list_id, name, parent_object, fields_summary
+- Happy path: `detectImmutableFields({ name: "New" })` passes (no immutable fields)
+- Edge case: `validateParentObject("deals")` rejects when "deals" not in workspace objects, lists valid options
+- Edge case: `expandTemplate("unknown_template")` throws with list of valid template names
+- Error path: `detectImmutableFields({ parent_object: "people" })` rejects explaining parent_object is immutable
+- Error path: `categorizeError(403 error)` returns permission-failure category with next-step suggestion
+- Integration: template expansion + validation pipeline runs end-to-end (expand → validate → normalize)
+
+**Verification:**
+
+- All unit tests pass for `ListConfigurationValidator`, `list-templates`, and `types`
+- `validateParentObject` rejects invalid objects and lists valid ones
+- `detectImmutableFields` catches `parent_object` mutation attempts
+- `normalizeResponse` always includes list_id, name, parent_object, fields_summary
+
+---
+
+### U2. Dedicated `create-list` Tool
+
+**Goal:** Add the `create-list` MCP tool that creates Attio lists with smart defaults, template support, dry-run, and normalized responses.
+
+**Requirements:** R1, R3, R5, R6, R7, R8, R9, R12
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `src/handlers/tool-configs/lists.ts` — add `createList` tool config and definition
+- Modify: `src/handlers/tool-types.ts` — add `CreateListToolConfig` interface
+- Modify: `src/handlers/tools/dispatcher/operations/lists.ts` — add `handleCreateListOperation`
+- Test: `test/handlers/tools/dispatcher/operations/create-list.test.ts`
+
+**Approach:**
+
+- Add `CreateListToolConfig` interface to `tool-types.ts` with handler signature accepting name, parent_object, description, template, dry_run, workspace_access, workspace_member_access
+- Add `createList` entry to `listsToolConfigs` with handler that:
+  1. If template provided, call `ListConfigurationValidator.expandTemplate()`
+  2. Call `ListConfigurationValidator.validateParentObject()`
+  3. If `dry_run`, return normalized preview without calling `createList()` API
+  4. Call `createList()` from `src/objects/lists/base.ts`
+  5. Call `ListConfigurationValidator.normalizeResponse()` on result
+  6. On error, call `ListConfigurationValidator.categorizeError()`
+- Add `create-list` definition to `listsToolDefinitions` with inputSchema (name required, parent_object required, template/description/dry_run/workspace_access/workspace_member_access optional)
+- Add `handleCreateListOperation` to dispatcher that routes to the tool config handler
+- `formatResult` renders the normalized response as readable text
+
+**Patterns to follow:**
+
+- Existing tool configs in `src/handlers/tool-configs/lists.ts` (e.g., `addRecordToList`)
+- `formatToolDescription()` for description formatting
+- Dispatcher handler pattern in `src/handlers/tools/dispatcher/operations/lists.ts`
+
+**Test scenarios:**
+
+- Happy path: create list with name + parent_object returns normalized response with list_id
+- Happy path: create list with template expands template and creates list
+- Covers AE3: create list with `dry_run: true` returns preview, no list created in Attio
+- Covers AE4: create list with template + dry_run shows expanded attributes
+- Covers AE1: create list with invalid parent_object returns error listing valid objects
+- Edge case: create list with template + explicit name override uses the override
+- Error path: create list with unknown template returns error listing valid templates
+- Error path: Attio 403 surfaced with category-appropriate message (pass-through per R12)
+
+**Verification:**
+
+- `create-list` tool appears in MCP tool list
+- Creating a list with valid inputs returns normalized response
+- Dry-run mode validates but does not persist
+- Invalid parent_object produces actionable error with valid options
+
+---
+
+### U3. Dedicated `update-list-configuration` Tool
+
+**Goal:** Add the `update-list-configuration` MCP tool that updates mutable list configuration with immutable-field detection, dry-run, and normalized responses.
+
+**Requirements:** R2, R4, R5, R6, R9, R12
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `src/handlers/tool-configs/lists.ts` — add `updateListConfiguration` tool config and definition
+- Modify: `src/handlers/tool-types.ts` — add `UpdateListToolConfig` interface
+- Modify: `src/handlers/tools/dispatcher/operations/lists.ts` — add `handleUpdateListConfigurationOperation`
+- Test: `test/handlers/tools/dispatcher/operations/update-list-configuration.test.ts`
+
+**Approach:**
+
+- Add `UpdateListToolConfig` interface with handler accepting list_id, attributes, dry_run
+- Add `updateListConfiguration` entry to `listsToolConfigs` with handler that:
+  1. Call `ListConfigurationValidator.detectImmutableFields()` on the attributes
+  2. If `dry_run`, fetch current list via `getListDetails()`, compute preview of changes, return normalized response with `dry_run: true`
+  3. Call `updateList()` from `src/objects/lists/base.ts`
+  4. Call `ListConfigurationValidator.normalizeResponse()` on result
+  5. On error, call `ListConfigurationValidator.categorizeError()`
+- Add `update-list-configuration` definition to `listsToolDefinitions` with inputSchema (list_id required, attributes required, dry_run optional)
+- Add `handleUpdateListConfigurationOperation` to dispatcher
+
+**Patterns to follow:**
+
+- Same patterns as U2 for tool config, definition, and dispatcher
+
+**Test scenarios:**
+
+- Happy path: update list name returns normalized response with updated name
+- Happy path: update list with dry_run returns preview without persisting
+- Covers AE2: update list attempting to change parent_object rejects with immutable-field explanation
+- Edge case: update with empty attributes object returns validation error
+- Error path: update non-existent list_id returns 404 categorized error
+- Error path: Attio 403 surfaced with category-appropriate message (pass-through per R12)
+
+**Verification:**
+
+- `update-list-configuration` tool appears in MCP tool list
+- Updating mutable fields succeeds with normalized response
+- Attempting to update parent_object is rejected before API call
+- Dry-run mode previews changes without persisting
+
+---
+
+### U4. Universal Path Hardening
+
+**Goal:** Harden the universal `create_record`/`update_record` paths for lists by integrating the shared `ListConfigurationValidator`, ensuring consistent error messages with the dedicated tools.
+
+**Requirements:** R10, R11
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `src/services/create/strategies/ListCreateStrategy.ts` — add parent-object validation before API call
+- Modify: `src/services/update/strategies/ListUpdateStrategy.ts` — add immutable-field detection before API call
+- Test: `test/services/create/strategies/ListCreateStrategy.test.ts`
+- Test: `test/services/update/strategies/ListUpdateStrategy.test.ts`
+
+**Approach:**
+
+- In `ListCreateStrategy.create()`: before calling `createList()`, call `ListConfigurationValidator.validateParentObject()` on `values.parent_object`. On rejection, throw `UniversalValidationError` with the same message format the dedicated tool uses.
+- In `ListUpdateStrategy.update()`: before calling `updateList()`, call `ListConfigurationValidator.detectImmutableFields()` on `values`. On rejection, throw `UniversalValidationError` with the same message format.
+- Both strategies continue to handle `Cannot find attribute` errors as they do today (field suggestions).
+
+**Patterns to follow:**
+
+- Existing error handling in `ListCreateStrategy` and `ListUpdateStrategy` (UniversalValidationError pattern)
+- `src/handlers/tool-configs/universal/validators/schema-validator.ts` — task immutable-field validation in universal path
+
+**Test scenarios:**
+
+- Covers AE5: universal `create_record` with `resource_type: "lists"` and invalid parent_object returns error matching dedicated tool format
+- Happy path: universal create with valid parent_object succeeds as before
+- Happy path: universal update with mutable fields succeeds as before
+- Error path: universal update attempting to change parent_object throws UniversalValidationError
+- Integration: error messages from universal path are textually consistent with dedicated tool errors
+
+**Verification:**
+
+- Universal create with invalid parent_object produces actionable error listing valid objects
+- Universal update with immutable field produces clear rejection before API call
+- Existing universal list operations continue to work unchanged
+
+---
+
+### U5. Integration Tests and E2E Coverage
+
+**Goal:** Add integration and E2E tests covering the full flows (F1, F2, F3) and acceptance examples (AE1–AE6).
+
+**Requirements:** All (R1–R12)
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+
+- Create: `test/integration/list-configuration-tools.integration.test.ts`
+- Modify: `test/e2e/mcp/list-management/list-operations.mcp.test.ts` — add E2E cases for create/update config
+
+**Approach:**
+
+- Integration tests use `ATTIO_API_KEY` to test real API calls for create and update flows
+- E2E tests exercise the full MCP tool call pipeline (tool request → dispatcher → handler → API → response)
+- Each AE from the origin document has a corresponding test case
+
+**Test scenarios:**
+
+- Covers AE1: invalid parent_object on create-list lists valid options
+- Covers AE2: immutable parent_object on update-list-configuration rejects with guidance
+- Covers AE3: dry_run on create-list returns preview without creating list
+- Covers AE4: template + dry_run shows expanded attributes
+- Covers AE5: universal create_record with invalid parent_object matches dedicated tool error format
+- Covers AE6: workspace_access pass-through on create-list, 403 surfaced as-is
+
+**Verification:**
+
+- `bun run test:offline` passes (unit/mocked tests)
+- `bun run test:integration` passes (real API with ATTIO_API_KEY)
+- E2E suite covers all six acceptance examples
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New tools register in `listsToolConfigs`/`listsToolDefinitions` — consumed by `registry.ts` and `dispatcher/core.ts`. No changes to existing tool routing.
+- **Error propagation:** `ListConfigurationValidator.categorizeError()` produces consistent error categories; universal strategies throw `UniversalValidationError` as they do today.
+- **State lifecycle risks:** Dry-run mode must not persist data — validator returns preview without calling API. Template expansion is stateless.
+- **API surface parity:** Dedicated tools and universal path now produce consistent errors for lists. Other resource types (companies, people, tasks) are unaffected.
+- **Integration coverage:** U5 covers cross-layer scenarios (tool request → validation → API → normalization → response).
+- **Unchanged invariants:** Existing list entry tools (`add-record-to-list`, `filter-list-entries`, etc.), list read tools (`get-lists`, `get-list-details`), and all non-list resource tools remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                        | Mitigation                                                                                                                |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Attio API rejects fields not in `IMMUTABLE_LIST_FIELDS`     | Validator pre-filters known immutable fields; unknown rejections surface as generic API errors. Expand set after testing. |
+| `getWorkspaceObjects()` latency on every create call        | Short-lived in-memory cache (TTL ~60s) in validator; `resolveObjectSlug()` already caches per-slug.                       |
+| Template attributes don't match Attio's current API shape   | Templates validated during implementation against real Attio API; dry-run lets agents preview before committing.          |
+| Universal hardening changes error format for existing users | Error messages become more specific (improvement), not less. Existing `UniversalValidationError` type preserved.          |
+
+---
+
+## Documentation / Operational Notes
+
+- New tools (`create-list`, `update-list-configuration`) should be documented in the MCP tool reference
+- Template catalog should be documented so agents know available options
+- Dry-run behavior should be called out in tool descriptions for agent discoverability
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/list-configuration-tools-requirements.md](docs/brainstorms/list-configuration-tools-requirements.md)
+- Related code: `src/objects/lists/base.ts` (createList, updateList)
+- Related code: `src/handlers/tool-configs/lists.ts` (existing list tool configs)
+- Related code: `src/services/create/strategies/ListCreateStrategy.ts`
+- Related code: `src/services/update/strategies/ListUpdateStrategy.ts`
+- Related code: `src/cli/commands/attributes.ts` (getAvailableObjects)
+- Related PRs/issues: #1195, #1148

--- a/src/handlers/tool-configs/lists.ts
+++ b/src/handlers/tool-configs/lists.ts
@@ -22,6 +22,8 @@ import {
   ToolConfig,
   GetListEntriesToolConfig,
   ListActionToolConfig,
+  CreateListToolConfig,
+  UpdateListConfigurationToolConfig,
 } from '../tool-types.js';
 import { formatToolDescription } from '@/handlers/tools/standards/index.js';
 
@@ -198,6 +200,31 @@ export const listsToolConfigs = {
       return JSON.stringify(Array.isArray(results) ? results : []);
     },
   } as ToolConfig,
+
+  // Dedicated list configuration tools (Issue #1195)
+  createList: {
+    name: 'create-list',
+    type: 'createList' as const,
+    handler: () => {
+      // Placeholder - actual routing happens in dispatcher
+      throw new Error('Direct handler call not supported - use dispatcher');
+    },
+    formatResult: (result: unknown) => {
+      return JSON.stringify(result);
+    },
+  } as CreateListToolConfig,
+
+  updateListConfiguration: {
+    name: 'update-list-configuration',
+    type: 'updateListConfiguration' as const,
+    handler: () => {
+      // Placeholder - actual routing happens in dispatcher
+      throw new Error('Direct handler call not supported - use dispatcher');
+    },
+    formatResult: (result: unknown) => {
+      return JSON.stringify(result);
+    },
+  } as UpdateListConfigurationToolConfig,
 };
 
 // Lists tool definitions
@@ -985,6 +1012,95 @@ ${formatToolDescription({
         },
       },
       required: ['listId', 'recordId'],
+      additionalProperties: false,
+    },
+  },
+  // Dedicated list configuration tools (Issue #1195)
+  {
+    name: 'create-list',
+    description: formatToolDescription({
+      capability:
+        'Create a new CRM list (sales pipeline, recruiting tracker, support queue). Supports templates for quick setup with smart defaults.',
+      boundaries: 'update existing lists or manage list entries.',
+      constraints:
+        'Requires name and parent_object. Template expansion fills defaults before validation. Dry-run mode previews without creating.',
+      recoveryHint:
+        'Use get-lists to verify the list was created. Use update-list-configuration to modify after creation.',
+    }),
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Name of the list to create',
+          example: 'My Sales Pipeline',
+        },
+        parent_object: {
+          type: 'string',
+          description:
+            'Object type this list is for (e.g., "companies", "people"). Auto-validated against workspace objects.',
+          example: 'companies',
+        },
+        description: {
+          type: 'string',
+          description: 'Optional description for the list',
+        },
+        template: {
+          type: 'string',
+          description:
+            'Optional template name for smart defaults. Expands before validation so errors reference actual values.',
+          enum: ['sales_pipeline', 'recruiting_tracker', 'support_queue'],
+        },
+        attributes: {
+          type: 'object',
+          description:
+            'Additional list attributes (e.g., stages, custom fields). Merged onto template defaults if template is specified.',
+          additionalProperties: true,
+        },
+        dry_run: {
+          type: 'boolean',
+          description:
+            'Preview the creation without committing. Returns normalized preview of what would be created.',
+          default: false,
+        },
+      },
+      required: ['name', 'parent_object'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'update-list-configuration',
+    description: formatToolDescription({
+      capability:
+        'Update configuration of an existing list (name, description, custom fields). Detects immutable fields and provides clear errors.',
+      boundaries: 'change parent_object (immutable) or manage list entries.',
+      constraints:
+        'Requires listId. Immutable fields (parent_object) are rejected before the API call. Dry-run mode previews changes.',
+      recoveryHint:
+        'Use get-list-details to inspect current configuration. Use create-list for a different parent_object.',
+    }),
+    inputSchema: {
+      type: 'object',
+      properties: {
+        listId: {
+          type: 'string',
+          description: 'UUID of the list to update',
+          example: '550e8400-e29b-41d4-a716-446655440000',
+        },
+        attributes: {
+          type: 'object',
+          description:
+            'Attributes to update. Immutable fields (parent_object) will be rejected with a clear error.',
+          additionalProperties: true,
+        },
+        dry_run: {
+          type: 'boolean',
+          description:
+            'Preview the update without committing. Returns normalized preview of what would change.',
+          default: false,
+        },
+      },
+      required: ['listId', 'attributes'],
       additionalProperties: false,
     },
   },

--- a/src/handlers/tool-types.ts
+++ b/src/handlers/tool-types.ts
@@ -87,6 +87,19 @@ export interface ListActionToolConfig extends ToolConfig {
   idParams?: string[];
 }
 
+// Create list tool configuration
+export interface CreateListToolConfig extends ToolConfig {
+  handler: (attributes: Record<string, unknown>) => Promise<AttioList>;
+}
+
+// Update list configuration tool configuration
+export interface UpdateListConfigurationToolConfig extends ToolConfig {
+  handler: (
+    listId: string,
+    attributes: Record<string, unknown>
+  ) => Promise<AttioList>;
+}
+
 // Prompts tool configuration
 export interface PromptsToolConfig extends ToolConfig {
   handler: (req: Request, res: Response) => Promise<void>;

--- a/src/handlers/tools/dispatcher/core.ts
+++ b/src/handlers/tools/dispatcher/core.ts
@@ -42,7 +42,11 @@ import {
   handleNotesOperation,
   handleCreateNoteOperation,
 } from '@/handlers/tools/dispatcher/operations/notes.js';
-import { handleGetListsOperation } from '@/handlers/tools/dispatcher/operations/lists.js';
+import {
+  handleGetListsOperation,
+  handleCreateListOperation,
+  handleUpdateListConfigurationOperation,
+} from '@/handlers/tools/dispatcher/operations/lists.js';
 
 // Import CRUD operation handlers
 import {
@@ -97,6 +101,8 @@ import {
   NotesToolConfig,
   CreateNoteToolConfig,
   GetListsToolConfig,
+  CreateListToolConfig,
+  UpdateListConfigurationToolConfig,
 } from '@/handlers/tool-types.js';
 
 /**
@@ -312,6 +318,16 @@ export async function executeToolRequest(request: CallToolRequest) {
       result = await handleGetListsOperation(
         request,
         toolConfig as GetListsToolConfig
+      );
+    } else if (toolType === 'createList') {
+      result = await handleCreateListOperation(
+        request,
+        toolConfig as CreateListToolConfig
+      );
+    } else if (toolType === 'updateListConfiguration') {
+      result = await handleUpdateListConfigurationOperation(
+        request,
+        toolConfig as UpdateListConfigurationToolConfig
       );
 
       // Handle CRUD operations (from emergency fix)

--- a/src/handlers/tools/dispatcher/operations/lists.ts
+++ b/src/handlers/tools/dispatcher/operations/lists.ts
@@ -22,10 +22,41 @@ import {
 } from '../../../../objects/lists/entries.js';
 import { ListEntryFilters } from '../../../../api/operations/index.js';
 import { warn, OperationType } from '@/utils/logger.js';
+import { ListConfigurationValidator } from '@/services/lists/ListConfigurationValidator.js';
+import { createList, updateList } from '@/objects/lists/base.js';
+import { UniversalValidationError } from '@/handlers/tool-configs/universal/errors/validation-errors.js';
+import { AttioApiError } from '@/errors/api-errors.js';
 
 // Deprecation metadata constants (Issue #1071)
 const DEPRECATION_VERSION = 'v2.0.0';
 const MIGRATION_GUIDE_PATH = '/docs/migration/v2-list-tools.md';
+
+/**
+ * Shared error handler for list configuration tool catch blocks.
+ * Preserves 4xx status for validation errors and categorizes for actionable guidance.
+ */
+function handleListToolError(
+  error: unknown,
+  path: string,
+  method: string
+): ReturnType<typeof createErrorResult> {
+  const isUserError = error instanceof UniversalValidationError;
+  const status = isUserError ? error.httpStatusCode : undefined;
+
+  const categorized = ListConfigurationValidator.categorizeError(error);
+  const errorMessage = categorized
+    ? `${categorized.message} (Next step: ${categorized.suggested_next_step})`
+    : error instanceof Error
+      ? error.message
+      : 'Unknown error';
+
+  const responseData = hasResponseData(error) ? error.response.data : {};
+  if (status) {
+    (responseData as Record<string, unknown>).status = status;
+  }
+
+  return createErrorResult(new Error(errorMessage), path, method, responseData);
+}
 
 /**
  * Handle getLists operations
@@ -1217,11 +1248,6 @@ export async function handleCreateListOperation(
   }
 
   try {
-    // Dynamic import to avoid circular dependency at module load
-    const { ListConfigurationValidator } =
-      await import('@/services/lists/ListConfigurationValidator.js');
-    const { createList } = await import('@/objects/lists/base.js');
-
     // Build attributes: start with explicit params, merge template, then caller attributes
     let listAttributes: Record<string, unknown> = {
       name,
@@ -1252,13 +1278,13 @@ export async function handleCreateListOperation(
     if (dryRun) {
       const preview = ListConfigurationValidator.normalizeResponse(
         {
+          ...listAttributes,
           id: { list_id: 'dry-run-preview' },
           title: listAttributes.name as string,
           object_slug: listAttributes.parent_object as string,
           workspace_id: 'preview',
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
-          ...listAttributes,
         } as import('@/types/attio.js').AttioList,
         true
       );
@@ -1277,40 +1303,7 @@ export async function handleCreateListOperation(
 
     return formatResponse(formattedResult);
   } catch (error: unknown) {
-    // Preserve 4xx status for validation errors (PR #1196 review)
-    const { UniversalValidationError: UVE } =
-      await import('@/handlers/tool-configs/universal/errors/validation-errors.js').catch(
-        () => ({ UniversalValidationError: null as never })
-      );
-    const isUserError = UVE && error instanceof UVE;
-    const status = isUserError
-      ? (error as InstanceType<typeof UVE>).httpStatusCode
-      : undefined;
-
-    // Categorize the error for actionable guidance
-    const { ListConfigurationValidator: validator } =
-      await import('@/services/lists/ListConfigurationValidator.js').catch(
-        () => ({ ListConfigurationValidator: null })
-      );
-    const categorized = validator ? validator.categorizeError(error) : null;
-
-    const errorMessage = categorized
-      ? `${categorized.message} (Next step: ${categorized.suggested_next_step})`
-      : error instanceof Error
-        ? error.message
-        : 'Unknown error';
-
-    const responseData = hasResponseData(error) ? error.response.data : {};
-    if (status) {
-      (responseData as Record<string, unknown>).status = status;
-    }
-
-    return createErrorResult(
-      new Error(errorMessage),
-      '/lists',
-      'POST',
-      responseData
-    );
+    return handleListToolError(error, '/lists', 'POST');
   }
 }
 
@@ -1350,11 +1343,6 @@ export async function handleUpdateListConfigurationOperation(
   }
 
   try {
-    // Dynamic import to avoid circular dependency at module load
-    const { ListConfigurationValidator } =
-      await import('@/services/lists/ListConfigurationValidator.js');
-    const { updateList } = await import('@/objects/lists/base.js');
-
     // Detect immutable fields before API call
     ListConfigurationValidator.detectImmutableFields(attributes);
 
@@ -1362,13 +1350,13 @@ export async function handleUpdateListConfigurationOperation(
     if (dryRun) {
       const preview = ListConfigurationValidator.normalizeResponse(
         {
+          ...attributes,
           id: { list_id: listId },
           title: (attributes.name as string) || 'Preview',
           object_slug: (attributes.parent_object as string) || '',
           workspace_id: 'preview',
           created_at: '',
           updated_at: new Date().toISOString(),
-          ...attributes,
         } as import('@/types/attio.js').AttioList,
         true
       );
@@ -1387,38 +1375,6 @@ export async function handleUpdateListConfigurationOperation(
 
     return formatResponse(formattedResult);
   } catch (error: unknown) {
-    // Preserve 4xx status for validation errors (PR #1196 review)
-    const { UniversalValidationError: UVE } =
-      await import('@/handlers/tool-configs/universal/errors/validation-errors.js').catch(
-        () => ({ UniversalValidationError: null as never })
-      );
-    const isUserError = UVE && error instanceof UVE;
-    const status = isUserError
-      ? (error as InstanceType<typeof UVE>).httpStatusCode
-      : undefined;
-
-    const { ListConfigurationValidator: validator } =
-      await import('@/services/lists/ListConfigurationValidator.js').catch(
-        () => ({ ListConfigurationValidator: null })
-      );
-    const categorized = validator ? validator.categorizeError(error) : null;
-
-    const errorMessage = categorized
-      ? `${categorized.message} (Next step: ${categorized.suggested_next_step})`
-      : error instanceof Error
-        ? error.message
-        : 'Unknown error';
-
-    const responseData = hasResponseData(error) ? error.response.data : {};
-    if (status) {
-      (responseData as Record<string, unknown>).status = status;
-    }
-
-    return createErrorResult(
-      new Error(errorMessage),
-      `/lists/${listId}`,
-      'PATCH',
-      responseData
-    );
+    return handleListToolError(error, `/lists/${listId}`, 'PATCH');
   }
 }

--- a/src/handlers/tools/dispatcher/operations/lists.ts
+++ b/src/handlers/tools/dispatcher/operations/lists.ts
@@ -1176,3 +1176,219 @@ export async function handleGetRecordListMembershipsOperation(
     );
   }
 }
+
+/**
+ * Handle createList operations (Issue #1195)
+ *
+ * Dedicated create-list tool with smart defaults:
+ * - Template expansion before validation
+ * - Parent-object auto-resolution
+ * - Dry-run mode
+ * - Normalized response
+ */
+export async function handleCreateListOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig
+) {
+  const params = request.params.arguments || {};
+  const name = params.name as string;
+  const parentObject = params.parent_object as string;
+  const description = params.description as string | undefined;
+  const templateName = params.template as string | undefined;
+  const attributes = params.attributes as Record<string, unknown> | undefined;
+  const dryRun = (params.dry_run as boolean) ?? false;
+
+  // Validate required parameters
+  if (!name) {
+    return createErrorResult(
+      new Error('name parameter is required'),
+      '/lists',
+      'POST',
+      { status: 400, message: 'Missing required parameter: name' }
+    );
+  }
+  if (!parentObject) {
+    return createErrorResult(
+      new Error('parent_object parameter is required'),
+      '/lists',
+      'POST',
+      { status: 400, message: 'Missing required parameter: parent_object' }
+    );
+  }
+
+  try {
+    // Dynamic import to avoid circular dependency at module load
+    const { ListConfigurationValidator } =
+      await import('@/services/lists/ListConfigurationValidator.js');
+    const { createList } = await import('@/objects/lists/base.js');
+
+    // Build attributes: start with explicit params, merge template, then caller attributes
+    let listAttributes: Record<string, unknown> = {
+      name,
+      parent_object: parentObject,
+    };
+
+    if (description) {
+      listAttributes.description = description;
+    }
+
+    // Template expansion happens before validation (R8)
+    if (templateName) {
+      const overrides = { ...listAttributes, ...attributes };
+      listAttributes = ListConfigurationValidator.expandTemplate(
+        templateName,
+        overrides
+      );
+    } else if (attributes) {
+      listAttributes = { ...listAttributes, ...attributes };
+    }
+
+    // Validate parent_object against workspace objects
+    await ListConfigurationValidator.validateParentObject(
+      listAttributes.parent_object as string
+    );
+
+    // Dry-run: return preview without API call
+    if (dryRun) {
+      const preview = ListConfigurationValidator.normalizeResponse(
+        {
+          id: { list_id: 'dry-run-preview' },
+          title: listAttributes.name as string,
+          object_slug: listAttributes.parent_object as string,
+          workspace_id: 'preview',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          ...listAttributes,
+        } as import('@/types/attio.js').AttioList,
+        true
+      );
+      const formattedResult = toolConfig.formatResult
+        ? toolConfig.formatResult(preview)
+        : JSON.stringify(preview);
+      return formatResponse(formattedResult);
+    }
+
+    // Create the list via the API
+    const result = await createList(listAttributes);
+    const normalized = ListConfigurationValidator.normalizeResponse(result);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(normalized)
+      : JSON.stringify(normalized);
+
+    return formatResponse(formattedResult);
+  } catch (error: unknown) {
+    // Categorize the error for actionable guidance
+    const { ListConfigurationValidator: validator } =
+      await import('@/services/lists/ListConfigurationValidator.js').catch(
+        () => ({ ListConfigurationValidator: null })
+      );
+    const categorized = validator ? validator.categorizeError(error) : null;
+
+    const errorMessage = categorized
+      ? `${categorized.message} (Next step: ${categorized.suggested_next_step})`
+      : error instanceof Error
+        ? error.message
+        : 'Unknown error';
+
+    return createErrorResult(
+      new Error(errorMessage),
+      '/lists',
+      'POST',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}
+
+/**
+ * Handle updateListConfiguration operations (Issue #1195)
+ *
+ * Dedicated update-list-configuration tool with:
+ * - Immutable field detection (rejects parent_object)
+ * - Dry-run mode
+ * - Normalized response
+ */
+export async function handleUpdateListConfigurationOperation(
+  request: CallToolRequest,
+  toolConfig: ToolConfig
+) {
+  const params = request.params.arguments || {};
+  const listId = params.listId as string;
+  const attributes = params.attributes as Record<string, unknown>;
+  const dryRun = (params.dry_run as boolean) ?? false;
+
+  // Validate required parameters
+  if (!listId) {
+    return createErrorResult(
+      new Error('listId parameter is required'),
+      '/lists',
+      'PATCH',
+      { status: 400, message: 'Missing required parameter: listId' }
+    );
+  }
+  if (!attributes || typeof attributes !== 'object') {
+    return createErrorResult(
+      new Error('attributes parameter is required and must be an object'),
+      `/lists/${listId}`,
+      'PATCH',
+      { status: 400, message: 'Missing or invalid attributes parameter' }
+    );
+  }
+
+  try {
+    // Dynamic import to avoid circular dependency at module load
+    const { ListConfigurationValidator } =
+      await import('@/services/lists/ListConfigurationValidator.js');
+    const { updateList } = await import('@/objects/lists/base.js');
+
+    // Detect immutable fields before API call
+    ListConfigurationValidator.detectImmutableFields(attributes);
+
+    // Dry-run: return preview without API call
+    if (dryRun) {
+      const preview = ListConfigurationValidator.normalizeResponse(
+        {
+          id: { list_id: listId },
+          title: (attributes.name as string) || 'Preview',
+          object_slug: (attributes.parent_object as string) || '',
+          workspace_id: 'preview',
+          created_at: '',
+          updated_at: new Date().toISOString(),
+          ...attributes,
+        } as import('@/types/attio.js').AttioList,
+        true
+      );
+      const formattedResult = toolConfig.formatResult
+        ? toolConfig.formatResult(preview)
+        : JSON.stringify(preview);
+      return formatResponse(formattedResult);
+    }
+
+    // Update the list via the API
+    const result = await updateList(listId, attributes);
+    const normalized = ListConfigurationValidator.normalizeResponse(result);
+    const formattedResult = toolConfig.formatResult
+      ? toolConfig.formatResult(normalized)
+      : JSON.stringify(normalized);
+
+    return formatResponse(formattedResult);
+  } catch (error: unknown) {
+    const { ListConfigurationValidator: validator } =
+      await import('@/services/lists/ListConfigurationValidator.js').catch(
+        () => ({ ListConfigurationValidator: null })
+      );
+    const categorized = validator ? validator.categorizeError(error) : null;
+
+    const errorMessage = categorized
+      ? `${categorized.message} (Next step: ${categorized.suggested_next_step})`
+      : error instanceof Error
+        ? error.message
+        : 'Unknown error';
+
+    return createErrorResult(
+      new Error(errorMessage),
+      `/lists/${listId}`,
+      'PATCH',
+      hasResponseData(error) ? error.response.data : {}
+    );
+  }
+}

--- a/src/handlers/tools/dispatcher/operations/lists.ts
+++ b/src/handlers/tools/dispatcher/operations/lists.ts
@@ -1277,6 +1277,16 @@ export async function handleCreateListOperation(
 
     return formatResponse(formattedResult);
   } catch (error: unknown) {
+    // Preserve 4xx status for validation errors (PR #1196 review)
+    const { UniversalValidationError: UVE } =
+      await import('@/handlers/tool-configs/universal/errors/validation-errors.js').catch(
+        () => ({ UniversalValidationError: null as never })
+      );
+    const isUserError = UVE && error instanceof UVE;
+    const status = isUserError
+      ? (error as InstanceType<typeof UVE>).httpStatusCode
+      : undefined;
+
     // Categorize the error for actionable guidance
     const { ListConfigurationValidator: validator } =
       await import('@/services/lists/ListConfigurationValidator.js').catch(
@@ -1290,11 +1300,16 @@ export async function handleCreateListOperation(
         ? error.message
         : 'Unknown error';
 
+    const responseData = hasResponseData(error) ? error.response.data : {};
+    if (status) {
+      (responseData as Record<string, unknown>).status = status;
+    }
+
     return createErrorResult(
       new Error(errorMessage),
       '/lists',
       'POST',
-      hasResponseData(error) ? error.response.data : {}
+      responseData
     );
   }
 }
@@ -1372,6 +1387,16 @@ export async function handleUpdateListConfigurationOperation(
 
     return formatResponse(formattedResult);
   } catch (error: unknown) {
+    // Preserve 4xx status for validation errors (PR #1196 review)
+    const { UniversalValidationError: UVE } =
+      await import('@/handlers/tool-configs/universal/errors/validation-errors.js').catch(
+        () => ({ UniversalValidationError: null as never })
+      );
+    const isUserError = UVE && error instanceof UVE;
+    const status = isUserError
+      ? (error as InstanceType<typeof UVE>).httpStatusCode
+      : undefined;
+
     const { ListConfigurationValidator: validator } =
       await import('@/services/lists/ListConfigurationValidator.js').catch(
         () => ({ ListConfigurationValidator: null })
@@ -1384,11 +1409,16 @@ export async function handleUpdateListConfigurationOperation(
         ? error.message
         : 'Unknown error';
 
+    const responseData = hasResponseData(error) ? error.response.data : {};
+    if (status) {
+      (responseData as Record<string, unknown>).status = status;
+    }
+
     return createErrorResult(
       new Error(errorMessage),
       `/lists/${listId}`,
       'PATCH',
-      hasResponseData(error) ? error.response.data : {}
+      responseData
     );
   }
 }

--- a/src/services/create/strategies/ListCreateStrategy.ts
+++ b/src/services/create/strategies/ListCreateStrategy.ts
@@ -9,10 +9,19 @@ import {
   UniversalValidationError,
   ErrorType,
 } from '@/handlers/tool-configs/universal/schemas.js';
+import { ListConfigurationValidator } from '@/services/lists/ListConfigurationValidator.js';
 
 export class ListCreateStrategy implements CreateStrategy {
   async create(params: CreateStrategyParams): Promise<AttioList> {
     const { values, resourceType } = params;
+
+    // Validate parent_object against workspace objects (Issue #1195)
+    if (values.parent_object && typeof values.parent_object === 'string') {
+      await ListConfigurationValidator.validateParentObject(
+        values.parent_object as string
+      );
+    }
+
     try {
       const list = await createList(values);
       return list;

--- a/src/services/create/strategies/ListCreateStrategy.ts
+++ b/src/services/create/strategies/ListCreateStrategy.ts
@@ -8,7 +8,7 @@ import { getFieldSuggestions } from '@/handlers/tool-configs/universal/field-map
 import {
   UniversalValidationError,
   ErrorType,
-} from '@/handlers/tool-configs/universal/schemas.js';
+} from '@/handlers/tool-configs/universal/errors/validation-errors.js';
 import { ListConfigurationValidator } from '@/services/lists/ListConfigurationValidator.js';
 
 export class ListCreateStrategy implements CreateStrategy {

--- a/src/services/lists/ListConfigurationValidator.ts
+++ b/src/services/lists/ListConfigurationValidator.ts
@@ -46,28 +46,42 @@ async function getWorkspaceObjects(): Promise<string[]> {
   }
 
   const client = getLazyAttioClient();
+  const PAGE_LIMIT = 200;
+  const allSlugs: string[] = [];
+  let offset = 0;
+
   try {
-    const response = await client.get('/objects', {
-      params: { limit: 200 },
-    });
+    // Paginate to handle workspaces with >200 objects (PR #1196 review)
+    let hasMore = true;
+    while (hasMore) {
+      const response = await client.get('/objects', {
+        params: { limit: PAGE_LIMIT, offset },
+      });
 
-    const data = response?.data;
-    const list = Array.isArray(data?.data)
-      ? data.data
-      : Array.isArray(data)
-        ? data
-        : data?.objects || [];
+      const data = response?.data;
+      const page = Array.isArray(data?.data)
+        ? data.data
+        : Array.isArray(data)
+          ? data
+          : data?.objects || [];
 
-    const slugs = list
-      .filter((pd: unknown) => pd != null)
-      .map((pd: Record<string, unknown>) =>
-        String(pd.api_slug || pd.slug || pd.id)
-      )
-      .filter(Boolean);
+      const slugs = page
+        .filter((pd: unknown) => pd != null)
+        .map((pd: Record<string, unknown>) =>
+          String(pd.api_slug || pd.slug || pd.id)
+        )
+        .filter(Boolean);
 
-    cachedObjects = { slugs, expiresAt: now + CACHE_TTL_MS };
-    log.debug('Fetched workspace objects', { count: slugs.length });
-    return slugs;
+      allSlugs.push(...slugs);
+      offset += PAGE_LIMIT;
+
+      // If we got fewer than PAGE_LIMIT, we've reached the end
+      hasMore = page.length >= PAGE_LIMIT;
+    }
+
+    cachedObjects = { slugs: allSlugs, expiresAt: now + CACHE_TTL_MS };
+    log.debug('Fetched workspace objects', { count: allSlugs.length });
+    return allSlugs;
   } catch (error: unknown) {
     log.warn('Failed to fetch workspace objects', {
       error: error instanceof Error ? error.message : String(error),

--- a/src/services/lists/ListConfigurationValidator.ts
+++ b/src/services/lists/ListConfigurationValidator.ts
@@ -15,6 +15,7 @@ import {
   UniversalValidationError,
   ErrorType,
 } from '@/handlers/tool-configs/universal/errors/validation-errors.js';
+import { AttioApiError } from '@/errors/api-errors.js';
 import { expandTemplate } from './list-templates.js';
 import {
   IMMUTABLE_LIST_FIELDS,
@@ -225,10 +226,11 @@ export class ListConfigurationValidator {
       };
     }
 
-    // Check for unsupported input patterns
+    // Check for unsupported input patterns — prefer HTTP status 400 over string matching
+    const httpStatus = extractStatus(error);
     if (
+      httpStatus === 400 ||
       message.includes('Cannot find attribute') ||
-      message.includes('Invalid') ||
       message.includes('is required') ||
       message.includes('must be')
     ) {
@@ -254,12 +256,11 @@ export class ListConfigurationValidator {
  */
 function extractStatus(error: unknown): number | undefined {
   if (!error) return undefined;
+  // Check AttioApiError subclasses first (AuthorizationError, AuthenticationError, etc.)
+  if (error instanceof AttioApiError) return error.statusCode;
   if (typeof error === 'object' && 'response' in error) {
     const resp = (error as { response?: { status?: number } }).response;
     return resp?.status;
-  }
-  if (typeof error === 'object' && 'status' in error) {
-    return (error as { status: number }).status;
   }
   return undefined;
 }

--- a/src/services/lists/ListConfigurationValidator.ts
+++ b/src/services/lists/ListConfigurationValidator.ts
@@ -1,0 +1,251 @@
+/**
+ * ListConfigurationValidator — shared validation logic consumed by both
+ * dedicated list tools and the universal create/update strategies.
+ *
+ * Provides:
+ * - validateParentObject: auto-resolve valid parent objects from workspace
+ * - detectImmutableFields: reject attempts to update immutable fields
+ * - expandTemplate: delegate to list-templates.ts
+ * - normalizeResponse: extract consistent agent-friendly shape
+ * - categorizeError: map Attio API errors to actionable categories
+ */
+import { getLazyAttioClient } from '@/api/lazy-client.js';
+import { createScopedLogger } from '@/utils/logger.js';
+import {
+  UniversalValidationError,
+  ErrorType,
+} from '@/handlers/tool-configs/universal/errors/validation-errors.js';
+import { expandTemplate } from './list-templates.js';
+import {
+  IMMUTABLE_LIST_FIELDS,
+  normalizeListResponse,
+  ListErrorCategory,
+} from './types.js';
+import type { NormalizedListResponse, CategorizedListError } from './types.js';
+import type { AttioList } from '@/types/attio.js';
+
+const log = createScopedLogger('services.lists', 'ListConfigurationValidator');
+
+/**
+ * In-memory cache for workspace object slugs.
+ * Short-lived (TTL ~60s) to avoid redundant API calls per request
+ * while still picking up newly created custom objects.
+ */
+let cachedObjects: { slugs: string[]; expiresAt: number } | null = null;
+const CACHE_TTL_MS = 60_000;
+
+/**
+ * Fetch all available object slugs from the workspace via GET /objects.
+ * Uses the lazy Attio client (no explicit API key needed).
+ * Results are cached for CACHE_TTL_MS.
+ */
+async function getWorkspaceObjects(): Promise<string[]> {
+  const now = Date.now();
+  if (cachedObjects && cachedObjects.expiresAt > now) {
+    return cachedObjects.slugs;
+  }
+
+  const client = getLazyAttioClient();
+  try {
+    const response = await client.get('/objects', {
+      params: { limit: 200 },
+    });
+
+    const data = response?.data;
+    const list = Array.isArray(data?.data)
+      ? data.data
+      : Array.isArray(data)
+        ? data
+        : data?.objects || [];
+
+    const slugs = list
+      .filter((pd: unknown) => pd != null)
+      .map((pd: Record<string, unknown>) =>
+        String(pd.api_slug || pd.slug || pd.id)
+      )
+      .filter(Boolean);
+
+    cachedObjects = { slugs, expiresAt: now + CACHE_TTL_MS };
+    log.debug('Fetched workspace objects', { count: slugs.length });
+    return slugs;
+  } catch (error: unknown) {
+    log.warn('Failed to fetch workspace objects', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // On failure, return empty — don't block creation, let API reject
+    return [];
+  }
+}
+
+/**
+ * Invalidate the workspace objects cache (useful for testing).
+ */
+export function invalidateObjectCache(): void {
+  cachedObjects = null;
+}
+
+export class ListConfigurationValidator {
+  /**
+   * Validate that the given parent_object exists in the workspace.
+   * Rejects invalid values with a list of valid options.
+   *
+   * @throws UniversalValidationError if parent_object is not a valid workspace object
+   */
+  static async validateParentObject(parentObject: string): Promise<string> {
+    if (!parentObject || typeof parentObject !== 'string') {
+      throw new UniversalValidationError(
+        'parent_object is required and must be a non-empty string',
+        ErrorType.USER_ERROR,
+        {
+          suggestion:
+            'Provide a valid object type such as "companies" or "people".',
+          field: 'parent_object',
+        }
+      );
+    }
+
+    const workspaceObjects = await getWorkspaceObjects();
+
+    // If we couldn't fetch objects (network error), allow through —
+    // the Attio API will reject invalid values
+    if (workspaceObjects.length === 0) {
+      log.warn('No workspace objects fetched, skipping validation', {
+        parentObject,
+      });
+      return parentObject;
+    }
+
+    if (!workspaceObjects.includes(parentObject)) {
+      const validOptions = workspaceObjects.join(', ');
+      throw new UniversalValidationError(
+        `Invalid parent_object "${parentObject}". Must be one of the available workspace objects.`,
+        ErrorType.USER_ERROR,
+        {
+          suggestion: `Valid parent objects: ${validOptions}`,
+          field: 'parent_object',
+          example: workspaceObjects[0] || 'companies',
+        }
+      );
+    }
+
+    return parentObject;
+  }
+
+  /**
+   * Detect immutable fields in the given attributes map.
+   * Rejects attempts to change fields that cannot be modified after creation.
+   *
+   * @throws UniversalValidationError if any immutable field is present
+   */
+  static detectImmutableFields(attributes: Record<string, unknown>): void {
+    if (!attributes || typeof attributes !== 'object') return;
+
+    const violations: string[] = [];
+    for (const field of IMMUTABLE_LIST_FIELDS) {
+      if (field in attributes) {
+        violations.push(field);
+      }
+    }
+
+    if (violations.length > 0) {
+      const fieldList = violations.join(', ');
+      throw new UniversalValidationError(
+        `Cannot update immutable field(s): ${fieldList}. These fields cannot be changed after list creation.`,
+        ErrorType.USER_ERROR,
+        {
+          suggestion:
+            'Remove immutable fields from your update request. To use a different parent_object, create a new list instead.',
+          field: violations[0],
+        }
+      );
+    }
+  }
+
+  /**
+   * Expand a template by merging caller overrides onto template defaults.
+   * Delegates to list-templates.ts.
+   *
+   * @throws Error if templateName is not in the catalog
+   */
+  static expandTemplate(
+    templateName: string,
+    overrides: Record<string, unknown> = {}
+  ): Record<string, unknown> {
+    return expandTemplate(templateName, overrides);
+  }
+
+  /**
+   * Normalize a raw Attio API list response into a consistent
+   * agent-friendly shape.
+   */
+  static normalizeResponse(
+    raw: AttioList,
+    dryRun?: boolean
+  ): NormalizedListResponse {
+    return normalizeListResponse(raw, dryRun);
+  }
+
+  /**
+   * Categorize an Attio API error into an actionable bucket
+   * with a suggested next step.
+   */
+  static categorizeError(error: unknown): CategorizedListError {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = extractStatus(error);
+
+    if (status === 403) {
+      return {
+        category: ListErrorCategory.PERMISSION_FAILURE,
+        message,
+        suggested_next_step:
+          'Verify your API token has the required scope for this operation. Check workspace permissions or contact an admin.',
+      };
+    }
+
+    if (status === 401) {
+      return {
+        category: ListErrorCategory.TOKEN_SCOPE,
+        message,
+        suggested_next_step:
+          'Your API token may be invalid or expired. Re-authenticate and try again.',
+      };
+    }
+
+    // Check for unsupported input patterns
+    if (
+      message.includes('Cannot find attribute') ||
+      message.includes('Invalid') ||
+      message.includes('is required') ||
+      message.includes('must be')
+    ) {
+      return {
+        category: ListErrorCategory.UNSUPPORTED_INPUT,
+        message,
+        suggested_next_step:
+          'Check your input parameters against the list schema. Use get-list-details to inspect valid attributes.',
+      };
+    }
+
+    return {
+      category: ListErrorCategory.API_FAILURE,
+      message,
+      suggested_next_step:
+        'An unexpected error occurred. Retry the operation. If the problem persists, check the Attio status page.',
+    };
+  }
+}
+
+/**
+ * Extract HTTP status code from an error object.
+ */
+function extractStatus(error: unknown): number | undefined {
+  if (!error) return undefined;
+  if (typeof error === 'object' && 'response' in error) {
+    const resp = (error as { response?: { status?: number } }).response;
+    return resp?.status;
+  }
+  if (typeof error === 'object' && 'status' in error) {
+    return (error as { status: number }).status;
+  }
+  return undefined;
+}

--- a/src/services/lists/ListConfigurationValidator.ts
+++ b/src/services/lists/ListConfigurationValidator.ts
@@ -232,7 +232,8 @@ export class ListConfigurationValidator {
       httpStatus === 400 ||
       message.includes('Cannot find attribute') ||
       message.includes('is required') ||
-      message.includes('must be')
+      message.includes('must be') ||
+      message.startsWith('Invalid list attributes') // wrapped 400 from base.ts
     ) {
       return {
         category: ListErrorCategory.UNSUPPORTED_INPUT,

--- a/src/services/lists/index.ts
+++ b/src/services/lists/index.ts
@@ -1,0 +1,22 @@
+/**
+ * List configuration services barrel export.
+ */
+export {
+  ListConfigurationValidator,
+  invalidateObjectCache,
+} from './ListConfigurationValidator.js';
+export {
+  LIST_TEMPLATES,
+  expandTemplate,
+  getTemplateNames,
+} from './list-templates.js';
+export {
+  IMMUTABLE_LIST_FIELDS,
+  ListErrorCategory,
+  normalizeListResponse,
+} from './types.js';
+export type {
+  NormalizedListResponse,
+  ListTemplate,
+  CategorizedListError,
+} from './types.js';

--- a/src/services/lists/list-templates.ts
+++ b/src/services/lists/list-templates.ts
@@ -1,0 +1,97 @@
+/**
+ * Static list template catalog and expansion logic.
+ *
+ * Templates provide opinionated defaults for common CRM list types.
+ * Template expansion merges caller overrides onto template defaults
+ * before validation, so dry-run and error messages reference actual values.
+ */
+import type { ListTemplate } from './types.js';
+
+/**
+ * The static template catalog. Easy to extend by adding entries.
+ */
+export const LIST_TEMPLATES: Readonly<Record<string, ListTemplate>> = {
+  sales_pipeline: {
+    name: 'Sales Pipeline',
+    parent_object: 'companies',
+    description: 'Track deals through pipeline stages',
+    attributes: {
+      stages: [
+        'Prospect',
+        'Qualified',
+        'Demo',
+        'Proposal',
+        'Negotiation',
+        'Won',
+        'Lost',
+      ],
+    },
+  },
+  recruiting_tracker: {
+    name: 'Recruiting Tracker',
+    parent_object: 'people',
+    description: 'Track candidates through the hiring process',
+    attributes: {
+      stages: [
+        'Applied',
+        'Screening',
+        'Interview',
+        'Offer',
+        'Hired',
+        'Rejected',
+      ],
+    },
+  },
+  support_queue: {
+    name: 'Support Queue',
+    parent_object: 'companies',
+    description: 'Manage support tickets by priority and status',
+    attributes: {
+      stages: ['New', 'In Progress', 'Waiting', 'Resolved', 'Closed'],
+    },
+  },
+};
+
+/**
+ * Return the list of valid template names.
+ */
+export function getTemplateNames(): string[] {
+  return Object.keys(LIST_TEMPLATES);
+}
+
+/**
+ * Expand a template by merging caller overrides onto template defaults.
+ *
+ * Caller values take precedence over template defaults.
+ * The `name` and `parent_object` from the template are used as defaults
+ * only if the caller does not supply them.
+ *
+ * @throws Error if the template name is not found in the catalog
+ */
+export function expandTemplate(
+  templateName: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const template = LIST_TEMPLATES[templateName];
+  if (!template) {
+    const valid = getTemplateNames().join(', ');
+    throw new Error(
+      `Unknown template "${templateName}". Valid templates: ${valid}`
+    );
+  }
+
+  // Start with template defaults, then overlay caller overrides
+  const expanded: Record<string, unknown> = {
+    name: template.name,
+    parent_object: template.parent_object,
+    ...template.attributes,
+    ...overrides,
+  };
+
+  // Preserve template description if caller didn't override
+  if (!overrides.description && template.description) {
+    expanded.description = template.description;
+  }
+
+  return expanded;
+}

--- a/src/services/lists/types.ts
+++ b/src/services/lists/types.ts
@@ -59,8 +59,18 @@ export function normalizeListResponse(
   raw: AttioList,
   dryRun?: boolean
 ): NormalizedListResponse {
+  if (!raw || typeof raw !== 'object') {
+    return {
+      list_id: '',
+      name: '',
+      parent_object: '',
+      fields_summary: {},
+      ...(dryRun ? { dry_run: true } : {}),
+    };
+  }
+
   const listId = raw.id?.list_id ?? '';
-  const name = raw.name || raw.title || '';
+  const name = raw.title || raw.name || '';
   const parentObject = raw.object_slug || '';
 
   // Build fields_summary from all non-metadata fields

--- a/src/services/lists/types.ts
+++ b/src/services/lists/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared types for list configuration tools and validation.
+ */
+import type { AttioList } from '@/types/attio.js';
+
+/**
+ * Normalized response shape returned by both dedicated list tools
+ * and the universal path after validation/normalization.
+ */
+export interface NormalizedListResponse {
+  list_id: string;
+  name: string;
+  parent_object: string;
+  fields_summary: Record<string, unknown>;
+  dry_run?: boolean;
+}
+
+/**
+ * A list template definition in the static catalog.
+ */
+export interface ListTemplate {
+  name: string;
+  parent_object: string;
+  description?: string;
+  attributes: Record<string, unknown>;
+}
+
+/**
+ * Error categories for list operations, each with a suggested next step.
+ */
+export enum ListErrorCategory {
+  UNSUPPORTED_INPUT = 'unsupported_input',
+  TOKEN_SCOPE = 'token_scope',
+  PERMISSION_FAILURE = 'permission_failure',
+  API_FAILURE = 'api_failure',
+}
+
+/**
+ * Categorized error with a suggested next step for the caller.
+ */
+export interface CategorizedListError {
+  category: ListErrorCategory;
+  message: string;
+  suggested_next_step: string;
+}
+
+/**
+ * Fields that are immutable on existing Attio lists.
+ * Attempts to update these fields should be rejected before the API call.
+ */
+export const IMMUTABLE_LIST_FIELDS: ReadonlySet<string> = new Set([
+  'parent_object',
+]);
+
+/**
+ * Build a NormalizedListResponse from a raw AttioList.
+ */
+export function normalizeListResponse(
+  raw: AttioList,
+  dryRun?: boolean
+): NormalizedListResponse {
+  const listId = raw.id?.list_id ?? '';
+  const name = raw.name || raw.title || '';
+  const parentObject = raw.object_slug || '';
+
+  // Build fields_summary from all non-metadata fields
+  const fieldsSummary: Record<string, unknown> = {};
+  const skipKeys = new Set([
+    'id',
+    'title',
+    'name',
+    'object_slug',
+    'workspace_id',
+    'created_at',
+    'updated_at',
+    'entry_count',
+  ]);
+  for (const [key, value] of Object.entries(raw)) {
+    if (!skipKeys.has(key) && value !== undefined) {
+      fieldsSummary[key] = value;
+    }
+  }
+
+  const result: NormalizedListResponse = {
+    list_id: listId,
+    name,
+    parent_object: parentObject,
+    fields_summary: fieldsSummary,
+  };
+
+  if (dryRun) {
+    result.dry_run = true;
+  }
+
+  return result;
+}

--- a/src/services/update/strategies/ListUpdateStrategy.ts
+++ b/src/services/update/strategies/ListUpdateStrategy.ts
@@ -2,7 +2,7 @@ import { getFieldSuggestions } from '@/handlers/tool-configs/universal/field-map
 import {
   UniversalValidationError,
   ErrorType,
-} from '@/handlers/tool-configs/universal/schemas.js';
+} from '@/handlers/tool-configs/universal/errors/validation-errors.js';
 import { updateList } from '@/objects/lists.js';
 import type { AttioList } from '@/types/attio.js';
 import type { UpdateStrategy } from '@/services/update/strategies/BaseUpdateStrategy.js';

--- a/src/services/update/strategies/ListUpdateStrategy.ts
+++ b/src/services/update/strategies/ListUpdateStrategy.ts
@@ -6,6 +6,7 @@ import {
 import { updateList } from '@/objects/lists.js';
 import type { AttioList } from '@/types/attio.js';
 import type { UpdateStrategy } from '@/services/update/strategies/BaseUpdateStrategy.js';
+import { ListConfigurationValidator } from '@/services/lists/ListConfigurationValidator.js';
 
 /**
  * ListUpdateStrategy - Handles updates for Attio Lists
@@ -19,6 +20,9 @@ export class ListUpdateStrategy implements UpdateStrategy {
     values: Record<string, unknown>,
     resourceType: string
   ): Promise<AttioList> {
+    // Detect immutable fields before API call (Issue #1195)
+    ListConfigurationValidator.detectImmutableFields(values);
+
     try {
       const list = await updateList(recordId, values);
       return {

--- a/test/services/lists/ListConfigurationValidator.test.ts
+++ b/test/services/lists/ListConfigurationValidator.test.ts
@@ -280,8 +280,11 @@ describe('ListConfigurationValidator', () => {
       expect(result.category).toBe(ListErrorCategory.UNSUPPORTED_INPUT);
     });
 
-    it('categorizes "Invalid" messages as unsupported_input', () => {
-      const error = new Error('Invalid list attributes: bad request');
+    it('categorizes 400-status errors as unsupported_input', () => {
+      const error = {
+        message: 'Invalid list attributes: bad request',
+        response: { status: 400 },
+      };
       const result = ListConfigurationValidator.categorizeError(error);
       expect(result.category).toBe(ListErrorCategory.UNSUPPORTED_INPUT);
     });
@@ -290,6 +293,13 @@ describe('ListConfigurationValidator', () => {
       const error = new Error('Something went wrong');
       const result = ListConfigurationValidator.categorizeError(error);
       expect(result.category).toBe(ListErrorCategory.API_FAILURE);
+    });
+
+    it('categorizes AttioApiError with 403 as permission_failure', async () => {
+      const { AttioApiError } = await import('@/errors/api-errors.js');
+      const error = new AttioApiError('Forbidden', 403, '/lists', 'POST');
+      const result = ListConfigurationValidator.categorizeError(error);
+      expect(result.category).toBe(ListErrorCategory.PERMISSION_FAILURE);
     });
   });
 });

--- a/test/services/lists/ListConfigurationValidator.test.ts
+++ b/test/services/lists/ListConfigurationValidator.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for ListConfigurationValidator.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ListConfigurationValidator,
+  invalidateObjectCache,
+} from '@/services/lists/ListConfigurationValidator.js';
+import {
+  IMMUTABLE_LIST_FIELDS,
+  ListErrorCategory,
+  normalizeListResponse,
+} from '@/services/lists/types.js';
+import type { AttioList } from '@/types/attio.js';
+
+// Mock the lazy client to control workspace object responses
+vi.mock('@/api/lazy-client.js', () => ({
+  getLazyAttioClient: vi.fn(() => ({
+    get: vi.fn(),
+  })),
+}));
+
+import { getLazyAttioClient } from '@/api/lazy-client.js';
+
+describe('ListConfigurationValidator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateObjectCache();
+  });
+
+  // --- validateParentObject ---
+
+  describe('validateParentObject', () => {
+    it('rejects empty or non-string parent_object', async () => {
+      await expect(
+        ListConfigurationValidator.validateParentObject('')
+      ).rejects.toThrow('parent_object is required');
+    });
+
+    it('rejects invalid parent_object with list of valid options', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        data: {
+          data: [
+            { api_slug: 'companies' },
+            { api_slug: 'people' },
+            { slug: 'deals' },
+          ],
+        },
+      });
+      vi.mocked(getLazyAttioClient).mockReturnValue({
+        get: mockGet,
+      } as never);
+
+      await expect(
+        ListConfigurationValidator.validateParentObject('invalid_object')
+      ).rejects.toThrow('Invalid parent_object "invalid_object"');
+
+      try {
+        await ListConfigurationValidator.validateParentObject('invalid_object');
+      } catch (e: unknown) {
+        const err = e as { suggestion?: string };
+        expect(err.suggestion).toContain('companies');
+        expect(err.suggestion).toContain('people');
+      }
+    });
+
+    it('passes for valid parent_object', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        data: {
+          data: [{ api_slug: 'companies' }, { api_slug: 'people' }],
+        },
+      });
+      vi.mocked(getLazyAttioClient).mockReturnValue({
+        get: mockGet,
+      } as never);
+
+      const result =
+        await ListConfigurationValidator.validateParentObject('companies');
+      expect(result).toBe('companies');
+    });
+
+    it('allows through when workspace objects fetch fails', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new Error('Network error'));
+      vi.mocked(getLazyAttioClient).mockReturnValue({
+        get: mockGet,
+      } as never);
+
+      // Should not throw — let API reject instead
+      const result =
+        await ListConfigurationValidator.validateParentObject('companies');
+      expect(result).toBe('companies');
+    });
+
+    it('uses cache on subsequent calls', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        data: {
+          data: [{ api_slug: 'companies' }],
+        },
+      });
+      vi.mocked(getLazyAttioClient).mockReturnValue({
+        get: mockGet,
+      } as never);
+
+      await ListConfigurationValidator.validateParentObject('companies');
+      await ListConfigurationValidator.validateParentObject('companies');
+
+      // Only one API call due to caching
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // --- detectImmutableFields ---
+
+  describe('detectImmutableFields', () => {
+    it('passes when no immutable fields are present', () => {
+      expect(() =>
+        ListConfigurationValidator.detectImmutableFields({ name: 'New Name' })
+      ).not.toThrow();
+    });
+
+    it('rejects parent_object as immutable', () => {
+      expect(() =>
+        ListConfigurationValidator.detectImmutableFields({
+          parent_object: 'people',
+        })
+      ).toThrow('Cannot update immutable field(s): parent_object');
+    });
+
+    it('error includes suggestion to create new list', () => {
+      try {
+        ListConfigurationValidator.detectImmutableFields({
+          parent_object: 'people',
+        });
+      } catch (e: unknown) {
+        const err = e as { suggestion?: string };
+        expect(err.suggestion).toContain('create a new list');
+      }
+    });
+
+    it('handles null/undefined attributes gracefully', () => {
+      expect(() =>
+        ListConfigurationValidator.detectImmutableFields(null as never)
+      ).not.toThrow();
+      expect(() =>
+        ListConfigurationValidator.detectImmutableFields(undefined as never)
+      ).not.toThrow();
+    });
+
+    it('IMMUTABLE_LIST_FIELDS contains parent_object', () => {
+      expect(IMMUTABLE_LIST_FIELDS.has('parent_object')).toBe(true);
+    });
+  });
+
+  // --- expandTemplate ---
+
+  describe('expandTemplate', () => {
+    it('delegates to list-templates expandTemplate', () => {
+      const result = ListConfigurationValidator.expandTemplate(
+        'sales_pipeline',
+        {
+          name: 'My Pipeline',
+        }
+      );
+      expect(result.name).toBe('My Pipeline');
+      expect(result.parent_object).toBe('companies');
+    });
+
+    it('throws for unknown template', () => {
+      expect(() =>
+        ListConfigurationValidator.expandTemplate('nonexistent')
+      ).toThrow('Unknown template');
+    });
+  });
+
+  // --- normalizeResponse ---
+
+  describe('normalizeResponse', () => {
+    const rawList: AttioList = {
+      id: { list_id: 'list-123' },
+      title: 'My List',
+      name: 'My List',
+      object_slug: 'companies',
+      workspace_id: 'ws-456',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-02',
+      entry_count: 10,
+      description: 'A test list',
+    };
+
+    it('returns normalized shape with list_id, name, parent_object', () => {
+      const result = ListConfigurationValidator.normalizeResponse(rawList);
+      expect(result.list_id).toBe('list-123');
+      expect(result.name).toBe('My List');
+      expect(result.parent_object).toBe('companies');
+    });
+
+    it('includes fields_summary with non-metadata fields', () => {
+      const result = ListConfigurationValidator.normalizeResponse(rawList);
+      expect(result.fields_summary).toBeDefined();
+      expect(result.fields_summary.description).toBe('A test list');
+      // Metadata fields excluded
+      expect('id' in result.fields_summary).toBe(false);
+      expect('workspace_id' in result.fields_summary).toBe(false);
+    });
+
+    it('includes dry_run flag when set', () => {
+      const result = ListConfigurationValidator.normalizeResponse(
+        rawList,
+        true
+      );
+      expect(result.dry_run).toBe(true);
+    });
+
+    it('omits dry_run when not set', () => {
+      const result = ListConfigurationValidator.normalizeResponse(rawList);
+      expect(result.dry_run).toBeUndefined();
+    });
+
+    it('falls back to title when name is absent', () => {
+      const noName = { ...rawList, name: undefined };
+      const result = ListConfigurationValidator.normalizeResponse(noName);
+      expect(result.name).toBe('My List'); // title fallback
+    });
+  });
+
+  // --- categorizeError ---
+
+  describe('categorizeError', () => {
+    it('categorizes 403 as permission_failure', () => {
+      const error = { message: 'Forbidden', response: { status: 403 } };
+      const result = ListConfigurationValidator.categorizeError(error);
+      expect(result.category).toBe(ListErrorCategory.PERMISSION_FAILURE);
+      expect(result.suggested_next_step).toContain('permissions');
+    });
+
+    it('categorizes 401 as token_scope', () => {
+      const error = { message: 'Unauthorized', response: { status: 401 } };
+      const result = ListConfigurationValidator.categorizeError(error);
+      expect(result.category).toBe(ListErrorCategory.TOKEN_SCOPE);
+    });
+
+    it('categorizes "Cannot find attribute" as unsupported_input', () => {
+      const error = new Error('Cannot find attribute with slug/ID "bad_field"');
+      const result = ListConfigurationValidator.categorizeError(error);
+      expect(result.category).toBe(ListErrorCategory.UNSUPPORTED_INPUT);
+    });
+
+    it('categorizes "Invalid" messages as unsupported_input', () => {
+      const error = new Error('Invalid list attributes: bad request');
+      const result = ListConfigurationValidator.categorizeError(error);
+      expect(result.category).toBe(ListErrorCategory.UNSUPPORTED_INPUT);
+    });
+
+    it('categorizes unknown errors as api_failure', () => {
+      const error = new Error('Something went wrong');
+      const result = ListConfigurationValidator.categorizeError(error);
+      expect(result.category).toBe(ListErrorCategory.API_FAILURE);
+    });
+  });
+});
+
+// --- normalizeListResponse standalone tests ---
+
+describe('normalizeListResponse', () => {
+  it('handles empty id gracefully', () => {
+    const raw = {
+      id: {},
+      title: 'Test',
+      object_slug: 'people',
+      workspace_id: 'ws',
+      created_at: '',
+      updated_at: '',
+    } as AttioList;
+    const result = normalizeListResponse(raw);
+    expect(result.list_id).toBe('');
+    expect(result.name).toBe('Test');
+  });
+});

--- a/test/services/lists/ListConfigurationValidator.test.ts
+++ b/test/services/lists/ListConfigurationValidator.test.ts
@@ -107,6 +107,41 @@ describe('ListConfigurationValidator', () => {
       // Only one API call due to caching
       expect(mockGet).toHaveBeenCalledTimes(1);
     });
+
+    it('paginates when workspace has >200 objects', async () => {
+      // First page: 200 items (full page → hasMore)
+      const page1 = Array.from({ length: 200 }, (_, i) => ({
+        api_slug: `obj_${i}`,
+      }));
+      // Second page: 5 items (partial → done)
+      const page2 = [
+        { api_slug: 'companies' },
+        { api_slug: 'people' },
+        { api_slug: 'deals' },
+        { api_slug: 'custom_obj_1' },
+        { api_slug: 'custom_obj_2' },
+      ];
+
+      const mockGet = vi
+        .fn()
+        .mockResolvedValueOnce({ data: { data: page1 } })
+        .mockResolvedValueOnce({ data: { data: page2 } });
+
+      vi.mocked(getLazyAttioClient).mockReturnValue({
+        get: mockGet,
+      } as never);
+
+      const result =
+        await ListConfigurationValidator.validateParentObject('companies');
+      expect(result).toBe('companies');
+
+      // Two API calls: page 1 + page 2
+      expect(mockGet).toHaveBeenCalledTimes(2);
+      // Verify offset was passed for pagination
+      expect(mockGet).toHaveBeenNthCalledWith(2, '/objects', {
+        params: { limit: 200, offset: 200 },
+      });
+    });
   });
 
   // --- detectImmutableFields ---

--- a/test/services/lists/list-config-handler.test.ts
+++ b/test/services/lists/list-config-handler.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Handler-level tests for create-list and update-list-configuration tools.
+ * Tests the actual dispatcher handler functions, not just the validator.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  handleCreateListOperation,
+  handleUpdateListConfigurationOperation,
+} from '@/handlers/tools/dispatcher/operations/lists.js';
+import { invalidateObjectCache } from '@/services/lists/ListConfigurationValidator.js';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolConfig } from '@/handlers/tool-types.js';
+
+// Mock the lazy client
+vi.mock('@/api/lazy-client.js', () => ({
+  getLazyAttioClient: vi.fn(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  })),
+}));
+
+// Mock createList / updateList
+vi.mock('@/objects/lists/base.js', () => ({
+  createList: vi.fn(),
+  updateList: vi.fn(),
+}));
+
+import { getLazyAttioClient } from '@/api/lazy-client.js';
+import { createList, updateList } from '@/objects/lists/base.js';
+
+function makeRequest(
+  toolName: string,
+  args: Record<string, unknown>
+): CallToolRequest {
+  return {
+    method: 'tools/call' as const,
+    params: { name: toolName, arguments: args },
+  };
+}
+
+const mockToolConfig: ToolConfig = {
+  name: 'create-list',
+  handler: vi.fn(),
+  formatResult: (result: unknown) => JSON.stringify(result),
+};
+
+function setupWorkspaceObjects(slugs: string[]) {
+  const mockGet = vi.fn().mockResolvedValue({
+    data: { data: slugs.map((s) => ({ api_slug: s })) },
+  });
+  vi.mocked(getLazyAttioClient).mockReturnValue({
+    get: mockGet,
+    post: vi.fn(),
+    patch: vi.fn(),
+  } as never);
+}
+
+describe('handleCreateListOperation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateObjectCache();
+  });
+
+  it('returns error when name is missing', async () => {
+    const result = await handleCreateListOperation(
+      makeRequest('create-list', { parent_object: 'companies' }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('name parameter is required');
+  });
+
+  it('returns error when parent_object is missing', async () => {
+    const result = await handleCreateListOperation(
+      makeRequest('create-list', { name: 'Test' }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('parent_object parameter is required');
+  });
+
+  it('returns error for invalid parent_object', async () => {
+    setupWorkspaceObjects(['companies', 'people']);
+
+    const result = await handleCreateListOperation(
+      makeRequest('create-list', {
+        name: 'Bad List',
+        parent_object: 'nonexistent',
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('Invalid parent_object');
+  });
+
+  it('creates list with valid params', async () => {
+    setupWorkspaceObjects(['companies']);
+    vi.mocked(createList).mockResolvedValue({
+      id: { list_id: 'new-123' },
+      title: 'My List',
+      name: 'My List',
+      object_slug: 'companies',
+      workspace_id: 'ws-1',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    });
+
+    const result = await handleCreateListOperation(
+      makeRequest('create-list', {
+        name: 'My List',
+        parent_object: 'companies',
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('new-123');
+    expect(text).toContain('companies');
+    expect(createList).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'My List', parent_object: 'companies' })
+    );
+  });
+
+  it('returns dry-run preview without API call', async () => {
+    setupWorkspaceObjects(['companies']);
+
+    const result = await handleCreateListOperation(
+      makeRequest('create-list', {
+        name: 'Pipeline',
+        parent_object: 'companies',
+        dry_run: true,
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('dry_run');
+    expect(text).toContain('dry-run-preview');
+    expect(createList).not.toHaveBeenCalled();
+  });
+
+  it('expands template before validation', async () => {
+    setupWorkspaceObjects(['companies']);
+    vi.mocked(createList).mockResolvedValue({
+      id: { list_id: 'tpl-123' },
+      title: 'Sales Pipeline',
+      name: 'Sales Pipeline',
+      object_slug: 'companies',
+      workspace_id: 'ws-1',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    });
+
+    const result = await handleCreateListOperation(
+      makeRequest('create-list', {
+        name: 'Sales Pipeline',
+        parent_object: 'companies',
+        template: 'sales_pipeline',
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('tpl-123');
+    expect(createList).toHaveBeenCalledWith(
+      expect.objectContaining({ stages: expect.any(Array) })
+    );
+  });
+});
+
+describe('handleUpdateListConfigurationOperation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateObjectCache();
+  });
+
+  it('returns error when listId is missing', async () => {
+    const result = await handleUpdateListConfigurationOperation(
+      makeRequest('update-list-configuration', {
+        attributes: { name: 'New' },
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('listId parameter is required');
+  });
+
+  it('returns error when attributes are missing', async () => {
+    const result = await handleUpdateListConfigurationOperation(
+      makeRequest('update-list-configuration', { listId: 'list-1' }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('attributes parameter is required');
+  });
+
+  it('rejects immutable field parent_object', async () => {
+    const result = await handleUpdateListConfigurationOperation(
+      makeRequest('update-list-configuration', {
+        listId: 'list-1',
+        attributes: { parent_object: 'people', name: 'New' },
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('immutable');
+    expect(updateList).not.toHaveBeenCalled();
+  });
+
+  it('updates list with valid attributes', async () => {
+    vi.mocked(updateList).mockResolvedValue({
+      id: { list_id: 'list-1' },
+      title: 'Updated Name',
+      name: 'Updated Name',
+      object_slug: 'companies',
+      workspace_id: 'ws-1',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-02',
+    });
+
+    const result = await handleUpdateListConfigurationOperation(
+      makeRequest('update-list-configuration', {
+        listId: 'list-1',
+        attributes: { name: 'Updated Name' },
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('list-1');
+    expect(text).toContain('Updated Name');
+    expect(updateList).toHaveBeenCalledWith('list-1', { name: 'Updated Name' });
+  });
+
+  it('returns dry-run preview without API call', async () => {
+    const result = await handleUpdateListConfigurationOperation(
+      makeRequest('update-list-configuration', {
+        listId: 'list-1',
+        attributes: { name: 'Preview' },
+        dry_run: true,
+      }),
+      mockToolConfig
+    );
+    const text = (result as { content: Array<{ text: string }> }).content[0]
+      .text;
+    expect(text).toContain('dry_run');
+    expect(text).toContain('list-1');
+    expect(updateList).not.toHaveBeenCalled();
+  });
+});

--- a/test/services/lists/list-configuration-tools.test.ts
+++ b/test/services/lists/list-configuration-tools.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for create-list and update-list-configuration dedicated tools.
+ * Tests the dispatcher handler logic via the ListConfigurationValidator integration.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ListConfigurationValidator,
+  invalidateObjectCache,
+} from '@/services/lists/ListConfigurationValidator.js';
+import { expandTemplate } from '@/services/lists/list-templates.js';
+import type { AttioList } from '@/types/attio.js';
+
+// Mock the lazy client
+vi.mock('@/api/lazy-client.js', () => ({
+  getLazyAttioClient: vi.fn(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  })),
+}));
+
+// Mock the objects/lists/base module
+vi.mock('@/objects/lists/base.js', () => ({
+  createList: vi.fn(),
+  updateList: vi.fn(),
+}));
+
+import { getLazyAttioClient } from '@/api/lazy-client.js';
+import { createList, updateList } from '@/objects/lists/base.js';
+
+describe('create-list tool logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateObjectCache();
+  });
+
+  it('validates parent_object before creating', async () => {
+    const mockGet = vi.fn().mockResolvedValue({
+      data: { data: [{ api_slug: 'companies' }, { api_slug: 'people' }] },
+    });
+    vi.mocked(getLazyAttioClient).mockReturnValue({
+      get: mockGet,
+      post: vi.fn(),
+      patch: vi.fn(),
+    } as never);
+
+    // Invalid parent_object should throw
+    await expect(
+      ListConfigurationValidator.validateParentObject('nonexistent')
+    ).rejects.toThrow('Invalid parent_object "nonexistent"');
+  });
+
+  it('creates list with valid parent_object', async () => {
+    const mockGet = vi.fn().mockResolvedValue({
+      data: { data: [{ api_slug: 'companies' }] },
+    });
+    const mockPost = vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          id: { list_id: 'new-list-123' },
+          title: 'My Pipeline',
+          name: 'My Pipeline',
+          object_slug: 'companies',
+          workspace_id: 'ws-1',
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+      },
+    });
+    vi.mocked(getLazyAttioClient).mockReturnValue({
+      get: mockGet,
+      post: mockPost,
+      patch: vi.fn(),
+    } as never);
+
+    const mockList: AttioList = {
+      id: { list_id: 'new-list-123' },
+      title: 'My Pipeline',
+      name: 'My Pipeline',
+      object_slug: 'companies',
+      workspace_id: 'ws-1',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    };
+    vi.mocked(createList).mockResolvedValue(mockList);
+
+    // Validate parent_object passes
+    const validated =
+      await ListConfigurationValidator.validateParentObject('companies');
+    expect(validated).toBe('companies');
+
+    // Create list
+    const result = await createList({
+      name: 'My Pipeline',
+      parent_object: 'companies',
+    });
+    expect(result.id.list_id).toBe('new-list-123');
+
+    // Normalize
+    const normalized = ListConfigurationValidator.normalizeResponse(result);
+    expect(normalized.list_id).toBe('new-list-123');
+    expect(normalized.name).toBe('My Pipeline');
+    expect(normalized.parent_object).toBe('companies');
+  });
+
+  it('expands template before validation', () => {
+    const expanded = expandTemplate('sales_pipeline', { name: 'Custom Name' });
+    expect(expanded.name).toBe('Custom Name');
+    expect(expanded.parent_object).toBe('companies');
+    expect(expanded.stages).toBeDefined();
+  });
+
+  it('dry-run returns preview without API call', async () => {
+    const mockGet = vi.fn().mockResolvedValue({
+      data: { data: [{ api_slug: 'companies' }] },
+    });
+    vi.mocked(getLazyAttioClient).mockReturnValue({
+      get: mockGet,
+      post: vi.fn(),
+      patch: vi.fn(),
+    } as never);
+
+    // Validate passes
+    await ListConfigurationValidator.validateParentObject('companies');
+
+    // Build preview (same as dispatcher dry-run logic)
+    const preview = ListConfigurationValidator.normalizeResponse(
+      {
+        id: { list_id: 'dry-run-preview' },
+        title: 'Test Pipeline',
+        object_slug: 'companies',
+        workspace_id: 'preview',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      } as AttioList,
+      true
+    );
+
+    expect(preview.dry_run).toBe(true);
+    expect(preview.list_id).toBe('dry-run-preview');
+    expect(preview.name).toBe('Test Pipeline');
+    expect(preview.parent_object).toBe('companies');
+
+    // createList should NOT have been called
+    expect(createList).not.toHaveBeenCalled();
+  });
+});
+
+describe('update-list-configuration tool logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateObjectCache();
+  });
+
+  it('rejects immutable field parent_object', () => {
+    expect(() =>
+      ListConfigurationValidator.detectImmutableFields({
+        parent_object: 'people',
+        name: 'New Name',
+      })
+    ).toThrow('Cannot update immutable field(s): parent_object');
+  });
+
+  it('allows non-immutable fields', () => {
+    expect(() =>
+      ListConfigurationValidator.detectImmutableFields({
+        name: 'New Name',
+        description: 'Updated desc',
+      })
+    ).not.toThrow();
+  });
+
+  it('updates list with valid attributes', async () => {
+    const mockList: AttioList = {
+      id: { list_id: 'list-456' },
+      title: 'Updated Name',
+      name: 'Updated Name',
+      object_slug: 'companies',
+      workspace_id: 'ws-1',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-02',
+    };
+    vi.mocked(updateList).mockResolvedValue(mockList);
+
+    const result = await updateList('list-456', { name: 'Updated Name' });
+    const normalized = ListConfigurationValidator.normalizeResponse(result);
+    expect(normalized.name).toBe('Updated Name');
+    expect(normalized.list_id).toBe('list-456');
+  });
+
+  it('dry-run returns preview without API call', () => {
+    const preview = ListConfigurationValidator.normalizeResponse(
+      {
+        id: { list_id: 'list-456' },
+        title: 'Preview Name',
+        object_slug: 'companies',
+        workspace_id: 'preview',
+        created_at: '',
+        updated_at: new Date().toISOString(),
+      } as AttioList,
+      true
+    );
+
+    expect(preview.dry_run).toBe(true);
+    expect(preview.list_id).toBe('list-456');
+    expect(updateList).not.toHaveBeenCalled();
+  });
+
+  it('categorizes permission errors with next steps', () => {
+    const error = { message: 'Forbidden', response: { status: 403 } };
+    const categorized = ListConfigurationValidator.categorizeError(error);
+    expect(categorized.category).toBe('permission_failure');
+    expect(categorized.suggested_next_step).toContain('permissions');
+  });
+});

--- a/test/services/lists/list-strategies-hardening.test.ts
+++ b/test/services/lists/list-strategies-hardening.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for universal path hardening (Issue #1195).
+ * Verifies ListCreateStrategy and ListUpdateStrategy consume the shared validator.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ListCreateStrategy } from '@/services/create/strategies/ListCreateStrategy.js';
+import { ListUpdateStrategy } from '@/services/update/strategies/ListUpdateStrategy.js';
+import { invalidateObjectCache } from '@/services/lists/ListConfigurationValidator.js';
+import type { AttioList } from '@/types/attio.js';
+
+// Mock the lazy client for workspace object fetching
+vi.mock('@/api/lazy-client.js', () => ({
+  getLazyAttioClient: vi.fn(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  })),
+}));
+
+// Mock the objects/lists module
+vi.mock('@/objects/lists.js', () => ({
+  createList: vi.fn(),
+  updateList: vi.fn(),
+}));
+
+// Mock field-mapper (used by both strategies for error handling)
+vi.mock('@/handlers/tool-configs/universal/field-mapper.js', () => ({
+  getFieldSuggestions: vi.fn().mockReturnValue('Try using a valid field name'),
+}));
+
+import { getLazyAttioClient } from '@/api/lazy-client.js';
+import { createList, updateList } from '@/objects/lists.js';
+
+const mockList: AttioList = {
+  id: { list_id: 'list-789' },
+  title: 'Test List',
+  name: 'Test List',
+  object_slug: 'companies',
+  workspace_id: 'ws-1',
+  created_at: '2024-01-01',
+  updated_at: '2024-01-02',
+};
+
+describe('ListCreateStrategy (hardened)', () => {
+  let strategy: ListCreateStrategy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateObjectCache();
+    strategy = new ListCreateStrategy();
+  });
+
+  it('validates parent_object before creating', async () => {
+    const mockGet = vi.fn().mockResolvedValue({
+      data: { data: [{ api_slug: 'companies' }, { api_slug: 'people' }] },
+    });
+    vi.mocked(getLazyAttioClient).mockReturnValue({
+      get: mockGet,
+      post: vi.fn(),
+      patch: vi.fn(),
+    } as never);
+
+    vi.mocked(createList).mockResolvedValue(mockList);
+
+    const result = await strategy.create({
+      values: { name: 'Test', parent_object: 'companies' },
+      resourceType: 'lists',
+    });
+
+    expect(result.id.list_id).toBe('list-789');
+    expect(createList).toHaveBeenCalledWith({
+      name: 'Test',
+      parent_object: 'companies',
+    });
+  });
+
+  it('rejects invalid parent_object before API call', async () => {
+    const mockGet = vi.fn().mockResolvedValue({
+      data: { data: [{ api_slug: 'companies' }] },
+    });
+    vi.mocked(getLazyAttioClient).mockReturnValue({
+      get: mockGet,
+      post: vi.fn(),
+      patch: vi.fn(),
+    } as never);
+
+    await expect(
+      strategy.create({
+        values: { name: 'Test', parent_object: 'invalid_object' },
+        resourceType: 'lists',
+      })
+    ).rejects.toThrow('Invalid parent_object "invalid_object"');
+
+    // API should NOT be called
+    expect(createList).not.toHaveBeenCalled();
+  });
+
+  it('skips validation when parent_object is absent', async () => {
+    const mockGet = vi.fn().mockResolvedValue({
+      data: { data: [{ api_slug: 'companies' }] },
+    });
+    vi.mocked(getLazyAttioClient).mockReturnValue({
+      get: mockGet,
+      post: vi.fn(),
+      patch: vi.fn(),
+    } as never);
+
+    vi.mocked(createList).mockResolvedValue(mockList);
+
+    // No parent_object — validation skipped
+    const result = await strategy.create({
+      values: { name: 'Test' },
+      resourceType: 'lists',
+    });
+
+    expect(result).toBeDefined();
+    // Workspace objects should NOT have been fetched
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('ListUpdateStrategy (hardened)', () => {
+  let strategy: ListUpdateStrategy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateObjectCache();
+    strategy = new ListUpdateStrategy();
+  });
+
+  it('allows non-immutable field updates', async () => {
+    vi.mocked(updateList).mockResolvedValue(mockList);
+
+    const result = await strategy.update(
+      'list-789',
+      { name: 'New Name' },
+      'lists'
+    );
+
+    expect(result.name).toBe('Test List');
+    expect(updateList).toHaveBeenCalledWith('list-789', { name: 'New Name' });
+  });
+
+  it('rejects parent_object as immutable before API call', async () => {
+    await expect(
+      strategy.update('list-789', { parent_object: 'people' }, 'lists')
+    ).rejects.toThrow('Cannot update immutable field(s): parent_object');
+
+    // API should NOT be called
+    expect(updateList).not.toHaveBeenCalled();
+  });
+
+  it('rejects update with both mutable and immutable fields', async () => {
+    await expect(
+      strategy.update(
+        'list-789',
+        { name: 'New Name', parent_object: 'people' },
+        'lists'
+      )
+    ).rejects.toThrow('Cannot update immutable field(s): parent_object');
+
+    expect(updateList).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing error handling for attribute errors', async () => {
+    vi.mocked(updateList).mockRejectedValue(
+      new Error('Cannot find attribute with slug/ID "bad_field"')
+    );
+
+    await expect(
+      strategy.update('list-789', { bad_field: 'value' }, 'lists')
+    ).rejects.toThrow('Cannot find attribute');
+  });
+});

--- a/test/services/lists/list-templates.test.ts
+++ b/test/services/lists/list-templates.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for list-templates module.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  LIST_TEMPLATES,
+  expandTemplate,
+  getTemplateNames,
+} from '@/services/lists/list-templates.js';
+
+describe('list-templates', () => {
+  describe('LIST_TEMPLATES', () => {
+    it('contains three initial templates', () => {
+      expect(Object.keys(LIST_TEMPLATES)).toHaveLength(3);
+      expect(LIST_TEMPLATES.sales_pipeline).toBeDefined();
+      expect(LIST_TEMPLATES.recruiting_tracker).toBeDefined();
+      expect(LIST_TEMPLATES.support_queue).toBeDefined();
+    });
+
+    it('each template has required fields', () => {
+      for (const template of Object.values(LIST_TEMPLATES)) {
+        expect(template.name).toBeTruthy();
+        expect(template.parent_object).toBeTruthy();
+        expect(template.attributes).toBeDefined();
+      }
+    });
+  });
+
+  describe('getTemplateNames', () => {
+    it('returns all template keys', () => {
+      const names = getTemplateNames();
+      expect(names).toContain('sales_pipeline');
+      expect(names).toContain('recruiting_tracker');
+      expect(names).toContain('support_queue');
+    });
+  });
+
+  describe('expandTemplate', () => {
+    it('expands a template with defaults', () => {
+      const result = expandTemplate('sales_pipeline');
+      expect(result.name).toBe('Sales Pipeline');
+      expect(result.parent_object).toBe('companies');
+      expect(result.description).toBe('Track deals through pipeline stages');
+      expect(result.stages).toBeDefined();
+    });
+
+    it('merges caller overrides onto template defaults', () => {
+      const result = expandTemplate('sales_pipeline', {
+        name: 'My Pipeline',
+      });
+      expect(result.name).toBe('My Pipeline');
+      expect(result.parent_object).toBe('companies'); // default preserved
+    });
+
+    it('preserves template description when caller does not override', () => {
+      const result = expandTemplate('sales_pipeline', { name: 'Custom' });
+      expect(result.description).toBe('Track deals through pipeline stages');
+    });
+
+    it('allows caller to override description', () => {
+      const result = expandTemplate('sales_pipeline', {
+        description: 'Custom desc',
+      });
+      expect(result.description).toBe('Custom desc');
+    });
+
+    it('throws for unknown template name', () => {
+      expect(() => expandTemplate('unknown_template')).toThrow(
+        /Unknown template "unknown_template"/
+      );
+    });
+
+    it('error message lists valid templates', () => {
+      try {
+        expandTemplate('nonexistent');
+      } catch (e) {
+        expect((e as Error).message).toContain('sales_pipeline');
+        expect((e as Error).message).toContain('recruiting_tracker');
+        expect((e as Error).message).toContain('support_queue');
+      }
+    });
+
+    it('expands recruiting_tracker with people parent', () => {
+      const result = expandTemplate('recruiting_tracker');
+      expect(result.parent_object).toBe('people');
+    });
+
+    it('expands support_queue with companies parent', () => {
+      const result = expandTemplate('support_queue');
+      expect(result.parent_object).toBe('companies');
+    });
+  });
+});

--- a/test/smoke-list-config-tools.test.ts
+++ b/test/smoke-list-config-tools.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Live smoke test for list configuration tools (Issue #1195).
+ * Uses real Attio API - requires ATTIO_API_KEY in .env.
+ *
+ * Run: bunx vitest run --config configs/vitest/vitest.config.ts test/smoke-list-config-tools.test.ts
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { executeToolRequest } from '@/handlers/tools/dispatcher/core.js';
+import { invalidateObjectCache } from '@/services/lists/ListConfigurationValidator.js';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+interface ToolResult {
+  content: Array<{ type?: string; text?: string }>;
+  isError?: boolean;
+}
+
+const hasApiKey = !!process.env.ATTIO_API_KEY;
+
+function makeRequest(
+  toolName: string,
+  args: Record<string, unknown>
+): CallToolRequest {
+  return {
+    method: 'tools/call' as const,
+    params: { name: toolName, arguments: args },
+  };
+}
+
+function getText(result: unknown): string {
+  const r = result as ToolResult;
+  return r?.content?.[0]?.text || '';
+}
+
+function isError(result: unknown): boolean {
+  const r = result as ToolResult;
+  return r?.isError === true;
+}
+
+describe.skipIf(!hasApiKey)('Live smoke: list configuration tools', () => {
+  let createdListId: string | null = null;
+
+  beforeEach(() => {
+    invalidateObjectCache();
+  });
+
+  it('create-list: basic creation', async () => {
+    const result = await executeToolRequest(
+      makeRequest('create-list', {
+        name: 'Smoke Test List',
+        parent_object: 'companies',
+        description: 'Created by smoke test - safe to delete',
+      })
+    );
+    const text = getText(result);
+    console.log('create-list response:', text.substring(0, 500));
+
+    expect(isError(result)).toBe(false);
+    const match = text.match(/"list_id"\s*:\s*"([^"]+)"/);
+    if (match) createdListId = match[1];
+    expect(text).toContain('list_id');
+    expect(text).toContain('companies');
+  });
+
+  it('create-list: template dry-run', async () => {
+    const result = await executeToolRequest(
+      makeRequest('create-list', {
+        name: 'Smoke Pipeline',
+        parent_object: 'companies',
+        template: 'sales_pipeline',
+        dry_run: true,
+      })
+    );
+    const text = getText(result);
+    console.log('template dry-run:', text.substring(0, 500));
+
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('dry_run');
+    expect(text).toContain('stages');
+  });
+
+  it('create-list: invalid parent_object is rejected', async () => {
+    const result = await executeToolRequest(
+      makeRequest('create-list', {
+        name: 'Bad List',
+        parent_object: 'nonexistent_object_xyz',
+      })
+    );
+    const text = getText(result);
+    console.log('invalid parent_object:', text.substring(0, 500));
+
+    // Should either be an error result or contain validation message
+    expect(isError(result) || text.includes('Invalid parent_object')).toBe(
+      true
+    );
+  });
+
+  it('update-list-configuration: rename', async () => {
+    if (!createdListId) return;
+    const result = await executeToolRequest(
+      makeRequest('update-list-configuration', {
+        listId: createdListId,
+        attributes: { name: 'Smoke Test List (Updated)' },
+      })
+    );
+    const text = getText(result);
+    console.log('update rename:', text.substring(0, 500));
+
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('list_id');
+  });
+
+  it('update-list-configuration: immutable field rejection', async () => {
+    if (!createdListId) return;
+    const result = await executeToolRequest(
+      makeRequest('update-list-configuration', {
+        listId: createdListId,
+        attributes: { parent_object: 'people' },
+      })
+    );
+    const text = getText(result);
+    console.log('immutable rejection:', text.substring(0, 500));
+
+    expect(isError(result) || text.includes('immutable')).toBe(true);
+  });
+
+  it('update-list-configuration: dry-run', async () => {
+    if (!createdListId) return;
+    const result = await executeToolRequest(
+      makeRequest('update-list-configuration', {
+        listId: createdListId,
+        attributes: { name: 'Dry Run Preview' },
+        dry_run: true,
+      })
+    );
+    const text = getText(result);
+    console.log('dry-run update:', text.substring(0, 500));
+
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('dry_run');
+  });
+
+  it('cleanup: delete test list', async () => {
+    if (!createdListId) return;
+    const result = await executeToolRequest(
+      makeRequest('delete-record', {
+        resource_type: 'lists',
+        record_id: createdListId,
+      })
+    );
+    console.log('cleanup done');
+    expect(result).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements dedicated list configuration tools with smart defaults, template expansion, immutable field detection, and dry-run mode.

## Changes

### U1: Shared List Configuration Validator
- **`src/services/lists/types.ts`** — `NormalizedListResponse`, `ListTemplate`, `CategorizedListError`, `IMMUTABLE_LIST_FIELDS`, `normalizeListResponse()`
- **`src/services/lists/list-templates.ts`** — Static template catalog (`sales_pipeline`, `recruiting_tracker`, `support_queue`) with `expandTemplate()` merging caller overrides onto defaults
- **`src/services/lists/ListConfigurationValidator.ts`** — Shared validator with:
  - `validateParentObject()` — auto-resolves valid objects via `GET /objects` with 60s in-memory cache
  - `detectImmutableFields()` — rejects `parent_object` updates before API call
  - `expandTemplate()` — delegates to list-templates
  - `normalizeResponse()` — consistent agent-friendly shape
  - `categorizeError()` — maps API errors to actionable categories with next-step guidance

### U2: Dedicated `create-list` Tool
- Tool config + definition in `src/handlers/tool-configs/lists.ts`
- Dispatcher handler `handleCreateListOperation` in `src/handlers/tools/dispatcher/operations/lists.ts`
- Template expansion before validation (R8), parent-object auto-resolution, dry-run preview, normalized response

### U3: Dedicated `update-list-configuration` Tool
- Tool config + definition in `src/handlers/tool-configs/lists.ts`
- Dispatcher handler `handleUpdateListConfigurationOperation` in `src/handlers/tools/dispatcher/operations/lists.ts`
- Immutable field detection (rejects `parent_object`), dry-run preview, categorized errors

### U4: Universal Path Hardening
- `ListCreateStrategy` now validates `parent_object` via shared validator before API call
- `ListUpdateStrategy` now detects immutable fields via shared validator before API call
- Consistent error handling between dedicated and universal paths

## Test Coverage
- 50 unit tests across 4 test files:
  - `list-templates.test.ts` (11 tests)
  - `ListConfigurationValidator.test.ts` (23 tests)
  - `list-configuration-tools.test.ts` (9 tests)
  - `list-strategies-hardening.test.ts` (7 tests)
- Full offline suite: 3522 tests passing

## Quality
- Typecheck: clean
- Lint: clean (0 errors, 1 pre-existing warning in tool-types.ts)

Closes #1195