### PR TITLE
Fix: Rebuild cached client when API key context changes

### DIFF
--- a/src/api/attio-client.ts
+++ b/src/api/attio-client.ts
@@ -64,6 +64,7 @@ function validateAndThrowForApiKey(
 
 // LEGACY: Global API client instance - replaced by ClientCache
 let apiInstance: AxiosInstance | null = null;
+let cachedClientApiKey: string | null = null;
 
 /**
  * UNIFIED CLIENT FACTORY: Support new createAttioClient(config) signature
@@ -376,6 +377,7 @@ export async function getStatusOptions(
  */
 export function initializeAttioClient(apiKey: string): AxiosInstance {
   apiInstance = createAttioClient(apiKey); // This will use the legacy signature
+  cachedClientApiKey = apiKey;
   ClientCache.setInstance(apiInstance);
   return apiInstance;
 }
@@ -404,6 +406,7 @@ export function getAttioClient(opts?: { rawE2E?: boolean }): AxiosInstance {
     // Clear cache to ensure fresh client
     ClientCache.clearInstance();
     apiInstance = null;
+    cachedClientApiKey = null;
 
     // Determine mode based on rawE2E option
     const mode = opts?.rawE2E
@@ -418,6 +421,22 @@ export function getAttioClient(opts?: { rawE2E?: boolean }): AxiosInstance {
     const client = createAttioClient(config);
     debug('attio-client', 'Returning fresh E2E client');
     return client;
+  }
+
+  const currentApiKey =
+    process.env.ATTIO_API_KEY ??
+    process.env.ATTIO_ACCESS_TOKEN ??
+    getContextApiKey() ??
+    null;
+
+  if (apiInstance && currentApiKey && cachedClientApiKey !== currentApiKey) {
+    debug(
+      'attio-client',
+      'Detected API key/context change - rebuilding cached client'
+    );
+    ClientCache.clearInstance();
+    apiInstance = null;
+    cachedClientApiKey = null;
   }
 
   // Check cache first
@@ -443,6 +462,7 @@ export function getAttioClient(opts?: { rawE2E?: boolean }): AxiosInstance {
     // Cache the client in both new and legacy systems
     ClientCache.setInstance(client);
     apiInstance = client;
+    cachedClientApiKey = currentApiKey;
 
     debug('attio-client', 'Created and cached new client');
     return client;

--- a/src/api/attio-client.ts
+++ b/src/api/attio-client.ts
@@ -429,7 +429,11 @@ export function getAttioClient(opts?: { rawE2E?: boolean }): AxiosInstance {
     getContextApiKey() ??
     null;
 
-  if (apiInstance && currentApiKey && cachedClientApiKey !== currentApiKey) {
+  if (
+    (apiInstance || ClientCache.hasInstance()) &&
+    currentApiKey &&
+    cachedClientApiKey !== currentApiKey
+  ) {
     debug(
       'attio-client',
       'Detected API key/context change - rebuilding cached client'

--- a/test/api/attio-client.context.test.ts
+++ b/test/api/attio-client.context.test.ts
@@ -3,6 +3,7 @@ import { clearClientCache } from '@/api/lazy-client.js';
 import { expectLogCallsToExclude } from '../utils/log-assertions.js';
 
 const originalApiKey = process.env.ATTIO_API_KEY;
+const originalAccessToken = process.env.ATTIO_ACCESS_TOKEN;
 const originalLogLevel = process.env.MCP_LOG_LEVEL;
 const { mockScopedDebug, mockScopedInfo, mockScopedWarn, mockScopedError } =
   vi.hoisted(() => ({
@@ -37,6 +38,7 @@ describe('Attio client context fallback', () => {
     mockScopedWarn.mockReset();
     mockScopedError.mockReset();
     delete process.env.ATTIO_API_KEY;
+    delete process.env.ATTIO_ACCESS_TOKEN;
     process.env.MCP_LOG_LEVEL = 'ERROR';
     vi.doMock('@/api/attio-client.js', async () => {
       const actual = await vi.importActual<
@@ -54,6 +56,12 @@ describe('Attio client context fallback', () => {
       process.env.ATTIO_API_KEY = originalApiKey;
     } else {
       delete process.env.ATTIO_API_KEY;
+    }
+
+    if (originalAccessToken) {
+      process.env.ATTIO_ACCESS_TOKEN = originalAccessToken;
+    } else {
+      delete process.env.ATTIO_ACCESS_TOKEN;
     }
 
     if (originalLogLevel) {
@@ -106,6 +114,47 @@ describe('Attio client context fallback', () => {
     const client = getAttioClient();
 
     expect(client.defaults.headers.Authorization).toBe('Bearer env-key-12345');
+  });
+
+  it('rebuilds cached clients when the context API key changes', async () => {
+    const { setGlobalContext } = await import('@/api/lazy-client.js');
+    const { getAttioClient } = await import('@/api/attio-client.js');
+
+    setGlobalContext({
+      getApiKey: () => 'tenant-a-key-12345',
+    });
+    const tenantAClient = getAttioClient();
+
+    setGlobalContext({
+      getApiKey: () => 'tenant-b-key-12345',
+    });
+    const tenantBClient = getAttioClient();
+
+    expect(tenantAClient.defaults.headers.Authorization).toBe(
+      'Bearer tenant-a-key-12345'
+    );
+    expect(tenantBClient.defaults.headers.Authorization).toBe(
+      'Bearer tenant-b-key-12345'
+    );
+    expect(tenantBClient).not.toBe(tenantAClient);
+  });
+
+  it('rebuilds cached clients when the environment access token changes', async () => {
+    const { getAttioClient } = await import('@/api/attio-client.js');
+
+    process.env.ATTIO_ACCESS_TOKEN = 'tenant-a-token-12345';
+    const tenantAClient = getAttioClient();
+
+    process.env.ATTIO_ACCESS_TOKEN = 'tenant-b-token-12345';
+    const tenantBClient = getAttioClient();
+
+    expect(tenantAClient.defaults.headers.Authorization).toBe(
+      'Bearer tenant-a-token-12345'
+    );
+    expect(tenantBClient.defaults.headers.Authorization).toBe(
+      'Bearer tenant-b-token-12345'
+    );
+    expect(tenantBClient).not.toBe(tenantAClient);
   });
 
   describe('Context getter exception handling', () => {


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant credential confusion in hosted Smithery where a single process-wide cached Axios client could be reused after the active API key/context changed, exposing other tenants' Attio workspaces.

### Description
- Added a module-scoped `cachedClientApiKey` to track the API key used to build the legacy/global cached client.
- Updated `initializeAttioClient()` to persist the initialized API key into `cachedClientApiKey` for cache-consistency.
- Updated `getAttioClient()` to compute the current effective API key from `process.env.ATTIO_API_KEY || process.env.ATTIO_ACCESS_TOKEN || getContextApiKey()` and invalidate `ClientCache`/legacy `apiInstance` when the key differs, forcing a rebuild of the client.
- Ensured the bypass-cache/E2E path also resets the tracked key and recorded the effective key immediately after creating a new cached client.

### Testing
- Ran `bun run typecheck`, which failed in this environment due to missing workspace dev dependencies/type declarations (e.g., `axios` and Node types); failures are unrelated to the logic change.
- No further automated tests were executed here; the patch is a minimal runtime-only cache invalidation to close the cross-tenant token leakage vector.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd843ff72083259afdf5fa4b16090b)