### PR TITLE
Fix: Restrict Claude command workflow privileges

### DIFF
--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -214,7 +214,7 @@ jobs:
           github_token: ${{ github.token }}
           track_progress: true
           # No --max-turns = runs until completion (default action behavior)
-          # Full tool access for implementation
+          # Local edit/read access only; no repository mutation shell commands.
           claude_args: >-
             --model claude-sonnet-4-5
             --allowedTools "Read,Edit,Write,Bash(rg:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)"
@@ -251,7 +251,7 @@ jobs:
             ## Project Standards (from AGENTS.md)
             - Commit format: `Type: Description #issue-number` where Type = Feature|Fix|Docs|Refactor|Test|Chore
             - Use `@/` path aliases instead of relative imports
-            - Run `npm run test:offline` for fast validation
+            - Run `bun run test:offline` for fast validation
             - ESLint warnings threshold: ≤1030
 
             ## Constraints

--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   issues: write
   actions: read
 
@@ -217,7 +217,7 @@ jobs:
           # Full tool access for implementation
           claude_args: >-
             --model claude-sonnet-4-5
-            --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(rg:*),Bash(fd:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)"
+            --allowedTools "Read,Edit,Write,Bash(rg:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)"
           prompt: |
             You are Claude acting via GitHub Actions for the Attio MCP Server repository.
 
@@ -239,14 +239,12 @@ jobs:
             Follow the user's request above. If they ask you to implement something:
 
             1. **Read AGENTS.md first** - it contains project conventions and standards
-            2. **Create a feature branch**: `git checkout -b feature/issue-${{ steps.classify.outputs.issue }}-description`
-            3. **Implement the changes** following project standards
-            4. **Run quality gates**:
-               - `npm run test:offline` (fast unit tests)
-               - `npm run fix:all` (lint/format)
-               - `npx tsc --noEmit` (TypeScript check)
-            5. **Commit with conventional format**: `Type: Description #${{ steps.classify.outputs.issue }}`
-            6. **Push and create a PR**: `gh pr create --title "Type: Description" --body "Fixes #${{ steps.classify.outputs.issue }}"`
+            2. **Implement the changes locally** following project standards
+            3. **Run quality gates**:
+               - `bun run test:offline` (fast unit tests)
+               - `bun run fix:all` (lint/format)
+               - `bun run typecheck` (TypeScript check)
+            4. **Provide a clear patch summary** in your response
 
             If they ask for analysis/advice, provide helpful guidance without implementing.
 


### PR DESCRIPTION
### Motivation
- The issue workflow previously combined untrusted issue/comment content with a write-scoped `GITHUB_TOKEN` and broad allowed shell tools, creating a prompt-injection → repository-write path. This change reduces the workflow blast radius while preserving the issue-assistant functionality.
- The goal is to prevent an LLM from executing arbitrary `gh`/`git`/`node`/`npm`/`npx` commands with write permissions derived from issue content.

### Description
- Reduced token surface in `.github/workflows/claude-commands.yml` by changing `permissions.contents` and `permissions.pull-requests` from `write` to `read`, while retaining `issues: write` for bot commenting and progress updates.
- Tightened the Claude tool allowlist in `claude_args` by removing high-risk patterns `Bash(git:*)`, `Bash(gh:*)`, `Bash(npm:*)`, `Bash(npx:*)`, and `Bash(node:*)`, keeping only read-oriented shell tools and `Read,Edit,Write` primitives for local file edits.
- Updated the embedded prompt to remove automated branch/commit/push/PR instructions and to instruct maintainers/assistant to implement changes locally and run repository-standard quality gates using `bun` (`bun run test:offline`, `bun run fix:all`, `bun run typecheck`) and provide a clear patch summary instead of performing direct repository mutations.
- Kept the maintainer-only gating and contextual fetch logic intact so the workflow still assists with issue-based requests without granting direct repo-write powers to the model.

### Testing
- No repository unit/integration/e2e test suites were executed for this workflow-only configuration change.
- Changes were validated via targeted static verification of the modified workflow file using file inspection and pattern searches (e.g. verifying `permissions:` and the `--allowedTools` list in ` .github/workflows/claude-commands.yml`).
- The updated workflow file passed the static checks and contains the intended reduced permission set and tightened tool allowlist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd671d06b88325b55fc381410e74bb)