### PR TITLE
Fix: Scope search cache by tenant context

### DIFF
--- a/src/api/operations/search.ts
+++ b/src/api/operations/search.ts
@@ -3,6 +3,8 @@
  * Handles basic and advanced search functionality
  */
 
+import { scryptSync } from 'crypto';
+
 import { getLazyAttioClient, getGlobalContext } from '@api/lazy-client.js';
 import { callWithRetry, RetryConfig } from '@api/operations/retry.js';
 import { ListEntryFilters } from '@api/operations/types.js';
@@ -81,14 +83,12 @@ function getCacheKey(
 }
 
 function getTenantScope(): string {
-  const context = getGlobalContext() as
-    | {
-        ATTIO_API_KEY?: string;
-        ATTIO_ACCESS_TOKEN?: string;
-        workspaceId?: string;
-        smitheryUserId?: string;
-      }
-    | null;
+  const context = getGlobalContext() as {
+    ATTIO_API_KEY?: string;
+    ATTIO_ACCESS_TOKEN?: string;
+    workspaceId?: string;
+    smitheryUserId?: string;
+  } | null;
 
   const workspaceId =
     typeof context?.workspaceId === 'string' ? context.workspaceId : '';
@@ -100,8 +100,13 @@ function getTenantScope(): string {
       : typeof context?.ATTIO_API_KEY === 'string'
         ? context.ATTIO_API_KEY
         : '';
+  const credentialHash = credential
+    ? scryptSync(credential, 'attio-mcp-search-cache-scope-v1', 32).toString(
+        'hex'
+      )
+    : '';
 
-  return `${workspaceId}:${smitheryUserId}:${credential}`;
+  return `${workspaceId}:${smitheryUserId}:${credentialHash}`;
 }
 
 function normalizeDomainValue(value: string): string {

--- a/src/api/operations/search.ts
+++ b/src/api/operations/search.ts
@@ -3,7 +3,7 @@
  * Handles basic and advanced search functionality
  */
 
-import { getLazyAttioClient } from '@api/lazy-client.js';
+import { getLazyAttioClient, getGlobalContext } from '@api/lazy-client.js';
 import { callWithRetry, RetryConfig } from '@api/operations/retry.js';
 import { ListEntryFilters } from '@api/operations/types.js';
 import { parseQuery, ParsedQuery } from '@api/operations/query-parser.js';
@@ -74,9 +74,34 @@ const searchCache = new LRUCache<string, AttioRecord[]>({
 function getCacheKey(
   objectType: ResourceType,
   query: string,
-  limit: number
+  limit: number,
+  tenantScope: string
 ): string {
-  return `${objectType}:${limit}:${query.toLowerCase()}`;
+  return `${tenantScope}:${objectType}:${limit}:${query.toLowerCase()}`;
+}
+
+function getTenantScope(): string {
+  const context = getGlobalContext() as
+    | {
+        ATTIO_API_KEY?: string;
+        ATTIO_ACCESS_TOKEN?: string;
+        workspaceId?: string;
+        smitheryUserId?: string;
+      }
+    | null;
+
+  const workspaceId =
+    typeof context?.workspaceId === 'string' ? context.workspaceId : '';
+  const smitheryUserId =
+    typeof context?.smitheryUserId === 'string' ? context.smitheryUserId : '';
+  const credential =
+    typeof context?.ATTIO_ACCESS_TOKEN === 'string'
+      ? context.ATTIO_ACCESS_TOKEN
+      : typeof context?.ATTIO_API_KEY === 'string'
+        ? context.ATTIO_API_KEY
+        : '';
+
+  return `${workspaceId}:${smitheryUserId}:${credential}`;
 }
 
 function normalizeDomainValue(value: string): string {
@@ -594,7 +619,7 @@ export async function searchObject<T extends AttioRecord>(
   const parsedQuery = trimmedQuery ? parseQuery(trimmedQuery) : null;
   const cacheKey =
     scoringEnabled && trimmedQuery
-      ? getCacheKey(objectType, trimmedQuery, baseLimit)
+      ? getCacheKey(objectType, trimmedQuery, baseLimit, getTenantScope())
       : null;
 
   if (scoringEnabled && cacheKey) {


### PR DESCRIPTION
### Motivation
- The global search result cache used keys based only on `objectType`, `limit`, and `query`, allowing cached CRM records to be returned across tenant/workspace contexts in shared runtimes. 
- Cache reuse across distinct client contexts is a confidentiality risk and must be partitioned by tenant/credential context while preserving intra-tenant caching benefits.

### Description
- Imported `getGlobalContext` and added `getTenantScope()` in `src/api/operations/search.ts` to derive a tenant-scoped identifier from `workspaceId`, `smitheryUserId`, and the current credential (`ATTIO_ACCESS_TOKEN` or `ATTIO_API_KEY`).
- Changed `getCacheKey(...)` to accept a `tenantScope` argument and prefixed cache keys with that scope (`${tenantScope}:${objectType}:${limit}:${query}`).
- Updated `searchObject` to compute the cache key with `getTenantScope()` so cached entries are partitioned per tenant/credential context.
- Preserved existing cache behavior, fast-path ranking, and fallback logic; only the cache key composition was changed to prevent cross-tenant leaks.

### Testing
- Ran `bun run typecheck`, which failed due to pre-existing dependency/type setup issues in the environment unrelated to this change (typecheck errors reported across the repo). 
- Attempted `bun run lint:file -- "src/api/operations/search.ts"`, which could not be executed because the `lint:file` script is not present in this environment.
- No repository unit/integration tests were executed in this session due to environment constraints; the change is minimal and limited to cache key construction and should be safe to validate with the normal CI/test matrix (`bun run test`, `bun run test:offline`) in a full environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd8fbc48048325b22586f30a6b495a)