### PR TITLE
Fix: Harden Claude comment context trust

### DIFF
--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -130,30 +130,37 @@ jobs:
               per_page: 100
             });
 
-            // Find most recent Claude response (for follow-up context)
+            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+            const isTrustedCommentAuthor = (comment) =>
+              comment.user?.type === 'Bot' || trustedAssociations.has(comment.author_association);
+
+            // Find most recent trusted Claude response (for follow-up context)
             const claudeResponses = allComments
               .filter(c => c.body.includes('<!-- claude-command-response -->'))
+              .filter(isTrustedCommentAuthor)
               .reverse(); // Most recent first
 
             const previousAnalysis = claudeResponses.length > 0
               ? claudeResponses[0].body.replace('<!-- claude-command-response -->\n', '').slice(0, 8000)
               : '';
 
-            // Get recent user comments (last 5, excluding triggering comment and bot comments)
+            // Get recent trusted comments (last 5, excluding triggering comment and Claude responses)
             const recentComments = allComments
               .filter(c => c.id !== commentId) // Exclude triggering comment
-              .filter(c => c.user.type !== 'Bot') // Exclude bot comments
+              .filter(isTrustedCommentAuthor) // Include maintainers/collaborators/bots only
               .filter(c => !c.body.includes('<!-- claude-command-response -->')) // Exclude previous Claude responses
               .slice(-5) // Get last 5 user comments
               .map(c => ({
                 author: c.user.login,
+                association: c.author_association,
                 created_at: c.created_at,
                 body: c.body.slice(0, 2000) // Limit each comment to 2000 chars
               }));
 
             const recentCommentsFormatted = recentComments.length > 0
               ? recentComments.map(c =>
-                  `**@${c.author}** (${new Date(c.created_at).toISOString().split('T')[0]}):\n${c.body}\n`
+                  `**@${c.author}** [${c.association}] (${new Date(c.created_at).toISOString().split('T')[0]}):\n${c.body}\n`
                 ).join('\n---\n\n')
               : '';
 


### PR DESCRIPTION
### Motivation
- Fix a prompt‑injection/trust boundary bug where any issue comment containing the hidden marker (`<!-- claude-command-response -->`) could be treated as prior Claude analysis regardless of author, allowing untrusted users to inject attacker-controlled context into a privileged agent prompt. 
- Prevent untrusted recent discussion from being inserted verbatim into the Claude prompt where the action has write/shell capabilities, which could lead to repository modification or secret exposure.

### Description
- Added a `trustedAssociations` set and an `isTrustedCommentAuthor` helper that treats `Bot` accounts and `OWNER`/`MEMBER`/`COLLABORATOR` associations as trusted. 
- Require `previous_analysis` candidate comments to both contain the Claude marker and pass `isTrustedCommentAuthor` before being used as follow-up context. 
- Restrict `recent_comments` included in `Recent Discussion` to trusted commenters only and exclude Claude responses. 
- Annotate formatted recent comments with `author_association` so provenance is explicit when included in the prompt.

### Testing
- Ran `git diff --check`, which completed without issues. 
- Attempted `bun run lint:file -- ".github/workflows/claude-commands.yml"`, which failed because the repository does not define a `lint:file` script (noted and no further lint step available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd6c4d926c832588c693710fe08585)