### PR TITLE
Fix: Reinstate batch safety limits for operations arrays

### DIFF
--- a/src/handlers/tool-configs/universal/operations/legacy-handlers.ts
+++ b/src/handlers/tool-configs/universal/operations/legacy-handlers.ts
@@ -80,6 +80,16 @@ async function executeCreateBatch(
     );
   }
 
+  const validation = validateBatchOperation({
+    items: records,
+    operationType: 'create',
+    resourceType,
+    checkPayload: true,
+  });
+  if (!validation.isValid) {
+    throw new Error(validation.error);
+  }
+
   const delayMs = process.env.NODE_ENV === 'test' ? TEST_DELAY_MS : 0;
 
   const operations = await processRecordChunks(

--- a/src/handlers/tool-configs/universal/operations/operations-array.ts
+++ b/src/handlers/tool-configs/universal/operations/operations-array.ts
@@ -39,90 +39,94 @@ export async function executeOperationsArray(
   validateOperationGroups(resourceType, operations);
 
   const results: JsonObject[] = [];
-  for (let chunkStart = 0; chunkStart < operations.length; chunkStart += DEFAULT_CHUNK_SIZE) {
+  for (
+    let chunkStart = 0;
+    chunkStart < operations.length;
+    chunkStart += DEFAULT_CHUNK_SIZE
+  ) {
     const chunk = operations.slice(chunkStart, chunkStart + DEFAULT_CHUNK_SIZE);
     const chunkResults = await Promise.all(
       chunk.map(async (operationInput, chunkIndex) => {
         const index = chunkStart + chunkIndex;
-      try {
-        const operation = operationInput.operation as string;
-        const recordData = operationInput.record_data as JsonObject;
+        try {
+          const operation = operationInput.operation as string;
+          const recordData = operationInput.record_data as JsonObject;
 
-        switch (operation) {
-          case 'create': {
-            const result = await handleUniversalCreate({
-              resource_type: resourceType,
-              record_data: recordData,
-              return_details: true,
-            });
+          switch (operation) {
+            case 'create': {
+              const result = await handleUniversalCreate({
+                resource_type: resourceType,
+                record_data: recordData,
+                return_details: true,
+              });
 
-            return {
-              index,
-              success: true,
-              result,
-            } as JsonObject;
+              return {
+                index,
+                success: true,
+                result,
+              } as JsonObject;
+            }
+
+            case 'update': {
+              if (!recordData || !recordData.id) {
+                throw new Error('Record ID is required for update operation');
+              }
+
+              const recordId = extractRecordId(recordData);
+              if (!recordId) {
+                throw new Error('Record ID is required for update operation');
+              }
+
+              // Remove id field from record_data to avoid sending it as an attribute update
+              const { id, ...updateData } = recordData;
+
+              const result = await handleUniversalUpdate({
+                resource_type: resourceType,
+                record_id: recordId,
+                record_data: updateData as JsonObject,
+                return_details: true,
+              });
+
+              return {
+                index,
+                success: true,
+                result,
+              } as JsonObject;
+            }
+
+            case 'delete': {
+              if (!recordData || !recordData.id) {
+                throw new Error('Record ID is required for delete operation');
+              }
+
+              const recordId = extractRecordId(recordData);
+              if (!recordId) {
+                throw new Error('Record ID is required for delete operation');
+              }
+
+              const result = await handleUniversalDelete({
+                resource_type: resourceType,
+                record_id: recordId,
+              });
+
+              return {
+                index,
+                success: true,
+                result,
+                record_id: recordId,
+              } as JsonObject;
+            }
+
+            default:
+              throw new Error(`Unsupported operation: ${operation}`);
           }
-
-          case 'update': {
-            if (!recordData || !recordData.id) {
-              throw new Error('Record ID is required for update operation');
-            }
-
-            const recordId = extractRecordId(recordData);
-            if (!recordId) {
-              throw new Error('Record ID is required for update operation');
-            }
-
-            // Remove id field from record_data to avoid sending it as an attribute update
-            const { id, ...updateData } = recordData;
-
-            const result = await handleUniversalUpdate({
-              resource_type: resourceType,
-              record_id: recordId,
-              record_data: updateData as JsonObject,
-              return_details: true,
-            });
-
-            return {
-              index,
-              success: true,
-              result,
-            } as JsonObject;
-          }
-
-          case 'delete': {
-            if (!recordData || !recordData.id) {
-              throw new Error('Record ID is required for delete operation');
-            }
-
-            const recordId = extractRecordId(recordData);
-            if (!recordId) {
-              throw new Error('Record ID is required for delete operation');
-            }
-
-            const result = await handleUniversalDelete({
-              resource_type: resourceType,
-              record_id: recordId,
-            });
-
-            return {
-              index,
-              success: true,
-              result,
-              record_id: recordId,
-            } as JsonObject;
-          }
-
-          default:
-            throw new Error(`Unsupported operation: ${operation}`);
+        } catch (error) {
+          return {
+            index,
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          } as JsonObject;
         }
-      } catch (error) {
-        return {
-          index,
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
-        } as JsonObject;
-      }
       })
     );
     results.push(...chunkResults);
@@ -162,27 +166,33 @@ function validateOperationGroups(
     }
   }
 
-  const createValidation = validateBatchOperation({
-    items: createRecords,
-    operationType: 'create',
-    resourceType,
-    checkPayload: true,
-  });
-  if (!createValidation.isValid) throw new Error(createValidation.error);
+  if (createRecords.length > 0) {
+    const createValidation = validateBatchOperation({
+      items: createRecords,
+      operationType: 'create',
+      resourceType,
+      checkPayload: true,
+    });
+    if (!createValidation.isValid) throw new Error(createValidation.error);
+  }
 
-  const updateValidation = validateBatchOperation({
-    items: updateRecords,
-    operationType: 'update',
-    resourceType,
-    checkPayload: true,
-  });
-  if (!updateValidation.isValid) throw new Error(updateValidation.error);
+  if (updateRecords.length > 0) {
+    const updateValidation = validateBatchOperation({
+      items: updateRecords,
+      operationType: 'update',
+      resourceType,
+      checkPayload: true,
+    });
+    if (!updateValidation.isValid) throw new Error(updateValidation.error);
+  }
 
-  const deleteValidation = validateBatchOperation({
-    items: deleteIds,
-    operationType: 'delete',
-    resourceType,
-    checkPayload: false,
-  });
-  if (!deleteValidation.isValid) throw new Error(deleteValidation.error);
+  if (deleteIds.length > 0) {
+    const deleteValidation = validateBatchOperation({
+      items: deleteIds,
+      operationType: 'delete',
+      resourceType,
+      checkPayload: false,
+    });
+    if (!deleteValidation.isValid) throw new Error(deleteValidation.error);
+  }
 }

--- a/src/handlers/tool-configs/universal/operations/operations-array.ts
+++ b/src/handlers/tool-configs/universal/operations/operations-array.ts
@@ -5,6 +5,10 @@ import {
   handleUniversalUpdate,
   handleUniversalDelete,
 } from '../shared-handlers.js';
+import { validateBatchOperation } from '../../../../utils/batch-validation.js';
+import { BATCH_CONFIG } from '../../../../config/batch-constants.js';
+
+const { DEFAULT_CHUNK_SIZE, DEFAULT_MAX_BATCH } = BATCH_CONFIG;
 
 export function extractRecordId(recordData: JsonObject): string {
   const rawId = recordData.id;
@@ -26,8 +30,20 @@ export async function executeOperationsArray(
   resourceType: UniversalResourceType,
   operations: JsonObject[]
 ): Promise<JsonObject> {
-  const results = await Promise.all(
-    operations.map(async (operationInput, index) => {
+  if (operations.length > DEFAULT_MAX_BATCH) {
+    throw new Error(
+      `Batch size (${operations.length}) exceeds maximum allowed (${DEFAULT_MAX_BATCH})`
+    );
+  }
+
+  validateOperationGroups(resourceType, operations);
+
+  const results: JsonObject[] = [];
+  for (let chunkStart = 0; chunkStart < operations.length; chunkStart += DEFAULT_CHUNK_SIZE) {
+    const chunk = operations.slice(chunkStart, chunkStart + DEFAULT_CHUNK_SIZE);
+    const chunkResults = await Promise.all(
+      chunk.map(async (operationInput, chunkIndex) => {
+        const index = chunkStart + chunkIndex;
       try {
         const operation = operationInput.operation as string;
         const recordData = operationInput.record_data as JsonObject;
@@ -107,8 +123,10 @@ export async function executeOperationsArray(
           error: error instanceof Error ? error.message : String(error),
         } as JsonObject;
       }
-    })
-  );
+      })
+    );
+    results.push(...chunkResults);
+  }
 
   const summary = {
     total: results.length,
@@ -120,4 +138,51 @@ export async function executeOperationsArray(
     operations: results,
     summary,
   } as JsonObject;
+}
+
+function validateOperationGroups(
+  resourceType: UniversalResourceType,
+  operations: JsonObject[]
+): void {
+  const createRecords: JsonObject[] = [];
+  const updateRecords: JsonObject[] = [];
+  const deleteIds: string[] = [];
+
+  for (const operationInput of operations) {
+    const operation = operationInput.operation as string;
+    const recordData = operationInput.record_data as JsonObject;
+
+    if (operation === 'create') {
+      createRecords.push(recordData);
+    } else if (operation === 'update') {
+      updateRecords.push(recordData);
+    } else if (operation === 'delete') {
+      const recordId = extractRecordId(recordData);
+      if (recordId) deleteIds.push(recordId);
+    }
+  }
+
+  const createValidation = validateBatchOperation({
+    items: createRecords,
+    operationType: 'create',
+    resourceType,
+    checkPayload: true,
+  });
+  if (!createValidation.isValid) throw new Error(createValidation.error);
+
+  const updateValidation = validateBatchOperation({
+    items: updateRecords,
+    operationType: 'update',
+    resourceType,
+    checkPayload: true,
+  });
+  if (!updateValidation.isValid) throw new Error(updateValidation.error);
+
+  const deleteValidation = validateBatchOperation({
+    items: deleteIds,
+    operationType: 'delete',
+    resourceType,
+    checkPayload: false,
+  });
+  if (!deleteValidation.isValid) throw new Error(deleteValidation.error);
 }

--- a/src/handlers/tool-configs/universal/schemas/advanced-schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas/advanced-schemas.ts
@@ -208,6 +208,7 @@ export const batchOperationsSchema = {
     // New flexible format: operations array
     operations: {
       type: 'array' as const,
+      maxItems: 100,
       items: {
         type: 'object' as const,
         properties: {


### PR DESCRIPTION
### Motivation
- A flexible `operations` array format allowed unbounded `Promise.all` execution and bypassed existing `validateBatchOperation` checks, enabling high-volume writes/deletes in a single request. 
- The legacy batch create path also lost its payload/size validation guard, making batch operations inconsistent and risky for destructive operations. 
- The change restores existing safety controls while preserving backward compatibility and the new array-format functionality.

### Description
- Add a schema-level cap by setting `operations.maxItems = 100` in `batchOperationsSchema` to provide a client-visible upper bound. 
- Harden the operations-array executor (`operations/operations-array.ts`) to enforce `DEFAULT_MAX_BATCH`, group and validate create/update/delete subgroups via `validateBatchOperation`, and process the array in bounded chunks of `DEFAULT_CHUNK_SIZE` instead of doing an unbounded `Promise.all` over the full array. 
- Restore batch validation for the legacy create path by calling `validateBatchOperation` with `checkPayload: true` in `operations/legacy-handlers.ts`. 
- Implementation details: import and use `validateBatchOperation` and `BATCH_CONFIG` constants, add `validateOperationGroups` helper to reuse existing validation logic, and throw clear errors when limits are exceeded.

### Testing
- Attempted lint with `bunx eslint src/handlers/.../operations/operations-array.ts src/handlers/.../legacy-handlers.ts src/handlers/.../schemas/advanced-schemas.ts`, which failed in this environment due to a missing local ESLint dependency (`@eslint/js`). 
- Attempted typecheck with `bun run typecheck`, which failed in this environment because repository build dependencies and type packages (e.g., `axios`, `@types/node`, and several SDK types) are not installed and produced unrelated type errors. 
- Performed targeted static source validations (grep/sed inspection) to confirm the new validation + chunking are wired correctly and committed the change as `Fix: Reinstate batch safety limits for operations arrays`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fda6dece40832593598e33606317fe)