### PR TITLE
Fix: Block universal list mutations in generic CRUD tools

### DIFF
--- a/src/handlers/tool-configs/universal/shared-handlers.ts
+++ b/src/handlers/tool-configs/universal/shared-handlers.ts
@@ -281,6 +281,11 @@ export async function handleUniversalDeleteNote(
 export async function handleUniversalCreate(
   params: UniversalCreateParams
 ): Promise<UniversalRecord> {
+  if (params.resource_type === UniversalResourceType.LISTS) {
+    throw new Error(
+      'resource_type "lists" is not supported by universal create-record. Use dedicated list tools for administrative list operations.'
+    );
+  }
   return UniversalCreateService.createRecord(params);
 }
 
@@ -290,6 +295,11 @@ export async function handleUniversalCreate(
 export async function handleUniversalUpdate(
   params: UniversalUpdateParams
 ): Promise<UniversalRecord> {
+  if (params.resource_type === UniversalResourceType.LISTS) {
+    throw new Error(
+      'resource_type "lists" is not supported by universal update-record. Use dedicated list tools for administrative list operations.'
+    );
+  }
   return UniversalUpdateService.updateRecord(params);
 }
 
@@ -299,6 +309,11 @@ export async function handleUniversalUpdate(
 export async function handleUniversalDelete(
   params: UniversalDeleteParams
 ): Promise<{ success: boolean; record_id: string }> {
+  if (params.resource_type === UniversalResourceType.LISTS) {
+    throw new Error(
+      'resource_type "lists" is not supported by universal delete-record. Use dedicated list tools for administrative list operations.'
+    );
+  }
   return UniversalDeleteService.deleteRecord(params);
 }
 

--- a/test/handlers/tool-configs/universal/shared-handlers-list-guards.test.ts
+++ b/test/handlers/tool-configs/universal/shared-handlers-list-guards.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  handleUniversalCreate,
+  handleUniversalDelete,
+  handleUniversalUpdate,
+} from '@/handlers/tool-configs/universal/shared-handlers.js';
+
+describe('universal list mutation guards', () => {
+  it('blocks lists in create-record', async () => {
+    await expect(
+      handleUniversalCreate({
+        resource_type: 'lists',
+        record_data: { name: 'x', parent_object: 'people' },
+      })
+    ).rejects.toThrow(/not supported by universal create-record/i);
+  });
+
+  it('blocks lists in update-record', async () => {
+    await expect(
+      handleUniversalUpdate({
+        resource_type: 'lists',
+        record_id: 'list_123',
+        record_data: { name: 'updated' },
+      })
+    ).rejects.toThrow(/not supported by universal update-record/i);
+  });
+
+  it('blocks lists in delete-record', async () => {
+    await expect(
+      handleUniversalDelete({
+        resource_type: 'lists',
+        record_id: 'list_123',
+      })
+    ).rejects.toThrow(/not supported by universal delete-record/i);
+  });
+});


### PR DESCRIPTION
### Motivation
- A recent change exposed `lists` via the universal resource enum which unintentionally allowed generic CRUD/batch tools to perform destructive list administration; this expands the destructive MCP surface.
- The intent of this change is to ensure list administration remains an explicit, dedicated capability rather than implicitly reachable through generic `create-record`, `update-record`, or `delete-record` handlers.

### Description
- Added explicit guards in `src/handlers/tool-configs/universal/shared-handlers.ts` to reject `resource_type === UniversalResourceType.LISTS` for `handleUniversalCreate`, `handleUniversalUpdate`, and `handleUniversalDelete`, with clear error messages directing callers to dedicated list tools.
- Kept universal read/search attribute paths for lists unchanged so non-destructive list reads remain available.
- Added a focused regression test `test/handlers/tool-configs/universal/shared-handlers-list-guards.test.ts` that asserts each guarded universal mutation path rejects `lists` with the expected error text.

### Testing
- Added the unit test file `test/handlers/tool-configs/universal/shared-handlers-list-guards.test.ts` targeting the guarded behavior. 
- Attempted to run `bun run test -- test/handlers/tool-configs/universal/shared-handlers-list-guards.test.ts`, but the `vitest` binary was not available in this environment so the tests could not be executed here. 
- Lint/test script invocations such as `bun run lint:file` and `bun run test:file` were attempted but the corresponding scripts are not present in this environment, so automated linting and unit execution did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fda950d3d88325a0c55fb93fa33070)