### PR TITLE
Fix: Harden publish workflow credential scope

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -7,11 +7,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       package_version: ${{ steps.extract.outputs.version }}
@@ -91,11 +93,14 @@ jobs:
         # --provenance generates a Sigstore attestation linking the package to this CI build.
         # Requires npm Trusted Publisher configuration for this repository/workflow.
         # See: https://docs.npmjs.com/generating-provenance-statements
-        run: npm publish --access public --provenance
+        run: npm publish --ignore-scripts --access public --provenance
 
   publish-registry:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Determine version
         id: version


### PR DESCRIPTION
### Motivation
- Mitigate credential-exposure risk where `npm publish` executed lifecycle scripts from a tag-controlled ref with `NODE_AUTH_TOKEN` available.
- Reduce OIDC blast radius by avoiding workflow-wide `id-token: write` permission.
- Preserve existing tag/manual dispatch release flow while closing the attack vector for token exfiltration.

### Description
- Removed `id-token: write` from top-level `permissions` in `.github/workflows/publish-mcp-registry.yml` to avoid workflow-scope OIDC minting.
- Scoped `id-token: write` to the specific jobs that require it by adding `permissions` to `publish-npm` and `publish-registry` jobs.
- Changed the publish command to `npm publish --ignore-scripts --access public` to prevent package lifecycle scripts (e.g., `prepare`) from running during the privileged publish step.

### Testing
- Attempted to run the offline test suite with `bun run test:offline`, but the command failed in this environment because `vitest`/dependencies are not installed (test runner not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd76fd93308325869b61f20244e1cb)