### PR TITLE
Fix: Validate OAuth callback state before token exchange

### DIFF
--- a/examples/cloudflare-mcp-server/worker.ts
+++ b/examples/cloudflare-mcp-server/worker.ts
@@ -456,8 +456,12 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
   await env.TOKEN_STORE.delete(`session:${state}`);
 
   if (!clientRedirectUri || !isAllowedRedirectUri(clientRedirectUri, env)) {
-    console.warn('OAuth callback rejected due to invalid redirect_uri in session');
-    return new Response('Invalid redirect URI in OAuth session', { status: 400 });
+    console.warn(
+      'OAuth callback rejected due to invalid redirect_uri in session'
+    );
+    return new Response('Invalid redirect URI in OAuth session', {
+      status: 400,
+    });
   }
 
   // Exchange code for tokens

--- a/examples/cloudflare-mcp-server/worker.ts
+++ b/examples/cloudflare-mcp-server/worker.ts
@@ -422,6 +422,44 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     return new Response('Missing authorization code', { status: 400 });
   }
 
+  // SECURITY: Require callback state to be a session issued by /oauth/authorize.
+  // Do not trust state payload from the callback itself.
+  if (!state) {
+    return new Response('Missing state parameter', { status: 400 });
+  }
+
+  const sessionDataStr = await env.TOKEN_STORE.get(`session:${state}`);
+  if (!sessionDataStr) {
+    console.warn(
+      'OAuth callback rejected: state was not issued by this worker',
+      state.substring(0, 8) + '...'
+    );
+    return new Response('Invalid or expired state', { status: 400 });
+  }
+
+  let clientRedirectUri: string | null = null;
+  let originalState: string | null = null;
+
+  try {
+    const sessionData = JSON.parse(sessionDataStr) as {
+      redirectUri?: string;
+      originalState?: string;
+    };
+    clientRedirectUri = sessionData.redirectUri || null;
+    originalState = sessionData.originalState || null;
+  } catch {
+    await env.TOKEN_STORE.delete(`session:${state}`);
+    return new Response('Invalid OAuth session state', { status: 400 });
+  }
+
+  // Clean up session data immediately after successful validation (single use)
+  await env.TOKEN_STORE.delete(`session:${state}`);
+
+  if (!clientRedirectUri || !isAllowedRedirectUri(clientRedirectUri, env)) {
+    console.warn('OAuth callback rejected due to invalid redirect_uri in session');
+    return new Response('Invalid redirect URI in OAuth session', { status: 400 });
+  }
+
   // Exchange code for tokens
   const tokenResponse = await fetch('https://app.attio.com/oauth/token', {
     method: 'POST',
@@ -518,39 +556,6 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
   );
   await tokenStorage.storeToken(`auth:${authCode}`, storedToken);
   console.log('[OAuth Callback] Token stored with auth: prefix');
-
-  // Extract redirect_uri from encoded state (primary method)
-  // Fall back to KV lookup if state decoding fails
-  let clientRedirectUri: string | null = null;
-  let originalState: string | null = null;
-
-  if (state) {
-    // Try to decode state (base64url encoded JSON)
-    try {
-      const paddedState = state.replace(/-/g, '+').replace(/_/g, '/');
-      const statePayload = JSON.parse(atob(paddedState));
-      clientRedirectUri = statePayload.redirectUri || null;
-      originalState = statePayload.originalState || null;
-    } catch {
-      // State wasn't encoded, try KV lookup as fallback
-      const sessionDataStr = await env.TOKEN_STORE.get(`session:${state}`);
-      if (sessionDataStr) {
-        try {
-          const sessionData = JSON.parse(sessionDataStr) as {
-            redirectUri?: string;
-            originalState?: string;
-          };
-          clientRedirectUri = sessionData.redirectUri || null;
-          originalState = sessionData.originalState || null;
-        } catch {
-          // Ignore parse errors
-        }
-      }
-    }
-
-    // Clean up session data
-    await env.TOKEN_STORE.delete(`session:${state}`);
-  }
 
   // If we have a client redirect_uri, redirect back to the client with the auth code
   if (clientRedirectUri && clientRedirectUri !== `${baseUrl}/oauth/callback`) {


### PR DESCRIPTION
### Motivation
- Close an OAuth attack where the callback trusted attacker-controlled `state` payload and could redirect generated MCP auth codes to arbitrary URLs. 
- Ensure the worker only exchanges Attio authorization codes after proving the callback `state` was issued by this worker and that the client redirect is allowlisted.

### Description
- Require `state` on `/oauth/callback` and reject requests missing it before any token exchange. 
- Require a matching `session:${state}` record in KV issued by `/oauth/authorize` and parse `redirectUri`/`originalState` only from that trusted session data. 
- Delete the session data immediately after validation (single-use) and re-validate the `clientRedirectUri` against the redirect allowlist before redirecting. 
- Stop decoding and trusting base64 JSON state from the callback payload (removed fallback that allowed attacker-supplied redirect URIs). 

### Testing
- Ran `bun run typecheck`, which failed due to unrelated baseline repository/environment dependency/type issues (missing modules/type defs), not caused by this patch. 
- Attempted `bun run lint:file -- "examples/cloudflare-mcp-server/worker.ts"`, but the lint helper script is not defined in this environment, so linting was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd6b9aeb648325aff229e359ec6bce)