### PR TITLE
Fix: Isolate Cloudflare tool auth per request

### DIFF
--- a/examples/cloudflare-mcp-server/src/mcp-handler.ts
+++ b/examples/cloudflare-mcp-server/src/mcp-handler.ts
@@ -8,7 +8,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { getToolsListPayload } from '../../../dist/utils/mcp-discovery.js';
 import { executeToolRequest } from '../../../dist/handlers/tools/dispatcher.js';
-import { ClientCache } from '../../../src/api/client-cache.js';
+import { ClientCache } from '../../../dist/api/client-cache.js';
 
 /**
  * MCP JSON-RPC request structure

--- a/examples/cloudflare-mcp-server/src/mcp-handler.ts
+++ b/examples/cloudflare-mcp-server/src/mcp-handler.ts
@@ -8,6 +8,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { getToolsListPayload } from '../../../dist/utils/mcp-discovery.js';
 import { executeToolRequest } from '../../../dist/handlers/tools/dispatcher.js';
+import { ClientCache } from '../../../src/api/client-cache.js';
 
 /**
  * MCP JSON-RPC request structure
@@ -71,6 +72,26 @@ const CAPABILITIES = {
 /**
  * MCP error codes
  */
+
+let toolExecutionLock: Promise<void> = Promise.resolve();
+
+async function runToolCallWithLock<T>(work: () => Promise<T>): Promise<T> {
+  const previousLock = toolExecutionLock;
+  let releaseLock: () => void = () => undefined;
+
+  toolExecutionLock = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+
+  await previousLock;
+
+  try {
+    return await work();
+  } finally {
+    releaseLock();
+  }
+}
+
 const ErrorCodes = {
   ParseError: -32700,
   InvalidRequest: -32600,
@@ -149,34 +170,50 @@ export function createMcpHandler(config: { attioToken: string }) {
       };
     }
 
-    // Inject per-request token for dispatcher
-    const previousToken = process.env.ATTIO_API_KEY;
-    process.env.ATTIO_API_KEY = attioToken;
+    return runToolCallWithLock(async () => {
+      // Clear shared client cache before injecting per-request credentials
+      ClientCache.clearInstance();
 
-    try {
-      const request: CallToolRequest = {
-        method: 'tools/call',
-        params: {
-          name,
-          arguments: args || {},
-        },
-      };
+      const previousApiKey = process.env.ATTIO_API_KEY;
+      const previousAccessToken = process.env.ATTIO_ACCESS_TOKEN;
 
-      const result = await executeToolRequest(request);
+      process.env.ATTIO_API_KEY = attioToken;
+      process.env.ATTIO_ACCESS_TOKEN = attioToken;
 
-      // Return dispatcher result directly - structuredOutput handles normalization
-      return {
-        content: (result as any).content,
-        isError: (result as any).isError,
-        error: (result as any).error,
-      };
-    } finally {
-      if (previousToken === undefined) {
-        delete process.env.ATTIO_API_KEY;
-      } else {
-        process.env.ATTIO_API_KEY = previousToken;
+      try {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name,
+            arguments: args || {},
+          },
+        };
+
+        const result = await executeToolRequest(request);
+
+        // Return dispatcher result directly - structuredOutput handles normalization
+        return {
+          content: (result as any).content,
+          isError: (result as any).isError,
+          error: (result as any).error,
+        };
+      } finally {
+        // Ensure no per-request credentials remain cached after execution
+        ClientCache.clearInstance();
+
+        if (previousApiKey === undefined) {
+          delete process.env.ATTIO_API_KEY;
+        } else {
+          process.env.ATTIO_API_KEY = previousApiKey;
+        }
+
+        if (previousAccessToken === undefined) {
+          delete process.env.ATTIO_ACCESS_TOKEN;
+        } else {
+          process.env.ATTIO_ACCESS_TOKEN = previousAccessToken;
+        }
       }
-    }
+    });
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant Attio token reuse caused by the Cloudflare MCP handler mutating `process.env` while the dispatcher uses a module-global cached Axios client, which allowed a warm Worker isolate to reuse another user's Authorization header.

### Description
- Serialize `tools/call` execution with a local async lock `runToolCallWithLock` to avoid concurrent races on shared environment state in `examples/cloudflare-mcp-server/src/mcp-handler.ts`.
- Import and use `ClientCache.clearInstance()` to clear the shared client cache immediately before and after each dispatcher call so a stale Axios instance cannot carry another user's token between requests.
- Set and restore both `ATTIO_API_KEY` and `ATTIO_ACCESS_TOKEN` inside the serialized block to ensure consistent credential source handling and to preserve previous environment state.
- Changes are contained to `examples/cloudflare-mcp-server/src/mcp-handler.ts` (adds `toolExecutionLock`, `runToolCallWithLock`, `ClientCache` import, and the client-cache/env handling around `executeToolRequest`).

### Testing
- Ran `bun run typecheck`; it failed in this environment due to missing dev dependencies/type definitions (e.g., `axios`, `@types/node`), which are unrelated to this change. (failure)
- Ran ESLint on the modified file via `bunx eslint examples/cloudflare-mcp-server/src/mcp-handler.ts`; it failed in this environment because ESLint config dependencies are not available (`@eslint/js`), not because of the patch. (failure)
- Verified local compile-edit and committed the patch; static inspection confirms the new lock and cache-clear logic wrap the dispatcher call and restore environment variables on exit. (manual verification)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd7186fb5c8325a3244609581288dc)