### PR TITLE
Fix: Prioritize server context credential for Attio client

### DIFF
--- a/src/api/attio-client.ts
+++ b/src/api/attio-client.ts
@@ -102,19 +102,21 @@ export function createAttioClient(
   // Supports both API keys and OAuth access tokens (Issue #928)
   const apiKey =
     config.apiKey ??
+    getContextApiKey() ??
     process.env.ATTIO_API_KEY ??
     process.env.ATTIO_ACCESS_TOKEN ??
-    getContextApiKey() ??
     '';
 
   // Determine the source for better error messages
   const apiKeySource = config.apiKey
     ? 'config parameter'
-    : process.env.ATTIO_API_KEY
-      ? 'ATTIO_API_KEY environment variable'
-      : process.env.ATTIO_ACCESS_TOKEN
-        ? 'ATTIO_ACCESS_TOKEN environment variable'
-        : 'context configuration';
+    : getContextApiKey()
+      ? 'context configuration'
+      : process.env.ATTIO_API_KEY
+        ? 'ATTIO_API_KEY environment variable'
+        : process.env.ATTIO_ACCESS_TOKEN
+          ? 'ATTIO_ACCESS_TOKEN environment variable'
+          : 'provided configuration';
 
   // Validate API key using standardized validation
   validateAndThrowForApiKey(apiKey, apiKeySource);

--- a/src/api/attio-client.ts
+++ b/src/api/attio-client.ts
@@ -100,9 +100,10 @@ export function createAttioClient(
 
   // Get API key from config, environment, or context
   // Supports both API keys and OAuth access tokens (Issue #928)
+  const contextApiKey = getContextApiKey();
   const apiKey =
     config.apiKey ??
-    getContextApiKey() ??
+    contextApiKey ??
     process.env.ATTIO_API_KEY ??
     process.env.ATTIO_ACCESS_TOKEN ??
     '';
@@ -110,7 +111,7 @@ export function createAttioClient(
   // Determine the source for better error messages
   const apiKeySource = config.apiKey
     ? 'config parameter'
-    : getContextApiKey()
+    : contextApiKey
       ? 'context configuration'
       : process.env.ATTIO_API_KEY
         ? 'ATTIO_API_KEY environment variable'

--- a/test/api/attio-client.context.test.ts
+++ b/test/api/attio-client.context.test.ts
@@ -122,18 +122,20 @@ describe('Attio client context fallback', () => {
     );
   });
 
-  it('prefers environment variable over context when both are provided', async () => {
+  it('prefers context credential over environment variable when both are provided', async () => {
     process.env.ATTIO_API_KEY = 'env-key-12345';
 
     const { setGlobalContext } = await import('@/api/lazy-client.js');
     setGlobalContext({
-      getApiKey: () => 'context-key-ignored-12345',
+      getApiKey: () => 'context-key-12345',
     });
 
     const { getAttioClient } = await import('@/api/attio-client.js');
     const client = getAttioClient();
 
-    expect(client.defaults.headers.Authorization).toBe('Bearer env-key-12345');
+    expect(client.defaults.headers.Authorization).toBe(
+      'Bearer context-key-12345'
+    );
   });
 
   it('rebuilds cached clients when the context API key changes', async () => {


### PR DESCRIPTION
### Motivation
- Restore tenant isolation by ensuring `createAttioClient` prefers per-request/server context credentials over process-level environment credentials to avoid cross-tenant API calls introduced by the prior change.

### Description
- Adjusted credential resolution in `createAttioClient` to prefer `config.apiKey` → `getContextApiKey()` → `process.env.ATTIO_API_KEY` → `process.env.ATTIO_ACCESS_TOKEN` and updated the `apiKeySource` attribution accordingly in `src/api/attio-client.ts`.

### Testing
- Ran `bun run typecheck`, which could not complete in this environment due to missing workspace/dependency type definitions (e.g., `axios`, Node typings), so static typechecking could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd9da86ee08325be572051111229a1)