### PR TITLE
Fix: Preserve context-aware Attio client resolution

### DIFF
--- a/src/services/search/QueryApiService.ts
+++ b/src/services/search/QueryApiService.ts
@@ -23,18 +23,13 @@ import {
   createContentSearchQuery,
 } from '@/utils/filters/index.js';
 import { RelationshipQuery, TimeframeQuery } from '@/utils/filters/types.js';
-import { getLazyAttioClient } from '@/api/lazy-client.js';
-import * as AttioClientModule from '@/api/attio-client.js';
 import type { AxiosInstance } from 'axios';
+import { getLazyAttioClient } from '@/api/lazy-client.js';
 
 /**
- * Resolve Query API client (prefers mocked version in tests)
+ * Resolve Query API client from context-aware lazy client.
  */
 function resolveQueryApiClient(): AxiosInstance {
-  const mod = AttioClientModule as { getAttioClient?: () => AxiosInstance };
-  if (typeof mod.getAttioClient === 'function') {
-    return mod.getAttioClient();
-  }
   return getLazyAttioClient();
 }
 

--- a/src/services/search/RecordsSearchService.ts
+++ b/src/services/search/RecordsSearchService.ts
@@ -9,7 +9,6 @@ import type { AxiosInstance } from 'axios';
 
 import type { UniversalRecord } from '@/types/attio.js';
 import { getLazyAttioClient } from '@/api/lazy-client.js';
-import * as AttioClientModule from '@/api/attio-client.js';
 import { listObjectRecords } from '@/objects/records/index.js';
 import { ValidationService } from '@/services/ValidationService.js';
 import { debug, createScopedLogger, OperationType } from '@/utils/logger.js';
@@ -24,13 +23,9 @@ import {
 } from '@/errors/api-errors.js';
 
 /**
- * Resolve API client (prefers mocked version in tests)
+ * Resolve API client from context-aware lazy client.
  */
 function resolveApiClient(): AxiosInstance {
-  const mod = AttioClientModule as { getAttioClient?: () => AxiosInstance };
-  if (typeof mod.getAttioClient === 'function') {
-    return mod.getAttioClient();
-  }
   return getLazyAttioClient();
 }
 

--- a/src/utils/client-resolver.ts
+++ b/src/utils/client-resolver.ts
@@ -72,9 +72,9 @@ function assertAxiosInstance(
 
 function resolveApiKey(): string | undefined {
   return (
+    getContextApiKey() ||
     process.env.ATTIO_API_KEY ||
-    process.env.ATTIO_ACCESS_TOKEN ||
-    getContextApiKey()
+    process.env.ATTIO_ACCESS_TOKEN
   );
 }
 
@@ -96,6 +96,7 @@ export function resolveAttioClient(): AxiosInstance {
   const resolvedApiKey = resolveApiKey();
 
   // Prefer unified factory with explicit credentials and cache bypass
+  // so request-scoped context credentials are honored in shared deployments.
   if (typeof mod.createAttioClient === 'function') {
     logger.debug(
       'Using createAttioClient() with explicit apiKey and bypassCache'
@@ -117,6 +118,14 @@ export function resolveAttioClient(): AxiosInstance {
       assertAxiosInstance(client, 'createAttioClient(config)');
       return client;
     }
+  }
+
+  // Backward-compatibility fallback for older module interfaces.
+  if (typeof mod.getAttioClient === 'function') {
+    logger.debug('Fallback to getAttioClient()');
+    const client = mod.getAttioClient();
+    assertAxiosInstance(client, 'getAttioClient()');
+    return client;
   }
 
   // Last resort: buildAttioClient

--- a/test/unit/services/search/QueryApiService.test.ts
+++ b/test/unit/services/search/QueryApiService.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/utils/filters/index.js', () => ({
   createContentSearchQuery: vi.fn(() => ({ filter: { test: 'content' } })),
 }));
 
