### PR TITLE
Fix: Mark manage-list-entry as write tool

### DIFF
--- a/src/handlers/tool-configs/lists.ts
+++ b/src/handlers/tool-configs/lists.ts
@@ -839,6 +839,9 @@ You must provide parameters for exactly ONE mode per call.
 - Replaces: add-record-to-list → Use Mode 1 (recordId + objectType)
 - Replaces: remove-record-from-list → Use Mode 2 (entryId only)
 - Replaces: update-list-entry → Use Mode 3 (entryId + attributes)`,
+    annotations: {
+      readOnlyHint: false,
+    },
     inputSchema: {
       type: 'object',
       properties: {

--- a/test/unit/list-tools-entry-management-consolidated.test.ts
+++ b/test/unit/list-tools-entry-management-consolidated.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleManageListEntryOperation } from '../../src/handlers/tools/dispatcher/operations/lists.js';
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { ToolConfig } from '../../src/handlers/tool-types.js';
+import { listsToolDefinitions } from '../../src/handlers/tool-configs/lists.js';
 import { AttioListEntry } from '../../src/types/attio.js';
 
 // Mock the entry management functions
@@ -52,6 +53,14 @@ describe('Consolidated manage-list-entry Tool', () => {
     vi.mocked(addRecordToList).mockResolvedValue(mockListEntry);
     vi.mocked(removeRecordFromList).mockResolvedValue(true);
     vi.mocked(updateListEntry).mockResolvedValue(mockListEntry);
+  });
+
+  it('advertises manage-list-entry as a write-capable tool', () => {
+    const definition = listsToolDefinitions.find(
+      (tool) => tool.name === 'manage-list-entry'
+    );
+
+    expect(definition?.annotations?.readOnlyHint).toBe(false);
   });
 
   describe('Mode Detection', () => {


### PR DESCRIPTION
### Motivation
- The consolidated `manage-list-entry` tool performs add/remove/update list operations but was being inferred as read-only by the name-based heuristic, which can cause MCP hosts to skip user approval for destructive actions.

### Description
- Added explicit annotations to the `manage-list-entry` tool definition in `src/handlers/tool-configs/lists.ts` by setting `annotations: { readOnlyHint: false }` so the tool is advertised as write-capable rather than inferred as read-only.

### Testing
- Attempted lint with `bunx eslint ... src/handlers/tool-configs/lists.ts` and unit tests with `bunx vitest --config configs/vitest/vitest.config.ts --run test/unit/list-tools-entry-management-consolidated.test.ts`, but both commands could not complete in this environment due to missing dev dependencies (`@eslint/js`, `vitest`); no test failures were caused by the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd68ff84c08325b8ad0462d8f93c72)