### PR TITLE
Fix: Pin trusted ref for Claude classifier checkout

### DIFF
--- a/.github/workflows/claude-commands.yml
+++ b/.github/workflows/claude-commands.yml
@@ -38,9 +38,11 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: Checkout repository
+      - name: Checkout trusted classifier scripts
         uses: actions/checkout@v4
         with:
+          ref: refs/heads/${{ github.event.repository.default_branch }}
+          persist-credentials: false
           sparse-checkout: |
             scripts/workflows/claude/
           sparse-checkout-cone-mode: false

--- a/.github/workflows/claude-comment-gate.yml
+++ b/.github/workflows/claude-comment-gate.yml
@@ -36,9 +36,11 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout trusted classifier scripts
         uses: actions/checkout@v4
         with:
+          ref: refs/heads/${{ github.event.repository.default_branch }}
+          persist-credentials: false
           sparse-checkout: |
             scripts/workflows/claude/
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
### Motivation
- Close a CI authorization flaw where workflows executed classifier scripts from the event/PR checkout before maintainer gates, allowing PR-controlled code to influence authorization.

### Description
- Updated `.github/workflows/claude-commands.yml` to perform the pre-classification sparse checkout from the repository default branch with `ref: refs/heads/${{ github.event.repository.default_branch }}` and `persist-credentials: false` so classifier scripts run from a trusted ref.
- Applied the same change to `.github/workflows/claude-comment-gate.yml` and renamed the step to `Checkout trusted classifier scripts` while keeping the sparse path `scripts/workflows/claude/` unchanged.
- This is a minimal hardening that prevents PR-controlled refs from supplying classifier scripts while preserving existing workflow logic and downstream full checkout behavior.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff issues and it succeeded.
- Ran `git status --short` to verify the working tree and staged changes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd7c350f408325b3f294eaf375bab2)