-import * as AttioClientModule from '@/api/attio-client.js';
+import * as LazyClientModule from '@/api/lazy-client.js';
 import { createTimeframeQuery } from '@/utils/filters/index.js';
 
 describe('QueryApiService', () => {
@@ -53,7 +53,7 @@ describe('QueryApiService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -76,7 +76,7 @@ describe('QueryApiService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 404, data: { error: 'Not found' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -93,7 +93,7 @@ describe('QueryApiService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 401, data: { error: 'Unauthorized' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -110,7 +110,7 @@ describe('QueryApiService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 429, data: { error: 'Rate limited' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -130,7 +130,7 @@ describe('QueryApiService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -161,7 +161,7 @@ describe('QueryApiService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 404, data: { error: 'Not found' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -202,7 +202,7 @@ describe('QueryApiService', () => {
           },
         },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -223,7 +223,7 @@ describe('QueryApiService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -244,7 +244,7 @@ describe('QueryApiService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -261,7 +261,7 @@ describe('QueryApiService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -278,7 +278,7 @@ describe('QueryApiService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 500, data: { error: 'Server error' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 

--- a/test/unit/services/search/RecordsSearchService.test.ts
+++ b/test/unit/services/search/RecordsSearchService.test.ts
@@ -37,7 +37,7 @@ vi.mock('@/services/ValidationService.js', () => ({
   },
 }));
 
-import * as AttioClientModule from '@/api/attio-client.js';
+import * as LazyClientModule from '@/api/lazy-client.js';
 import { listObjectRecords } from '@/objects/records/index.js';
 import { ValidationService } from '@/services/ValidationService.js';
 
@@ -96,7 +96,7 @@ describe('RecordsSearchService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -117,7 +117,7 @@ describe('RecordsSearchService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -134,7 +134,7 @@ describe('RecordsSearchService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -165,7 +165,7 @@ describe('RecordsSearchService', () => {
       const mockPost = vi
         .fn()
         .mockResolvedValue({ data: { data: mockRecords } });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
       vi.mocked(ValidationService.validateUUIDForSearch).mockReturnValue(true);
@@ -187,7 +187,7 @@ describe('RecordsSearchService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 500, data: { error: 'Server error' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -200,7 +200,7 @@ describe('RecordsSearchService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 401, data: { error: 'Unauthorized' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 
@@ -213,7 +213,7 @@ describe('RecordsSearchService', () => {
       const mockPost = vi.fn().mockRejectedValue({
         response: { status: 429, data: { error: 'Rate limited' } },
       });
-      vi.mocked(AttioClientModule.getAttioClient).mockReturnValue({
+      vi.mocked(LazyClientModule.getLazyAttioClient).mockReturnValue({
         post: mockPost,
       } as any);
 

--- a/test/utils/client-resolver.test.ts
+++ b/test/utils/client-resolver.test.ts
@@ -239,7 +239,7 @@ describe('Client Resolver', () => {
   });
 
   describe('environment precedence', () => {
-    it('prefers environment variable over context API key', async () => {
+    it('prefers context API key over environment variable', async () => {
       const mockClient = createMockClient();
       const createAttioClient = vi.fn().mockReturnValue(mockClient);
       mockAttioModule({ createAttioClient });
@@ -251,10 +251,10 @@ describe('Client Resolver', () => {
 
       // After fix in e75725b3, createAttioClient is called with config object (not string)
       expect(createAttioClient).toHaveBeenCalledWith({
-        apiKey: 'env-key-12345',
+        apiKey: 'context-key',
         bypassCache: true,
       });
-      expect(createAttioClient).not.toHaveBeenCalledWith('context-key');
+      expect(createAttioClient).not.toHaveBeenCalledWith('env-key-12345');
     });
 
     it('does not cache resolved clients between calls', async () => {
@@ -312,7 +312,7 @@ describe('Client Resolver', () => {
       ]);
     });
 
-    it('uses ATTIO_ACCESS_TOKEN when ATTIO_API_KEY is absent', async () => {
+    it('uses context API key before ATTIO_ACCESS_TOKEN', async () => {
       const mockClient = createMockClient();
       const createAttioClient = vi.fn().mockReturnValue(mockClient);
       mockAttioModule({ createAttioClient });
@@ -324,10 +324,10 @@ describe('Client Resolver', () => {
 
       expect(client).toBe(mockClient);
       expect(createAttioClient).toHaveBeenCalledWith({
-        apiKey: 'access-token-12345',
+        apiKey: 'context-key-12345',
         bypassCache: true,
       });
-      expect(createAttioClient).not.toHaveBeenCalledWith('context-key-12345');
+      expect(createAttioClient).not.toHaveBeenCalledWith('access-token-12345');
     });
 
     it('does not serialize createAttioClient failure details in debug logs', async () => {


### PR DESCRIPTION
### Motivation
- Several runtime code paths were preferring the legacy `getAttioClient()` factory, which uses a module-global client or `process.env.ATTIO_API_KEY`, causing Smithery/Smithery-like per-request ServerContext credentials to be bypassed and enabling cross-tenant reads/writes.
- Restore context-aware client resolution so request-scoped credentials (e.g., Smithery's `getApiKey()`) are honored in task operations, advanced searches, and validation helpers.

### Description
- Prefer the context-aware factory by updating the unified resolver in `src/utils/client-resolver.ts` to use `createAttioClient(config)` first and only fall back to `getAttioClient()` for backward compatibility.
- Remove the direct legacy-client preference from the Query API service by changing `src/services/search/QueryApiService.ts` to resolve clients via the context-aware `getLazyAttioClient()`.
- Remove the direct legacy-client preference from the Records search service by changing `src/services/search/RecordsSearchService.ts` to resolve clients via the context-aware `getLazyAttioClient()`.

### Testing
- Ran static checks with `bun run typecheck`, which failed in this environment due to missing project dependencies/type declarations (e.g., `axios`, `zod`, Node typings) and is unrelated to the behavioral fix.
- No other CI/unit tests were executed in this container; recommended CI (offline/unit) and integration/e2e test runs should be executed in CI or a dev environment with dependencies installed to validate end-to-end behavior with Smithery contexts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd9705210883259dc360f0da56df48)