### PR TITLE
Fix: avoid cross-tenant cached client reuse

### DIFF
--- a/src/utils/client-resolver.ts
+++ b/src/utils/client-resolver.ts
@@ -70,6 +70,14 @@ function assertAxiosInstance(
   }
 }
 
+function resolveApiKey(): string | undefined {
+  return (
+    process.env.ATTIO_API_KEY ||
+    process.env.ATTIO_ACCESS_TOKEN ||
+    getContextApiKey()
+  );
+}
+
 /**
  * Resolves an Attio client instance using the unified interface.
  *
@@ -85,34 +93,34 @@ export function resolveAttioClient(): AxiosInstance {
     logger.debug('Credential resolution attempted');
   }
 
-  // Resolve API key from current context/environment first
-  const contextApiKey = getContextApiKey();
-  const envApiKey = process.env.ATTIO_API_KEY;
-  const resolvedApiKey = envApiKey || contextApiKey;
+  const resolvedApiKey = resolveApiKey();
 
   // Prefer unified factory with explicit credentials and cache bypass
   if (typeof mod.createAttioClient === 'function') {
-    logger.debug('Using createAttioClient() with explicit apiKey and bypassCache');
+    logger.debug(
+      'Using createAttioClient() with explicit apiKey and bypassCache'
+    );
+    let client: AxiosInstance | unknown;
     try {
       const config: ClientConfig = {
         apiKey: resolvedApiKey,
         bypassCache: true,
       };
-      const client = mod.createAttioClient(config);
-      assertAxiosInstance(client, 'createAttioClient(config)');
-      return client;
+      client = mod.createAttioClient(config);
     } catch (_error) {
       logger.debug('createAttioClient failed');
       // Continue to last resort
+      client = undefined;
+    }
+
+    if (client !== undefined) {
+      assertAxiosInstance(client, 'createAttioClient(config)');
+      return client;
     }
   }
 
   // Last resort: buildAttioClient
   if (typeof mod.buildAttioClient === 'function') {
-    const contextApiKey = getContextApiKey();
-    const envApiKey = process.env.ATTIO_API_KEY;
-    const resolvedApiKey = envApiKey || contextApiKey;
-
     if (!resolvedApiKey) {
       throw new Error(
         'Attio API key is required for client initialization. Please set ATTIO_API_KEY environment variable.'

--- a/src/utils/client-resolver.ts
+++ b/src/utils/client-resolver.ts
@@ -16,7 +16,7 @@ const logger = createScopedLogger('client-resolver');
  */
 interface AttioClientFactories {
   getAttioClient?(): AxiosInstance | unknown;
-  createAttioClient?(apiKey: string): AxiosInstance | unknown;
+  createAttioClient?(config: ClientConfig): AxiosInstance | unknown;
   buildAttioClient?(config: { apiKey: string }): AxiosInstance | unknown;
   [key: string]: unknown;
 }
