### PR TITLE
Chore: prepare v1.6.1 release

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -102,10 +102,12 @@ jobs:
           node --version
           npm --version
 
-      - name: Publish to NPM with trusted publishing
+      - name: Publish to NPM with provenance
         if: steps.check.outputs.should_publish == 'true'
+        # --provenance generates a Sigstore attestation linking the package to this CI build.
         # Requires npm Trusted Publisher configuration for this repository/workflow.
-        run: npm publish --access public
+        # See: https://docs.npmjs.com/generating-provenance-statements
+        run: npm publish --access public --provenance
 
   publish-registry:
     needs: publish-npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   packages: write
   pull-requests: read
+  id-token: write
 
 jobs:
   # Job 1: Validate Release

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# Supply chain security defaults
+# These settings are read by npm, pnpm, and bun (with varying support levels).
+
+# Enforce exact version pinning (no ^ or ~ ranges on save)
+save-exact=true
+
+# Strict peer dependency checking — fail on missing/invalid peers
+strict-peer-dependencies=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-05-14
+
+**TL;DR for Users**: New dedicated list configuration tools, npm provenance for supply chain verification, and Docker build fix.
+
 ### Added
 
 - **`create-list` tool** (#1195, #1196) - Dedicated list creation with template expansion (`sales_pipeline`, `recruiting_tracker`, `support_queue`), parent-object validation against workspace objects, and dry-run preview
 - **`update-list-configuration` tool** (#1195, #1196) - Dedicated list update with immutable field detection (rejects `parent_object` changes), dry-run preview, and categorized error guidance
 - Shared `ListConfigurationValidator` for parent-object validation, immutable field detection, template expansion, and error categorization — consumed by both dedicated tools and universal create/update strategies (#1195)
+- **npm provenance publishing** — every release is now cryptographically linked to the GitHub Actions build and source commit via Sigstore, enabling supply chain verification with `npm view attio-mcp --json | jq .attestations`
+- `.npmrc` with `save-exact` and `strict-peer-dependencies` for safer installs
 
 ### Changed
 
 - Universal list create and update paths now validate `parent_object` and detect immutable fields before API calls (#1195)
 - List error categorization prefers HTTP status codes over fragile string matching (#1196)
+- Docker build stage now uses `oven/bun:1` instead of `node:20-slim` for consistency with the project's package manager
 
 ## [1.6.0] - 2026-05-05
 
@@ -949,7 +956,8 @@ Users upgrading from v0.1.x should note:
 - Troubleshooting guides
 - Development and contribution guidelines
 
-[Unreleased]: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/kesslerio/attio-mcp-server/compare/v1.4.0...v1.4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,24 @@
 # =============================================================================
 # Build Stage
 # =============================================================================
-FROM node:20-slim AS builder
+FROM oven/bun:1 AS builder
 
 WORKDIR /app
 
 # Copy package files first for better layer caching
-COPY package*.json ./
+COPY package.json bun.lock ./
 
 # Install all dependencies (including devDependencies for build)
-RUN npm ci
+RUN bun install --frozen-lockfile
 
 # Copy source code
 COPY . .
 
 # Build the project
-RUN npm run build
+RUN bun run build
 
 # Prune devDependencies for production
-RUN npm prune --production
+RUN bun install --frozen-lockfile --production
 
 # =============================================================================
 # Production Stage

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![GitHub Release](https://img.shields.io/github/v/release/kesslerio/attio-mcp-server)](https://github.com/kesslerio/attio-mcp-server/releases)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kesslerio/attio-mcp-server)
+[![npm provenance](https://img.shields.io/npm/attio-mcp/provenance)](https://www.npmjs.com/package/attio-mcp)
 
 A comprehensive Model Context Protocol (MCP) server for [Attio](https://attio.com/), providing **complete CRM surface coverage**. This server enables AI assistants like Claude and ChatGPT to interact directly with your entire Attio workspace through natural language—manage Deals, Tasks, Lists, People, Companies, Records, and Notes without falling back to raw API calls.
 
@@ -734,6 +735,24 @@ Deal stages are specific to your workspace. Check your Attio workspace settings 
 - **No Data Storage**: Direct API passthrough with no local data retention
 - **Open Source**: Full transparency with Apache 2.0 license
 - **Optional On-Premises**: Deploy in your own infrastructure
+- **npm Provenance**: Published with [Sigstore provenance](https://docs.npmjs.com/generating-provenance-statements) — every release is cryptographically linked to the GitHub Actions build and source commit
+
+### Supply Chain Verification
+
+This package is published with npm provenance, creating a verifiable chain from source code to published artifact. Verify a release:
+
+```sh
+# Check provenance attestation on any published version
+npm view attio-mcp --json | jq .attestations
+
+# With pnpm (v10+), enforce trust policy at install time
+# pnpm trustPolicy: no-downgrade blocks packages published with weaker credentials
+```
+
+For maximum supply chain protection, install with [pnpm v10+](https://pnpm.io) which enforces:
+
+- **`trustPolicy: no-downgrade`** — blocks versions published with weaker credentials than prior versions
+- **`minimumReleaseAge`** — cooldown period before new versions can be installed
 
 ## 📚 Documentation
 

--- a/configs/vitest/vitest.config.offline.ts
+++ b/configs/vitest/vitest.config.offline.ts
@@ -24,6 +24,8 @@ export default defineConfig({
       // Temporarily exclude failing CI tests (#1061)
       'test/unit/core/tools/status-field-validation.test.ts', // Requires @attio-mcp/core build
       'test/utils/postal-code-mapping.test.ts', // Display name normalization fails in CI
+      // Live smoke tests require real Attio API
+      'test/smoke-list-config-tools.test.ts',
     ],
     globals: true,
     testTimeout: 10000,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/kesslerio/attio-mcp-server",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "attio-mcp",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "transport": {
         "type": "stdio"
       },

--- a/test/scripts/release-notes.test.ts
+++ b/test/scripts/release-notes.test.ts
@@ -22,18 +22,16 @@ describe('release notes builder', () => {
       packageJson.version
     );
 
-    expect(releaseNotes).toContain(
-      'This release makes common company and deal writes easier'
-    );
+    expect(releaseNotes).toContain('list configuration tools');
     expect(releaseNotes).toContain("## What's New");
     expect(releaseNotes).toContain('### Added');
-    expect(releaseNotes).toContain('### Fixed');
-    expect(releaseNotes).toContain('create_company');
-    expect(releaseNotes).toContain('config-discovered custom objects');
+    expect(releaseNotes).toContain('### Changed');
+    expect(releaseNotes).toContain('create-list');
+    expect(releaseNotes).toContain('npm provenance');
     expect(releaseNotes).toContain('npm install -g attio-mcp');
     expect(releaseNotes).toContain('npm update -g attio-mcp');
     expect(releaseNotes).toContain(
-      '**Full Changelog**: https://github.com/kesslerio/attio-mcp-server/compare/v1.5.0...v1.6.0'
+      '**Full Changelog**: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.0...v1.6.1'
     );
   });
 });


### PR DESCRIPTION
## v1.6.1 Release

**TL;DR for Users**: New dedicated list configuration tools, npm provenance for supply chain verification, and Docker build fix.

### Changes

- **`create-list` tool** (#1195, #1196) - Dedicated list creation with template expansion, parent-object validation, and dry-run preview
- **`update-list-configuration` tool** (#1195, #1196) - Dedicated list update with immutable field detection, dry-run preview, and categorized error guidance
- **npm provenance publishing** — every release is now cryptographically linked to the GitHub Actions build and source commit via Sigstore
- `.npmrc` with `save-exact` and `strict-peer-dependencies` for safer installs
- **Dockerfile fix** — build stage now uses `oven/bun:1` instead of `node:20-slim` for consistency with the project's package manager
- `id-token: write` permission added to release workflow
- Provenance badge and verification docs added to README

### Post-Merge

- [ ] Tag `v1.6.1` on main after merge
- [ ] Verify npm publish with provenance succeeds
- [ ] Verify `npm view attio-mcp --json | jq .attestations` shows provenance

**Full Changelog**: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.0...v1.6.1