### PR TITLE
Fix: Remove untrusted manual ref selection in release workflow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -41,7 +41,6 @@ jobs:
             exit 1
           fi
 
-
       - name: Check if package exists on npm
         id: check
         run: |

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version tag to publish (e.g., v1.4.0)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -24,12 +18,7 @@ jobs:
     steps:
       - name: Determine version
         id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
+        run: echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,10 +41,6 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "$PKG_VERSION" != "$TAG_VERSION_STRIPPED" ]; then
-            echo "::error::Version mismatch: package.json=$PKG_VERSION, input tag=$TAG_VERSION_STRIPPED"
-            exit 1
-          fi
 
       - name: Check if package exists on npm
         id: check
@@ -115,12 +100,7 @@ jobs:
     steps:
       - name: Determine version
         id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
+        run: echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- The manual `workflow_dispatch` `version` input allowed untrusted string interpolation and arbitrary `actions/checkout` refs, creating command-injection and credential-exfiltration risks.
- Releases must run from an immutable tag-ref trust boundary so publishing credentials are not exposed to attacker-controlled code.

### Description
- Removed the `workflow_dispatch` trigger and free-form `version` input from `.github/workflows/publish-mcp-registry.yml` so publishes are only triggered by tag pushes (`v*`).
- Replaced both `Determine version` steps to derive the version strictly from `GITHUB_REF_NAME` instead of using `inputs.version`.
- Removed the dispatch-specific post-check that compared `inputs.version` to package metadata, since the manual input is no longer accepted.
- Preserved the existing tag-based publish flow, npm existence check, test/build steps, and MCP Registry publish logic.

### Testing
- No automated unit/integration tests were required for this metadata-only change; no CI runs were executed.
- Verified the change by inspecting the workflow diff (`git diff .github/workflows/publish-mcp-registry.yml`) and committing the updated workflow; the diff shows removal of `workflow_dispatch` and the simplified `Determine version` steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd63adc2588325925078229503fb85)