@@ -72,10 +72,10 @@ function assertAxiosInstance(
 
 /**
  * Resolves an Attio client instance using the unified interface.
- * Uses getAttioClient() which handles caching, environment detection, and strategy pattern.
  *
- * This simplification fixes Issue #904 client initialization validation failures by using
- * the proven getAttioClient() code path instead of attempting multiple factory methods.
+ * Security note: this resolver must always honor the current request context key.
+ * Therefore it creates a fresh client with an explicitly resolved API key and
+ * bypasses process-global caches that may hold another tenant's credentials.
  */
 export function resolveAttioClient(): AxiosInstance {
   const mod = AttioClientModule as AttioClientFactories;
@@ -85,27 +85,20 @@ export function resolveAttioClient(): AxiosInstance {
     logger.debug('Credential resolution attempted');
   }
 
-  // Use getAttioClient() - it handles all the complexity:
-  // - Caching (ClientCache and legacy apiInstance)
-  // - Environment detection (E2E, test, production modes)
-  // - Strategy pattern (ProductionClientStrategy, E2EClientStrategy, etc.)
-  // - API key resolution (env, context, config)
-  // This is the proven code path used throughout the codebase
-  if (typeof mod.getAttioClient === 'function') {
-    logger.debug('Using getAttioClient()');
-    const client = mod.getAttioClient();
-    assertAxiosInstance(client, 'getAttioClient()');
-    return client;
-  }
+  // Resolve API key from current context/environment first
+  const contextApiKey = getContextApiKey();
+  const envApiKey = process.env.ATTIO_API_KEY;
+  const resolvedApiKey = envApiKey || contextApiKey;
 
-  // Fallback to createAttioClient with config object
+  // Prefer unified factory with explicit credentials and cache bypass
   if (typeof mod.createAttioClient === 'function') {
-    logger.debug('Fallback to createAttioClient(config)');
+    logger.debug('Using createAttioClient() with explicit apiKey and bypassCache');
     try {
-      const config: ClientConfig = {};
-      const client = (
-        mod.createAttioClient as (config: ClientConfig) => AxiosInstance
-      )(config);
+      const config: ClientConfig = {
+        apiKey: resolvedApiKey,
+        bypassCache: true,
+      };
+      const client = mod.createAttioClient(config);
       assertAxiosInstance(client, 'createAttioClient(config)');
       return client;
     } catch (_error) {

--- a/test/utils/client-resolver.test.ts
+++ b/test/utils/client-resolver.test.ts
@@ -86,17 +86,22 @@ describe('Client Resolver', () => {
   });
 
   describe('resolveAttioClient', () => {
-    it('prioritises getAttioClient() when available', async () => {
+    it('uses createAttioClient() with explicit API key and bypassCache', async () => {
       const mockClient = createMockClient();
-      const getAttioClient = vi.fn().mockReturnValue(mockClient);
-      mockAttioModule({ getAttioClient });
-      mockContextModule(undefined);
+      const createAttioClient = vi.fn().mockReturnValue(mockClient);
+      const getAttioClient = vi.fn();
+      mockAttioModule({ createAttioClient, getAttioClient });
+      mockContextModule('context-key-123');
 
       const { resolveAttioClient } = await importResolver();
       const client = resolveAttioClient();
 
       expect(client).toBe(mockClient);
-      expect(getAttioClient).toHaveBeenCalledTimes(1);
+      expect(createAttioClient).toHaveBeenCalledWith({
+        apiKey: 'context-key-123',
+        bypassCache: true,
+      });
+      expect(getAttioClient).not.toHaveBeenCalled();
     });
 
     it('falls back to createAttioClient() when getAttioClient is absent', async () => {
@@ -111,7 +116,10 @@ describe('Client Resolver', () => {
 
       expect(client).toBe(mockClient);
       // After fix in e75725b3, createAttioClient is called with config object (not string)
-      expect(createAttioClient).toHaveBeenCalledWith({});
+      expect(createAttioClient).toHaveBeenCalledWith({
+        apiKey: 'test-key-12345',
+        bypassCache: true,
+      });
     });
 
     it('falls back to buildAttioClient() when other factories missing', async () => {
@@ -139,7 +147,10 @@ describe('Client Resolver', () => {
 
       expect(client).toBe(mockClient);
       // After fix in e75725b3, createAttioClient is called with config object (not string)
-      expect(createAttioClient).toHaveBeenCalledWith({});
+      expect(createAttioClient).toHaveBeenCalledWith({
+        apiKey: 'context-key-123',
+        bypassCache: true,
+      });
     });
 
     it('throws descriptive error when no factories available', async () => {
@@ -227,7 +238,10 @@ describe('Client Resolver', () => {
       resolveAttioClient();
 
       // After fix in e75725b3, createAttioClient is called with config object (not string)
-      expect(createAttioClient).toHaveBeenCalledWith({});
+      expect(createAttioClient).toHaveBeenCalledWith({
+        apiKey: 'env-key-12345',
+        bypassCache: true,
+      });
       expect(createAttioClient).not.toHaveBeenCalledWith('context-key');
     });
 

--- a/test/utils/client-resolver.test.ts
+++ b/test/utils/client-resolver.test.ts
@@ -3,6 +3,7 @@ import type { AxiosInstance } from 'axios';
 import { expectLogCallsToExclude } from '../utils/log-assertions.js';
 
 const originalApiKey = process.env.ATTIO_API_KEY;
+const originalAccessToken = process.env.ATTIO_ACCESS_TOKEN;
 const originalLogLevel = process.env.MCP_LOG_LEVEL;
 const { mockScopedDebug, mockScopedInfo, mockScopedWarn, mockScopedError } =
   vi.hoisted(() => ({
@@ -68,6 +69,7 @@ describe('Client Resolver', () => {
     mockScopedWarn.mockReset();
     mockScopedError.mockReset();
     delete process.env.ATTIO_API_KEY;
+    delete process.env.ATTIO_ACCESS_TOKEN;
     delete process.env.MCP_LOG_LEVEL;
   });
 
@@ -76,6 +78,12 @@ describe('Client Resolver', () => {
       process.env.ATTIO_API_KEY = originalApiKey;
     } else {
       delete process.env.ATTIO_API_KEY;
+    }
+
+    if (originalAccessToken) {
+      process.env.ATTIO_ACCESS_TOKEN = originalAccessToken;
+    } else {
+      delete process.env.ATTIO_ACCESS_TOKEN;
     }
 
     if (originalLogLevel) {
@@ -207,19 +215,23 @@ describe('Client Resolver', () => {
   describe('getValidatedAttioClient', () => {
     it('returns client when resolution succeeds', async () => {
       const mockClient = createMockClient();
-      const getAttioClient = vi.fn().mockReturnValue(mockClient);
-      mockAttioModule({ getAttioClient });
-      mockContextModule(undefined);
+      const createAttioClient = vi.fn().mockReturnValue(mockClient);
+      mockAttioModule({ createAttioClient });
+      mockContextModule('context-key-123');
 
       const { getValidatedAttioClient } = await importResolver();
       const client = getValidatedAttioClient();
       expect(client).toBe(mockClient);
+      expect(createAttioClient).toHaveBeenCalledWith({
+        apiKey: 'context-key-123',
+        bypassCache: true,
+      });
     });
 
     it('throws when resolved client is invalid', async () => {
-      const getAttioClient = vi.fn().mockReturnValue({});
-      mockAttioModule({ getAttioClient });
-      mockContextModule(undefined);
+      const createAttioClient = vi.fn().mockReturnValue({});
+      mockAttioModule({ createAttioClient });
+      mockContextModule('context-key-123');
 
       const { getValidatedAttioClient } = await importResolver();
       expect(() => getValidatedAttioClient()).toThrow(/invalid Axios client/);
@@ -248,13 +260,13 @@ describe('Client Resolver', () => {
     it('does not cache resolved clients between calls', async () => {
       const mockClient1 = createMockClient();
       const mockClient2 = createMockClient();
-      const getAttioClient = vi
+      const createAttioClient = vi
         .fn()
         .mockReturnValueOnce(mockClient1)
         .mockReturnValueOnce(mockClient2);
 
-      mockAttioModule({ getAttioClient });
-      mockContextModule(undefined);
+      mockAttioModule({ createAttioClient });
+      mockContextModule('context-key-123');
 
       const { resolveAttioClient } = await importResolver();
       const client1 = resolveAttioClient();
@@ -262,13 +274,21 @@ describe('Client Resolver', () => {
 
       expect(client1).toBe(mockClient1);
       expect(client2).toBe(mockClient2);
-      expect(getAttioClient).toHaveBeenCalledTimes(2);
+      expect(createAttioClient).toHaveBeenCalledTimes(2);
+      expect(createAttioClient).toHaveBeenNthCalledWith(1, {
+        apiKey: 'context-key-123',
+        bypassCache: true,
+      });
+      expect(createAttioClient).toHaveBeenNthCalledWith(2, {
+        apiKey: 'context-key-123',
+        bypassCache: true,
+      });
     });
 
     it('logs only a message when debug credential resolution is enabled', async () => {
       const mockClient = createMockClient();
-      const getAttioClient = vi.fn().mockReturnValue(mockClient);
-      mockAttioModule({ getAttioClient });
+      const createAttioClient = vi.fn().mockReturnValue(mockClient);
+      mockAttioModule({ createAttioClient });
       mockContextModule('context-key-12345');
       process.env.ATTIO_API_KEY = 'env-key-12345';
       process.env.MCP_LOG_LEVEL = 'DEBUG';
@@ -290,6 +310,24 @@ describe('Client Resolver', () => {
         'env-key-12345',
         'context-key-12345',
       ]);
+    });
+
+    it('uses ATTIO_ACCESS_TOKEN when ATTIO_API_KEY is absent', async () => {
+      const mockClient = createMockClient();
+      const createAttioClient = vi.fn().mockReturnValue(mockClient);
+      mockAttioModule({ createAttioClient });
+      mockContextModule('context-key-12345');
+      process.env.ATTIO_ACCESS_TOKEN = 'access-token-12345';
+
+      const { resolveAttioClient } = await importResolver();
+      const client = resolveAttioClient();
+
+      expect(client).toBe(mockClient);
+      expect(createAttioClient).toHaveBeenCalledWith({
+        apiKey: 'access-token-12345',
+        bypassCache: true,
+      });
+      expect(createAttioClient).not.toHaveBeenCalledWith('context-key-12345');
     });
 
     it('does not serialize createAttioClient failure details in debug logs', async () => {


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant credential leakage by ensuring client resolution always honors the current request context API key instead of returning a process-global cached client.
- The previous resolver prioritized `getAttioClient()` which could return a cached Axios instance created under another tenant's credentials, allowing requests to be sent with the wrong bearer token.

### Description
- Change `resolveAttioClient()` to explicitly resolve the current API key and call `createAttioClient({ apiKey, bypassCache: true })` so per-request context cannot reuse a process-global cached client.
- Update the `AttioClientFactories` typing to use the `ClientConfig` object form for `createAttioClient` to reflect the config-based factory usage.
- Preserve `buildAttioClient()` as a fallback when `createAttioClient` is unavailable.
- Update unit tests in `test/utils/client-resolver.test.ts` to assert explicit API key passing and `bypassCache: true` behavior.

### Testing
- Attempted to run the resolver unit tests with `bun run test -- --run test/utils/client-resolver.test.ts`, which failed in this environment because the `vitest` binary was not available (test runner not installed). 
- Ran type checking with `bun run typecheck`, which failed in this environment due to missing project dependencies/types (e.g., `axios`, `@types/node`); failures are environmental and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd727a201c8325b734c14eb3bdc1c0)