### PR TITLE
Fix: validate note_id for note update/delete paths

### DIFF
--- a/src/handlers/tool-configs/universal/schemas/utility-schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas/utility-schemas.ts
@@ -63,7 +63,11 @@ export const getNotesSchema = {
 export const updateNoteSchema = {
   type: 'object' as const,
   properties: {
-    note_id: { type: 'string' as const, description: 'Note ID to update' },
+    note_id: {
+      type: 'string' as const,
+      pattern: '^[a-zA-Z0-9_-]+$',
+      description: 'Note ID to update',
+    },
     title: { type: 'string' as const, description: 'New title' },
     content: { type: 'string' as const, description: 'New content' },
   },
@@ -91,7 +95,11 @@ export const searchNotesSchema = {
 export const deleteNoteSchema = {
   type: 'object' as const,
   properties: {
-    note_id: { type: 'string' as const, description: 'Note ID to delete' },
+    note_id: {
+      type: 'string' as const,
+      pattern: '^[a-zA-Z0-9_-]+$',
+      description: 'Note ID to delete',
+    },
   },
   required: ['note_id' as const],
   additionalProperties: false,

--- a/src/handlers/tool-configs/universal/validators/field-validator.ts
+++ b/src/handlers/tool-configs/universal/validators/field-validator.ts
@@ -147,6 +147,7 @@ export function validateIdFields(params: SanitizedObject): void {
     'company_id',
     'person_id',
     'list_id',
+    'note_id',
   ];
   for (const field of idFields) {
     if (

--- a/test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts
+++ b/test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts
@@ -584,4 +584,23 @@ describe('validateUniversalToolParams', () => {
       });
     });
   });
+
+  describe('note operations - note_id validation', () => {
+    it('should reject traversal-style note_id values for update-note', () => {
+      expect(() =>
+        validateUniversalToolParams('update-note', {
+          note_id: '../objects/companies',
+          title: 'Updated note',
+        })
+      ).toThrow('Invalid note_id format');
+    });
+
+    it('should reject traversal-style note_id values for delete-note', () => {
+      expect(() =>
+        validateUniversalToolParams('delete-note', {
+          note_id: '../objects/companies',
+        })
+      ).toThrow('Invalid note_id format');
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent path-traversal / intent-bypass where attacker-controlled `note_id` values (for example `../objects/...`) are interpolated into `/notes/${note_id}` and cause authenticated requests to other Attio v2 endpoints.

### Description
- Add `note_id` to `validateIdFields` in `src/handlers/tool-configs/universal/validators/field-validator.ts` so runtime validation enforces the safe ID pattern and length limits.
- Add `pattern: '^[a-zA-Z0-9_-]+$'` constraints to `note_id` in `updateNoteSchema` and `deleteNoteSchema` in `src/handlers/tool-configs/universal/schemas/utility-schemas.ts` to enforce schema-level validation.
- The change is minimal and ensures IDs containing slashes or dot-dot segments are rejected before the Attio client path is constructed.

### Testing
- Ran `bun run typecheck`, which failed due to pre-existing environment/dependency/type resolution issues unrelated to this targeted change.
- Attempted lint commands (`bun run lint` and `bun run lint:file`) but the specific scripts were not available in this environment or returned errors.
- No unit/integration tests were executed for this patch in this environment due to the above limitations; the change is intentionally small and focused to minimize behavioral impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fda607d5b08325b23cb7680bc41aff)