### PR TITLE
Fix: Invalidate cached Attio client on global context changes

### DIFF
--- a/src/api/lazy-client.ts
+++ b/src/api/lazy-client.ts
@@ -33,6 +33,8 @@ export function getLazyAttioClient(config?: ClientConfig): AxiosInstance {
 
 export function setGlobalContext(context: Record<string, unknown>): void {
   setClientContext(context);
+  // Context changes may carry different credentials; invalidate stale cached client
+  ClientCache.clearInstance();
 }
 
 export function clearClientCache(): void {

--- a/test/api/attio-client.context.test.ts
+++ b/test/api/attio-client.context.test.ts
@@ -102,6 +102,26 @@ describe('Attio client context fallback', () => {
     );
   });
 
+  it('invalidates cached client when global context changes', async () => {
+    const { setGlobalContext } = await import('@/api/lazy-client.js');
+    const { getLazyAttioClient } = await import('@/api/lazy-client.js');
+
+    setGlobalContext({
+      getApiKey: () => 'tenant-a-key-12345',
+    });
+    const firstClient = getLazyAttioClient();
+
+    setGlobalContext({
+      getApiKey: () => 'tenant-b-key-67890',
+    });
+    const secondClient = getLazyAttioClient();
+
+    expect(secondClient).not.toBe(firstClient);
+    expect(secondClient.defaults.headers.Authorization).toBe(
+      'Bearer tenant-b-key-67890'
+    );
+  });
+
   it('prefers environment variable over context when both are provided', async () => {
     process.env.ATTIO_API_KEY = 'env-key-12345';
 


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant credential reuse where a module-global `ClientCache` could return a stale Axios instance with another tenant's `Authorization` header after `setGlobalContext` is called in shared runtimes.

### Description
- In `src/api/lazy-client.ts` call `ClientCache.clearInstance()` from `setGlobalContext()` to invalidate any cached client when the global context changes.
- Add a focused regression test in `test/api/attio-client.context.test.ts` that simulates tenant A then tenant B context and asserts a new client is created and uses tenant B's credentials.

### Testing
- Attempted to run the focused test with `bunx vitest --config configs/vitest/vitest.config.ts test/api/attio-client.context.test.ts --run`, but execution failed in this environment due to missing `vitest` dependency resolution, so tests could not be executed here.
- Linting of the changed files was intended via `bunx eslint src/api/lazy-client.ts test/api/attio-client.context.test.ts`, but the full toolchain could not be run in this workspace for the same environment/dependency limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd7fe35ae0832587d4f7ebeb01c3e6)