### PR TITLE
Fix: remove ATTIO_API_KEY exposure in performance workflow

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -144,7 +144,6 @@ jobs:
 
       - name: Run performance tests on PR branch
         env:
-          ATTIO_API_KEY: ${{ secrets.ATTIO_API_KEY }}
           NODE_ENV: test
         run: |
           bun run test test/performance/regression.test.ts > pr-performance.txt 2>&1 || true
@@ -162,7 +161,6 @@ jobs:
 
       - name: Run performance tests on base branch
         env:
-          ATTIO_API_KEY: ${{ secrets.ATTIO_API_KEY }}
           NODE_ENV: test
         run: |
           bun run test test/performance/regression.test.ts > base-performance.txt 2>&1 || true


### PR DESCRIPTION
### Motivation
- Prevent exposing `secrets.ATTIO_API_KEY` to code checked out from pull requests which could execute malicious changes and exfiltrate repository secrets.

### Description
- Removed the `ATTIO_API_KEY` environment variable from the PR-branch and base-branch performance test steps in `.github/workflows/performance-tests.yml` so the performance-comparison job runs without supplying secrets while preserving the existing test/build flow and `NODE_ENV: test`.

### Testing
- No automated tests were changed or required for this config-only fix; the change was validated by running `git diff -- .github/workflows/performance-tests.yml` and inspecting the workflow section with `nl -ba .github/workflows/performance-tests.yml | sed -n '136,176p'`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fdac49e6888325b9af6b91fc2c1629)