### PR TITLE
Refactor: Migrate alias imports batch 1

### DIFF
--- a/docs/plans/2026-06-09-001-refactor-alias-imports-batch-1-plan.md
+++ b/docs/plans/2026-06-09-001-refactor-alias-imports-batch-1-plan.md
@@ -1,0 +1,227 @@
+---
+title: 'refactor: Alias Imports Batch 1'
+type: refactor
+status: active
+date: 2026-06-09
+origin: https://github.com/kesslerio/attio-mcp-server/issues/745
+---
+
+# refactor: Alias Imports Batch 1
+
+## Summary
+
+Migrate the first high-impact batch of remaining deep relative imports to the existing TypeScript path aliases for issue #745. This batch targets current production hotspots and their paired service tests, without attempting the full repo-wide migration in one oversized PR.
+
+---
+
+## Problem Frame
+
+Issue #745 asks for the repo to finish moving away from deep relative imports such as `../../src/...` and `../utils/...` toward configured aliases like `@/`, `@services/*`, `@handlers/*`, and `@test/*`. The original Tier 1 files from the issue analysis are already migrated in this checkout, but a fresh scan still finds roughly 1,200 deep relative import lines across `src/` and `test/`. A bounded first batch should reduce the worst current hotspots while preserving reviewability.
+
+---
+
+## Requirements
+
+- R1. Replace deep relative import/export specifiers in the selected batch with existing path aliases.
+- R2. Preserve ESM `.js` suffixes where imports currently resolve TypeScript sources through NodeNext.
+- R3. Do not add new aliases unless an existing alias cannot express the import cleanly.
+- R4. Keep the change mechanical: no behavior changes, no refactors beyond import specifiers.
+- R5. Validate with Bun-based repo commands, not stale `npm`/`npx` commands from the old issue body.
+- R6. Keep the PR reviewable and leave the broader repo-wide migration to later #745 batches.
+
+---
+
+## Scope Boundaries
+
+- In scope: selected high-count production files and directly relevant paired service tests.
+- Out of scope: all remaining repo imports, E2E-wide migration, new path alias design, runtime behavior changes, dependency updates, issue label cleanup.
+- Out of scope: converting imports inside generated output, `dist/`, or historical test artifacts.
+
+### Deferred to Follow-Up Work
+
+- Additional #745 batches for `test/e2e/**`, `test/handlers/**`, lower-count production modules, and any directories still showing deep relative imports after this PR.
+- Optional issue hygiene update to remove stale `status:untriaged` from #745.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `tsconfig.json` already defines aliases for `@/*`, `@handlers/*`, `@services/*`, `@api/*`, `@config/*`, `@shared-types/*`, `@utils/*`, `@errors/*`, `@test-support/*`, and `@test/*`.
+- Current code already uses aliases with `.js` suffixes, for example `@/handlers/tool-configs/universal/shared-handlers.js`, `@services/UniversalSearchService.js`, and `@api/operations/query-parser.js`.
+- Fresh scan on 2026-06-09 found the original Tier 1 files already migrated: `src/handlers/tool-configs/universal/shared-handlers.ts`, `src/services/UniversalSearchService.ts`, `src/services/UniversalRetrievalService.ts`, and `src/handlers/tools/registry.ts`.
+- Current highest production hotspots include `src/objects/companies/basic.ts`, `src/objects/records/index.ts`, `src/objects/companies/notes.ts`, `src/services/UniversalDeleteService.ts`, `src/services/create/CreateValidation.ts`, and `src/objects/tasks.ts`.
+- Current highest paired service-test hotspots include `test/services/UniversalRetrievalService-validation.test.ts`, `test/services/UniversalRetrievalService-core-operations.test.ts`, `test/services/UniversalUpdateService-core-operations.test.ts`, `test/services/UniversalSearchService-companies-people-lists.test.ts`, and `test/services/UniversalDeleteService.test.ts`.
+
+### Institutional Learnings
+
+- Repository guidance requires Bun commands for validation.
+- Import alias migration must preserve `.js` suffixes because the project uses `moduleResolution: "NodeNext"`.
+- PR size guidance prefers focused batches; the full remaining migration is too large for one normal PR.
+
+---
+
+## Key Technical Decisions
+
+- **Use existing aliases only**: Use `@/` for source areas without dedicated aliases, such as `src/objects`, and use dedicated aliases where already present (`@services/*`, `@handlers/*`, `@utils/*`, `@api/*`, `@shared-types/*`, `@test/*`). This avoids tsconfig churn.
+- **Batch by current import count, not old issue count**: The old Tier 1 files are already migrated, so implementation should target the current scan results.
+- **Include paired service tests where low-risk**: Service tests import the same central modules and are good coverage for alias resolution. Avoid sweeping E2E files in this first PR because those are more likely to involve test-runner path and mock subtleties.
+- **Use mechanical replacement with verification**: Prefer AST- or resolver-aware reasoning where possible, but the implementation can use deterministic specifier replacement because only import paths change.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this PR migrate the entire repo? No. The current scan shows roughly 1,200 import lines, which would exceed normal PR-size guidance and muddy review.
+- Are the issue's original top four files still the right first target? No. They are already using aliases in this checkout.
+
+### Deferred to Implementation
+
+- Exact final file set can adjust slightly if a selected file has path shapes that are risky or if nearby paired tests are needed to keep validation green.
+
+---
+
+## Implementation Units
+
+### U1. Production Import Hotspots
+
+**Goal:** Convert deep relative imports in the highest-count production files to existing aliases while preserving behavior.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `src/objects/companies/basic.ts`
+- Modify: `src/objects/records/index.ts`
+- Modify: `src/objects/companies/notes.ts`
+- Modify: `src/services/UniversalDeleteService.ts`
+- Modify: `src/services/create/CreateValidation.ts`
+- Modify: `src/objects/tasks.ts`
+- Modify: other adjacent high-count production files only if needed to keep the batch coherent and reviewable
+
+**Approach:**
+
+- Replace relative imports targeting `src/` with aliases:
+  - `src/objects/**` targets use `@/objects/...`
+  - `src/services/**` targets use `@services/...`
+  - `src/handlers/**` targets use `@handlers/...`
+  - `src/api/**` targets use `@api/...`
+  - `src/utils/**` targets use `@utils/...`
+  - `src/types/**` targets use `@shared-types/...` or existing local convention when the file already prefers `@/types/...`
+- Preserve `.js` suffixes.
+- Avoid changing import ordering unless the formatter/linter requires it.
+
+**Patterns to follow:**
+
+- `src/services/UniversalSearchService.ts`
+- `src/services/UniversalRetrievalService.ts`
+- `src/handlers/tools/registry.ts`
+
+**Test scenarios:**
+
+- TypeScript resolves every changed production import.
+- Build/lint do not report unresolved modules.
+- No runtime code changes appear in the diff except import specifiers.
+
+**Verification:**
+
+- `bun run typecheck`
+- `bun run lint:src`
+
+### U2. Paired Service Test Imports
+
+**Goal:** Convert deep relative imports in the paired service tests that cover the migrated central services.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `test/services/UniversalRetrievalService-validation.test.ts`
+- Modify: `test/services/UniversalRetrievalService-core-operations.test.ts`
+- Modify: `test/services/UniversalUpdateService-core-operations.test.ts`
+- Modify: `test/services/UniversalSearchService-companies-people-lists.test.ts`
+- Modify: `test/services/UniversalDeleteService.test.ts`
+
+**Approach:**
+
+- Replace `../../src/...` test imports with `@/...` or dedicated source aliases.
+- Replace relative imports to test utilities with `@test/...` where appropriate.
+- Check `vi.mock()` path strings carefully; update only when the mocked module path should match the new alias and Vitest alias resolution already supports it.
+
+**Patterns to follow:**
+
+- `test/services/openai-compatibility.service.test.ts`
+- `test/integration/universal-tools-lists.test.ts`
+- `test/handlers/tools/registry-mode.test.ts`
+
+**Test scenarios:**
+
+- Tests still import the same production modules.
+- Vitest mocks still target the intended modules.
+- The selected service tests pass or fail only for pre-existing unrelated reasons documented in verification output.
+
+**Verification:**
+
+- `bun run test:offline:run -- test/services/UniversalRetrievalService-validation.test.ts`
+- `bun run test:offline:run -- test/services/UniversalRetrievalService-core-operations.test.ts`
+- `bun run test:offline:run -- test/services/UniversalUpdateService-core-operations.test.ts`
+- `bun run test:offline:run -- test/services/UniversalSearchService-companies-people-lists.test.ts`
+- `bun run test:offline:run -- test/services/UniversalDeleteService.test.ts`
+
+### U3. Batch-Level Validation and Residual Accounting
+
+**Goal:** Prove the first alias batch is coherent and leave a clear accounting of remaining issue #745 work.
+
+**Requirements:** R5, R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: no source files expected beyond U1/U2
+- Optional Modify: `docs/plans/2026-06-09-001-refactor-alias-imports-batch-1-plan.md` status only at shipping time if the workflow marks it complete
+
+**Approach:**
+
+- Run a fresh import scan after edits to show the selected files no longer contain deep relative import/export specifiers.
+- Run targeted validation first, then broader `bun run typecheck`.
+- If full offline tests are cheap enough in the current environment, run `bun run test:offline:run`; otherwise document why targeted tests were used.
+
+**Test scenarios:**
+
+- Fresh scan reports zero deep relative import lines in changed files.
+- Typecheck passes after alias conversion.
+- Targeted service tests pass.
+
+**Verification:**
+
+- `rg -n "^\\s*(import|export)\\s+(type\\s+)?(.+?\\s+from\\s+)?['\\\"]\\.\\./|import\\(['\\\"]\\.\\./" <changed-files>`
+- `bun run typecheck`
+- Targeted test commands from U2
+
+---
+
+## Risks and Mitigations
+
+- **Alias mismatch risk:** Use aliases already configured in `tsconfig.json`; verify with `bun run typecheck`.
+- **Vitest mock identity risk:** Be careful with `vi.mock()` path strings; run the affected tests directly.
+- **Oversized PR risk:** Keep this to batch 1 and defer the rest of issue #745.
+- **False progress risk:** The old issue scan is stale; rely on fresh import scans before and after changes.
+
+---
+
+## Verification Checklist
+
+- [ ] Changed production files use aliases instead of deep relative imports.
+- [ ] Changed service tests use aliases where practical and still target the same modules.
+- [ ] Fresh scan reports no deep relative imports in changed files.
+- [ ] `bun run typecheck` passes.
+- [ ] Targeted service tests pass or any unrelated pre-existing failures are documented.
+- [ ] PR body references issue #745 and states this is batch 1, not the full migration.

--- a/src/objects/companies/basic.ts
+++ b/src/objects/companies/basic.ts
@@ -1,30 +1,30 @@
 /**
  * Basic CRUD operations for companies
  */
-import { getLazyAttioClient } from '../../api/lazy-client.js';
-import { getObjectDetails, listObjects } from '../../api/operations/index.js';
-import { ResourceType, Company, RecordAttributes } from '../../types/attio.js';
-import { CompanyUpdateInput } from '../../types/company-types.js';
+import { getLazyAttioClient } from '@api/lazy-client.js';
+import { getObjectDetails, listObjects } from '@api/operations/index.js';
+import { ResourceType, Company, RecordAttributes } from '@shared-types/attio.js';
+import { CompanyUpdateInput } from '@shared-types/company-types.js';
 import { CompanyAttributes } from './types.js';
-import { CompanyValidator } from '../../validators/company-validator.js';
+import { CompanyValidator } from '@/validators/company-validator.js';
 import {
   CompanyOperationError,
   InvalidCompanyDataError,
-} from '../../errors/company-errors.js';
+} from '@errors/company-errors.js';
 import {
   createObjectWithDynamicFields,
   updateObjectWithDynamicFields,
   updateObjectAttributeWithDynamicFields,
   deleteObjectWithValidation,
-} from '../base-operations.js';
-import { findPersonReference } from '../../utils/person-lookup.js';
+} from '@/objects/base-operations.js';
+import { findPersonReference } from '@utils/person-lookup.js';
 import {
   setMockCompany,
   createMockCompanyWithApiStructure,
   updateMockCompany,
   getMockCompany,
-} from '../../utils/mock-state.js';
-import { CompanyFieldValue } from '../../types/tool-types.js';
+} from '@utils/mock-state.js';
+import { CompanyFieldValue } from '@shared-types/tool-types.js';
 
 /**
  * Lists companies sorted by most recent interaction
@@ -78,7 +78,7 @@ export async function getCompanyDetails(
         process.env.NODE_ENV === 'development' ||
         process.env.E2E_MODE === 'true'
       ) {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.basic', 'getCompanyDetails').debug(
           'Returning company from shared mock state',
           {
@@ -100,7 +100,7 @@ export async function getCompanyDetails(
       process.env.NODE_ENV === 'development' ||
       process.env.E2E_MODE === 'true'
     ) {
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('companies.basic', 'getCompanyDetails').debug(
         'Returning static mock company (not found in shared state)',
         {
@@ -217,7 +217,7 @@ export async function createCompany(
     process.env.NODE_ENV === 'development' ||
     process.env.E2E_MODE === 'true'
   ) {
-    const { createScopedLogger } = await import('../../utils/logger.js');
+    const { createScopedLogger } = await import('@utils/logger.js');
     createScopedLogger('companies.basic', 'createCompany').debug(
       'Input attributes',
       { attributes }
@@ -236,7 +236,7 @@ export async function createCompany(
       process.env.NODE_ENV === 'development' ||
       process.env.E2E_MODE === 'true'
     ) {
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('companies.basic', 'createCompany').debug(
         'Result from createObjectWithDynamicFields',
         {
@@ -263,7 +263,7 @@ export async function createCompany(
         process.env.NODE_ENV === 'development' ||
         process.env.E2E_MODE === 'true'
       ) {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.basic', 'createCompany').warn(
           'Invalid ID structure detected, attempting fallback',
           {
@@ -303,7 +303,7 @@ export async function createCompany(
             process.env.E2E_MODE === 'true'
           ) {
             const { createScopedLogger } =
-              await import('../../utils/logger.js');
+              await import('@utils/logger.js');
             createScopedLogger('companies.basic', 'createCompany').debug(
               'Query fallback response',
               {
@@ -328,7 +328,7 @@ export async function createCompany(
               process.env.E2E_MODE === 'true'
             ) {
               const { createScopedLogger } =
-                await import('../../utils/logger.js');
+                await import('@utils/logger.js');
               createScopedLogger('companies.basic', 'createCompany').info(
                 'Found existing company via query fallback',
                 { foundCompany }
@@ -366,7 +366,7 @@ export async function createCompany(
               process.env.E2E_MODE === 'true'
             ) {
               const { createScopedLogger } =
-                await import('../../utils/logger.js');
+                await import('@utils/logger.js');
               createScopedLogger('companies.basic', 'createCompany').debug(
                 'Created mock company result for testing',
                 { result }
@@ -379,7 +379,7 @@ export async function createCompany(
             process.env.E2E_MODE === 'true'
           ) {
             const { createScopedLogger } =
-              await import('../../utils/logger.js');
+              await import('@utils/logger.js');
             createScopedLogger('companies.basic', 'createCompany').error(
               'Query fallback failed during company creation',
               queryError instanceof Error ? queryError : undefined
@@ -415,7 +415,7 @@ export async function createCompany(
               process.env.E2E_MODE === 'true'
             ) {
               const { createScopedLogger } =
-                await import('../../utils/logger.js');
+                await import('@utils/logger.js');
               createScopedLogger('companies.basic', 'createCompany').warn(
                 'Created emergency mock company result after query failure',
                 { result }
@@ -452,7 +452,7 @@ export async function createCompany(
           process.env.NODE_ENV === 'development' ||
           process.env.E2E_MODE === 'true'
         ) {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.basic', 'createCompany').warn(
             'Created mock company result without name for testing',
             { result }
@@ -484,7 +484,7 @@ export async function createCompany(
         process.env.NODE_ENV === 'development' ||
         process.env.E2E_MODE === 'true'
       ) {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.basic', 'createCompany').error(
           'CRITICAL: Result still missing ID structure before return',
           undefined,
@@ -514,7 +514,7 @@ export async function createCompany(
           process.env.NODE_ENV === 'development' ||
           process.env.E2E_MODE === 'true'
         ) {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.basic', 'createCompany').warn(
             'EMERGENCY: Created last-resort mock ID structure',
             { result }
@@ -533,7 +533,7 @@ export async function createCompany(
       process.env.NODE_ENV === 'development' ||
       process.env.E2E_MODE === 'true'
     ) {
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('companies.basic', 'createCompany').debug(
         'Returning valid company record',
         {
@@ -550,7 +550,7 @@ export async function createCompany(
       process.env.NODE_ENV === 'development' ||
       process.env.E2E_MODE === 'true'
     ) {
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       const logger = createScopedLogger('companies.basic', 'createCompany');
       logger.error('Error caught', error);
       logger.debug('Error type', { type: typeof error });
@@ -620,7 +620,7 @@ export async function updateCompany(
           process.env.NODE_ENV === 'development' ||
           process.env.E2E_MODE === 'true'
         ) {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.basic', 'updateCompany').debug(
             'Updated mock company in shared state',
             {
@@ -648,7 +648,7 @@ export async function updateCompany(
           process.env.NODE_ENV === 'development' ||
           process.env.E2E_MODE === 'true'
         ) {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.basic', 'updateCompany').debug(
             'Created new mock company in shared state (not found)',
             { mockUpdatedCompany }

--- a/src/objects/companies/basic.ts
+++ b/src/objects/companies/basic.ts
@@ -3,7 +3,11 @@
  */
 import { getLazyAttioClient } from '@api/lazy-client.js';
 import { getObjectDetails, listObjects } from '@api/operations/index.js';
-import { ResourceType, Company, RecordAttributes } from '@shared-types/attio.js';
+import {
+  ResourceType,
+  Company,
+  RecordAttributes,
+} from '@shared-types/attio.js';
 import { CompanyUpdateInput } from '@shared-types/company-types.js';
 import { CompanyAttributes } from './types.js';
 import { CompanyValidator } from '@/validators/company-validator.js';
@@ -286,7 +290,7 @@ export async function createCompany(
           attributes.name !== null &&
           'value' in (attributes.name as Record<string, unknown>)
             ? (attributes.name as { value: string }).value
-            : (attributes.name ?? '');
+            : attributes.name ?? '';
 
         try {
           const api = getLazyAttioClient();
@@ -302,8 +306,7 @@ export async function createCompany(
             process.env.NODE_ENV === 'development' ||
             process.env.E2E_MODE === 'true'
           ) {
-            const { createScopedLogger } =
-              await import('@utils/logger.js');
+            const { createScopedLogger } = await import('@utils/logger.js');
             createScopedLogger('companies.basic', 'createCompany').debug(
               'Query fallback response',
               {
@@ -327,8 +330,7 @@ export async function createCompany(
               process.env.NODE_ENV === 'development' ||
               process.env.E2E_MODE === 'true'
             ) {
-              const { createScopedLogger } =
-                await import('@utils/logger.js');
+              const { createScopedLogger } = await import('@utils/logger.js');
               createScopedLogger('companies.basic', 'createCompany').info(
                 'Found existing company via query fallback',
                 { foundCompany }
@@ -341,7 +343,9 @@ export async function createCompany(
           ) {
             // For testing: Create a mock company result when API returns empty
             // This allows integration tests to proceed when Attio API is not working properly
-            const mockCompanyId = `comp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+            const mockCompanyId = `comp_${Date.now()}_${Math.random()
+              .toString(36)
+              .substr(2, 9)}`;
 
             // Create mock with proper Attio API structure
             const mockAttributes = {
@@ -365,8 +369,7 @@ export async function createCompany(
               process.env.NODE_ENV === 'development' ||
               process.env.E2E_MODE === 'true'
             ) {
-              const { createScopedLogger } =
-                await import('@utils/logger.js');
+              const { createScopedLogger } = await import('@utils/logger.js');
               createScopedLogger('companies.basic', 'createCompany').debug(
                 'Created mock company result for testing',
                 { result }
@@ -378,8 +381,7 @@ export async function createCompany(
             process.env.NODE_ENV === 'development' ||
             process.env.E2E_MODE === 'true'
           ) {
-            const { createScopedLogger } =
-              await import('@utils/logger.js');
+            const { createScopedLogger } = await import('@utils/logger.js');
             createScopedLogger('companies.basic', 'createCompany').error(
               'Query fallback failed during company creation',
               queryError instanceof Error ? queryError : undefined
@@ -391,7 +393,9 @@ export async function createCompany(
               process.env.NODE_ENV === 'test') &&
             nameValue
           ) {
-            const mockCompanyId = `comp_fallback_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+            const mockCompanyId = `comp_fallback_${Date.now()}_${Math.random()
+              .toString(36)
+              .substr(2, 9)}`;
 
             const mockAttributes = {
               name: nameValue,
@@ -414,8 +418,7 @@ export async function createCompany(
               process.env.NODE_ENV === 'development' ||
               process.env.E2E_MODE === 'true'
             ) {
-              const { createScopedLogger } =
-                await import('@utils/logger.js');
+              const { createScopedLogger } = await import('@utils/logger.js');
               createScopedLogger('companies.basic', 'createCompany').warn(
                 'Created emergency mock company result after query failure',
                 { result }
@@ -428,7 +431,9 @@ export async function createCompany(
         process.env.NODE_ENV === 'test'
       ) {
         // If no name is provided but we're in test mode, create a mock anyway
-        const mockCompanyId = `comp_noname_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        const mockCompanyId = `comp_noname_${Date.now()}_${Math.random()
+          .toString(36)
+          .substr(2, 9)}`;
 
         const mockAttributes = {
           name: 'Test Company (No Name Provided)',
@@ -465,7 +470,9 @@ export async function createCompany(
         throw new CompanyOperationError(
           'create',
           undefined,
-          `API returned invalid company record without proper ID structure. Response: ${JSON.stringify(result)}`
+          `API returned invalid company record without proper ID structure. Response: ${JSON.stringify(
+            result
+          )}`
         );
       }
     }
@@ -474,7 +481,9 @@ export async function createCompany(
       throw new CompanyOperationError(
         'create',
         undefined,
-        `API returned invalid company record without values object. Response: ${JSON.stringify(result)}`
+        `API returned invalid company record without values object. Response: ${JSON.stringify(
+          result
+        )}`
       );
     }
 
@@ -500,7 +509,9 @@ export async function createCompany(
 
       // Last resort: Create a mock structure if we're in test mode
       if (process.env.E2E_MODE === 'true' || process.env.NODE_ENV === 'test') {
-        const emergencyMockId = `comp_emergency_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        const emergencyMockId = `comp_emergency_${Date.now()}_${Math.random()
+          .toString(36)
+          .substr(2, 9)}`;
         result = {
           ...result,
           id: {
@@ -524,7 +535,9 @@ export async function createCompany(
         throw new CompanyOperationError(
           'create',
           undefined,
-          `CRITICAL: Company record still missing ID structure after all fallback attempts. Response: ${JSON.stringify(result)}`
+          `CRITICAL: Company record still missing ID structure after all fallback attempts. Response: ${JSON.stringify(
+            result
+          )}`
         );
       }
     }

--- a/src/objects/companies/basic.ts
+++ b/src/objects/companies/basic.ts
@@ -290,7 +290,7 @@ export async function createCompany(
           attributes.name !== null &&
           'value' in (attributes.name as Record<string, unknown>)
             ? (attributes.name as { value: string }).value
-            : attributes.name ?? '';
+            : (attributes.name ?? '');
 
         try {
           const api = getLazyAttioClient();

--- a/src/objects/companies/notes.ts
+++ b/src/objects/companies/notes.ts
@@ -1,12 +1,12 @@
 /**
  * Note operations for companies
  */
-import { getLazyAttioClient } from '../../api/lazy-client.js';
+import { getLazyAttioClient } from '@api/lazy-client.js';
 import {
   getObjectNotes,
   createObjectNote,
-} from '../../api/operations/index.js';
-import { ResourceType, AttioNote } from '../../types/attio.js';
+} from '@api/operations/index.js';
+import { ResourceType, AttioNote } from '@shared-types/attio.js';
 
 interface HttpErrorLike {
   response?: {
@@ -76,7 +76,7 @@ export async function getCompanyNotes(
       }
 
       if (process.env.NODE_ENV === 'development') {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.notes', 'getCompanyNotes').debug(
           'Extracted company ID from URI',
           { companyId, companyIdOrUri }
@@ -87,7 +87,7 @@ export async function getCompanyNotes(
       companyId = companyIdOrUri;
 
       if (process.env.NODE_ENV === 'development') {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.notes', 'getCompanyNotes').debug(
           'Using direct company ID',
           { companyId }
@@ -110,7 +110,7 @@ export async function getCompanyNotes(
       );
     } catch (error: unknown) {
       if (process.env.NODE_ENV === 'development') {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.notes', 'getCompanyNotes').error(
           'Unified operation failed',
           error instanceof Error ? error : new Error(String(error))
@@ -123,7 +123,7 @@ export async function getCompanyNotes(
         const path = `/notes?limit=${limit}&offset=${offset}&parent_object=companies&parent_record_id=${companyId}`;
 
         if (process.env.NODE_ENV === 'development') {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.notes', 'getCompanyNotes').warn(
             'Trying direct API call',
             { path }
@@ -137,7 +137,7 @@ export async function getCompanyNotes(
         return notes;
       } catch (directError: unknown) {
         if (process.env.NODE_ENV === 'development') {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.notes', 'getCompanyNotes').error(
             'All attempts failed',
             new Error('All attempts failed'),
@@ -220,7 +220,7 @@ export async function createCompanyNote(
       }
 
       if (process.env.NODE_ENV === 'development') {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.notes', 'createCompanyNote').debug(
           'Extracted company ID from URI',
           { companyId, companyIdOrUri }
@@ -231,7 +231,7 @@ export async function createCompanyNote(
       companyId = companyIdOrUri;
 
       if (process.env.NODE_ENV === 'development') {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.notes', 'createCompanyNote').debug(
           'Using direct company ID',
           { companyId }
@@ -254,7 +254,7 @@ export async function createCompanyNote(
       );
     } catch (error: unknown) {
       if (process.env.NODE_ENV === 'development') {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('companies.notes', 'createCompanyNote').error(
           'Unified operation failed',
           error instanceof Error ? error : new Error(String(error))
@@ -267,7 +267,7 @@ export async function createCompanyNote(
         const path = 'notes';
 
         if (process.env.NODE_ENV === 'development') {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.notes', 'createCompanyNote').warn(
             'Trying direct API call',
             { path }
@@ -290,7 +290,7 @@ export async function createCompanyNote(
         return createdNote;
       } catch (directError: unknown) {
         if (process.env.NODE_ENV === 'development') {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('companies.notes', 'createCompanyNote').error(
             'All attempts failed',
             new Error('All attempts failed'),

--- a/src/objects/companies/notes.ts
+++ b/src/objects/companies/notes.ts
@@ -2,10 +2,7 @@
  * Note operations for companies
  */
 import { getLazyAttioClient } from '@api/lazy-client.js';
-import {
-  getObjectNotes,
-  createObjectNote,
-} from '@api/operations/index.js';
+import { getObjectNotes, createObjectNote } from '@api/operations/index.js';
 import { ResourceType, AttioNote } from '@shared-types/attio.js';
 
 interface HttpErrorLike {

--- a/src/objects/records/index.ts
+++ b/src/objects/records/index.ts
@@ -1,7 +1,7 @@
 /**
  * Record-related functionality
  */
-import { getLazyAttioClient } from '../../api/lazy-client.js';
+import { getLazyAttioClient } from '@api/lazy-client.js';
 import {
   createRecord,
   getRecord,
@@ -12,18 +12,18 @@ import {
   batchUpdateRecords,
   BatchConfig,
   BatchResponse,
-} from '../../api/operations/index.js';
+} from '@api/operations/index.js';
 import {
   ResourceType,
   AttioRecord,
   RecordAttributes,
   RecordListParams,
-} from '../../types/attio.js';
+} from '@shared-types/attio.js';
 import {
   getErrorStatus,
   getErrorMessage,
   HttpErrorLike,
-} from '../../types/error-interfaces.js';
+} from '@shared-types/error-interfaces.js';
 
 /**
  * Creates a new record for a specific object type
@@ -54,7 +54,7 @@ export async function createObjectRecord<T extends AttioRecord>(
     process.env.NODE_ENV === 'development' ||
     process.env.E2E_MODE === 'true'
   ) {
-    const { createScopedLogger } = await import('../../utils/logger.js');
+    const { createScopedLogger } = await import('@utils/logger.js');
     const log = createScopedLogger('objects.records', 'createObjectRecord');
     log.info('Creating record', { objectSlug: normalizedSlug });
     log.debug('Attributes', { attributes });
@@ -66,7 +66,7 @@ export async function createObjectRecord<T extends AttioRecord>(
       process.env.NODE_ENV === 'development' ||
       process.env.E2E_MODE === 'true'
     ) {
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.records', 'createObjectRecord').info(
         'Calling createRecord with',
         { objectSlug: normalizedSlug, objectId, attributes }
@@ -83,7 +83,7 @@ export async function createObjectRecord<T extends AttioRecord>(
       process.env.NODE_ENV === 'development' ||
       process.env.E2E_MODE === 'true'
     ) {
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.records', 'createObjectRecord').info(
         'createRecord returned',
         {
@@ -118,7 +118,7 @@ export async function createObjectRecord<T extends AttioRecord>(
         process.env.NODE_ENV === 'development' ||
         process.env.E2E_MODE === 'true'
       ) {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('objects.records', 'createObjectRecord').warn(
           'Empty result for company creation, trying query fallback',
           { nameValue }
@@ -140,7 +140,7 @@ export async function createObjectRecord<T extends AttioRecord>(
           process.env.NODE_ENV === 'development' ||
           process.env.E2E_MODE === 'true'
         ) {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('objects.records', 'createObjectRecord').debug(
             'Query fallback response',
             {
@@ -165,7 +165,7 @@ export async function createObjectRecord<T extends AttioRecord>(
             process.env.E2E_MODE === 'true'
           ) {
             const { createScopedLogger } =
-              await import('../../utils/logger.js');
+              await import('@utils/logger.js');
             createScopedLogger('objects.records', 'createObjectRecord').info(
               'Found existing company via query fallback',
               { foundRecord }
@@ -178,7 +178,7 @@ export async function createObjectRecord<T extends AttioRecord>(
           process.env.NODE_ENV === 'development' ||
           process.env.E2E_MODE === 'true'
         ) {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('objects.records', 'createObjectRecord').warn(
             'Query fallback failed',
             {
@@ -199,7 +199,7 @@ export async function createObjectRecord<T extends AttioRecord>(
       process.env.NODE_ENV === 'development' ||
       process.env.E2E_MODE === 'true'
     ) {
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.records', 'createObjectRecord').warn(
         'Primary createRecord failed, trying fallback',
         { error: error instanceof Error ? error.message : String(error) }
@@ -219,7 +219,7 @@ export async function createObjectRecord<T extends AttioRecord>(
       const path = `/objects/${objectId || objectSlug}/records`;
 
       // ENHANCED DEBUG: Add path builder logging as requested by user
-      const { createScopedLogger } = await import('../../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.records', 'createObjectRecord').debug(
         'POST',
         { path, sampleKeys: Object.keys(attributes || {}) }
@@ -236,7 +236,7 @@ export async function createObjectRecord<T extends AttioRecord>(
         process.env.NODE_ENV === 'development' ||
         process.env.E2E_MODE === 'true'
       ) {
-        const { createScopedLogger } = await import('../../utils/logger.js');
+        const { createScopedLogger } = await import('@utils/logger.js');
         createScopedLogger('objects.records', 'createObjectRecord').debug(
           'Fallback request',
           { path, payloadSize: JSON.stringify(body).length }
@@ -250,7 +250,7 @@ export async function createObjectRecord<T extends AttioRecord>(
           process.env.NODE_ENV === 'development' ||
           process.env.E2E_MODE === 'true'
         ) {
-          const { createScopedLogger } = await import('../../utils/logger.js');
+          const { createScopedLogger } = await import('@utils/logger.js');
           createScopedLogger('objects.records', 'createObjectRecord').debug(
             'Fallback response structure',
             {

--- a/src/objects/records/index.ts
+++ b/src/objects/records/index.ts
@@ -164,8 +164,7 @@ export async function createObjectRecord<T extends AttioRecord>(
             process.env.NODE_ENV === 'development' ||
             process.env.E2E_MODE === 'true'
           ) {
-            const { createScopedLogger } =
-              await import('@utils/logger.js');
+            const { createScopedLogger } = await import('@utils/logger.js');
             createScopedLogger('objects.records', 'createObjectRecord').info(
               'Found existing company via query fallback',
               { foundRecord }
@@ -290,7 +289,9 @@ export async function createObjectRecord<T extends AttioRecord>(
             !looksLikeCreatedRecord)
         ) {
           throw new Error(
-            `Create operation returned empty or invalid response. Response structure: ${JSON.stringify(response?.data)}`
+            `Create operation returned empty or invalid response. Response structure: ${JSON.stringify(
+              response?.data
+            )}`
           );
         }
 
@@ -319,7 +320,10 @@ export async function createObjectRecord<T extends AttioRecord>(
             body.data.values?.domain &&
             typeof body.data.values.domain === 'string'
           ) {
-            body.data.values.domain = `${body.data.values.domain.replace(/\.$/, '')}-${suffix}`;
+            body.data.values.domain = `${body.data.values.domain.replace(
+              /\.$/,
+              ''
+            )}-${suffix}`;
           } else if (
             Array.isArray(body.data.values?.domains) &&
             body.data.values.domains[0] &&

--- a/src/objects/tasks.ts
+++ b/src/objects/tasks.ts
@@ -5,16 +5,16 @@ import {
   updateTask as apiUpdate,
   linkRecordToTask as apiLink,
   unlinkRecordFromTask as apiUnlink,
-} from '../api/operations/index.js';
-import { AttioTask } from '../types/attio.js';
-import { isValidId } from '../utils/validation.js';
-import { shouldUseMockData } from '../services/create/index.js';
-import { deleteTask as apiDelete } from '../api/operations/index.js';
+} from '@api/operations/index.js';
+import { AttioTask } from '@shared-types/attio.js';
+import { isValidId } from '@utils/validation.js';
+import { shouldUseMockData } from '@services/create/index.js';
+import { deleteTask as apiDelete } from '@api/operations/index.js';
 import {
   getErrorStatus,
   getErrorMessage,
   getErrorCode,
-} from '../types/error-interfaces.js';
+} from '@shared-types/error-interfaces.js';
 
 // Input validation helper function is now imported from ../utils/validation.js for consistency
 
@@ -51,7 +51,7 @@ export async function createTask(
       process.env.NODE_ENV === 'development' ||
       process.env.VERBOSE_TESTS === 'true'
     ) {
-      const { createScopedLogger } = await import('../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.tasks', 'createTask').debug(
         'Using mock data for task creation'
       );
@@ -131,7 +131,7 @@ export async function updateTask(
       process.env.NODE_ENV === 'development' ||
       process.env.VERBOSE_TESTS === 'true'
     ) {
-      const { createScopedLogger } = await import('../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.tasks', 'updateTask').debug(
         'Using mock data for task update'
       );
@@ -188,7 +188,7 @@ export async function deleteTask(taskId: string): Promise<boolean> {
       process.env.NODE_ENV === 'development' ||
       process.env.VERBOSE_TESTS === 'true'
     ) {
-      const { createScopedLogger } = await import('../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.tasks', 'deleteTask').debug(
         'Using mock data for task deletion'
       );
@@ -232,7 +232,7 @@ export async function linkRecordToTask(
       process.env.NODE_ENV === 'development' ||
       process.env.VERBOSE_TESTS === 'true'
     ) {
-      const { createScopedLogger } = await import('../utils/logger.js');
+      const { createScopedLogger } = await import('@utils/logger.js');
       createScopedLogger('objects.tasks', 'linkTaskRecord').debug(
         'Using mock data for task-record linking'
       );

--- a/src/services/UniversalDeleteService.ts
+++ b/src/services/UniversalDeleteService.ts
@@ -5,10 +5,10 @@
  * Provides universal delete functionality across all resource types.
  */
 
-import { UniversalResourceType } from '../handlers/tool-configs/universal/types.js';
-import type { UniversalDeleteParams } from '../handlers/tool-configs/universal/types.js';
-import { isValidId } from '../utils/validation.js';
-import { debug } from '../utils/logger.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import type { UniversalDeleteParams } from '@handlers/tool-configs/universal/types.js';
+import { isValidId } from '@utils/validation.js';
+import { debug } from '@utils/logger.js';
 
 // Import shared type definitions and utilities
 import {
@@ -16,17 +16,17 @@ import {
   createNotFoundError,
   type TaskError,
   type ApiErrorWithResponse,
-} from '../types/universal-service-types.js';
+} from '@shared-types/universal-service-types.js';
 
 // Import delete functions for each resource type
-import { deleteCompany } from '../objects/companies/index.js';
-import { deletePerson } from '../objects/people-write.js';
-import { deleteList } from '../objects/lists.js';
-import { deleteObjectRecord } from '../objects/records/index.js';
-import { deleteTask, getTask } from '../objects/tasks.js';
-import { deleteNote } from '../objects/notes.js';
+import { deleteCompany } from '@/objects/companies/index.js';
+import { deletePerson } from '@/objects/people-write.js';
+import { deleteList } from '@/objects/lists.js';
+import { deleteObjectRecord } from '@/objects/records/index.js';
+import { deleteTask, getTask } from '@/objects/tasks.js';
+import { deleteNote } from '@/objects/notes.js';
 import { shouldUseMockData } from './create/index.js';
-import { isConfiguredCustomObjectResourceType } from '../utils/resource-type-detection.js';
+import { isConfiguredCustomObjectResourceType } from '@utils/resource-type-detection.js';
 
 /**
  * UniversalDeleteService provides centralized record deletion functionality

--- a/src/services/create/CreateValidation.ts
+++ b/src/services/create/CreateValidation.ts
@@ -1,12 +1,12 @@
-import type { AttioRecord } from '../../types/attio.js';
-import { UniversalResourceType } from '../../handlers/tool-configs/universal/types.js';
-import { shouldUseMockData } from '../create/index.js';
-import { UniversalUtilityService } from '../UniversalUtilityService.js';
-import { getObjectRecord } from '../../objects/records/index.js';
-import { getTask } from '../../objects/tasks.js';
-import { getCompanyDetails } from '../../objects/companies/index.js';
-import { getPersonDetails } from '../../objects/people/basic.js';
-import { getListDetails } from '../../objects/lists.js';
+import type { AttioRecord } from '@shared-types/attio.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { shouldUseMockData } from '@services/create/index.js';
+import { UniversalUtilityService } from '@services/UniversalUtilityService.js';
+import { getObjectRecord } from '@/objects/records/index.js';
+import { getTask } from '@/objects/tasks.js';
+import { getCompanyDetails } from '@/objects/companies/index.js';
+import { getPersonDetails } from '@/objects/people/basic.js';
+import { getListDetails } from '@/objects/lists.js';
 
 interface ListDetailsResponse {
   id: {

--- a/test/services/UniversalDeleteService.test.ts
+++ b/test/services/UniversalDeleteService.test.ts
@@ -6,35 +6,35 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { UniversalDeleteService } from '../../src/services/UniversalDeleteService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
+import { UniversalDeleteService } from '@services/UniversalDeleteService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
 
 // Mock the dependencies
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   deleteCompany: vi.fn(),
 }));
 
-vi.mock('../../src/objects/people-write.js', () => ({
+vi.mock('@/objects/people-write.js', () => ({
   deletePerson: vi.fn(),
 }));
 
-vi.mock('../../src/objects/lists.js', () => ({
+vi.mock('@/objects/lists.js', () => ({
   deleteList: vi.fn(),
 }));
 
-vi.mock('../../src/objects/records/index.js', () => ({
+vi.mock('@/objects/records/index.js', () => ({
   deleteObjectRecord: vi.fn(),
 }));
 
-vi.mock('../../src/objects/tasks.js', () => ({
+vi.mock('@/objects/tasks.js', () => ({
   deleteTask: vi.fn(),
 }));
 
-vi.mock('../../src/utils/validation.js', () => ({
+vi.mock('@utils/validation.js', () => ({
   isValidId: vi.fn(),
 }));
 
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@services/create/index.js', () => ({
   shouldUseMockData: vi.fn(),
 }));
 
@@ -50,13 +50,13 @@ vi.mock('@/utils/config-loader.js', () => ({
   })),
 }));
 
-import { deleteCompany } from '../../src/objects/companies/index.js';
-import { deletePerson } from '../../src/objects/people-write.js';
-import { deleteList } from '../../src/objects/lists.js';
-import { deleteObjectRecord } from '../../src/objects/records/index.js';
-import { deleteTask } from '../../src/objects/tasks.js';
-import { isValidId } from '../../src/utils/validation.js';
-import { shouldUseMockData } from '../../src/services/create/index.js';
+import { deleteCompany } from '@/objects/companies/index.js';
+import { deletePerson } from '@/objects/people-write.js';
+import { deleteList } from '@/objects/lists.js';
+import { deleteObjectRecord } from '@/objects/records/index.js';
+import { deleteTask } from '@/objects/tasks.js';
+import { isValidId } from '@utils/validation.js';
+import { shouldUseMockData } from '@services/create/index.js';
 
 describe('UniversalDeleteService', () => {
   beforeEach(() => {

--- a/test/services/UniversalRetrievalService-core-operations.test.ts
+++ b/test/services/UniversalRetrievalService-core-operations.test.ts
@@ -3,16 +3,16 @@
  */
 // Local mocks (must match specifiers used below)
 import { vi } from 'vitest';
-vi.mock('../../src/services/ValidationService.js', () => ({
+vi.mock('@services/ValidationService.js', () => ({
   ValidationService: { validateUUID: vi.fn() },
 }));
-vi.mock('../../src/services/CachingService.js', () => ({
+vi.mock('@services/CachingService.js', () => ({
   CachingService: { isCached404: vi.fn(), cache404Response: vi.fn() },
 }));
-vi.mock('../../src/services/UniversalUtilityService.js', () => ({
+vi.mock('@services/UniversalUtilityService.js', () => ({
   UniversalUtilityService: { convertTaskToRecord: vi.fn() },
 }));
-vi.mock('../../src/middleware/performance-enhanced.js', () => ({
+vi.mock('@/middleware/performance-enhanced.js', () => ({
   enhancedPerformanceTracker: {
     startOperation: vi.fn(() => 'perf-123'),
     markTiming: vi.fn(),
@@ -21,13 +21,13 @@ vi.mock('../../src/middleware/performance-enhanced.js', () => ({
     endOperation: vi.fn(),
   },
 }));
-vi.mock('../../src/utils/validation/uuid-validation.js', () => ({
+vi.mock('@utils/validation/uuid-validation.js', () => ({
   createRecordNotFoundError: vi.fn(
     (recordId: string, resourceType: string) =>
       new Error(`${resourceType} record not found: ${recordId}`)
   ),
 }));
-vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
+vi.mock('@/errors/enhanced-api-errors.js', () => ({
   ErrorEnhancer: {
     autoEnhance: vi.fn((e) => e),
     getErrorMessage: vi.fn((e) => (e as any).message),
@@ -53,19 +53,19 @@ vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
     }
   },
 }));
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   getCompanyDetails: vi.fn(),
 }));
-vi.mock('../../src/objects/people/index.js', () => ({
+vi.mock('@/objects/people/index.js', () => ({
   getPersonDetails: vi.fn(),
 }));
 vi.mock('@/objects/lists.js', () => ({ getListDetails: vi.fn() }));
-vi.mock('../../src/objects/records/index.js', () => ({
+vi.mock('@/objects/records/index.js', () => ({
   getObjectRecord: vi.fn(),
 }));
-vi.mock('../../src/objects/tasks.js', () => ({ getTask: vi.fn() }));
-vi.mock('../../src/objects/notes.js', () => ({ getNote: vi.fn() }));
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@/objects/tasks.js', () => ({ getTask: vi.fn() }));
+vi.mock('@/objects/notes.js', () => ({ getNote: vi.fn() }));
+vi.mock('@services/create/index.js', () => ({
   shouldUseMockData: vi.fn(),
 }));
 vi.mock('@/utils/config-loader.js', () => ({
@@ -80,18 +80,18 @@ vi.mock('@/utils/config-loader.js', () => ({
   })),
 }));
 import { describe, it, expect, beforeEach } from 'vitest';
-import { UniversalRetrievalService } from '../../src/services/UniversalRetrievalService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord, AttioTask } from '../../src/types/attio.js';
-import { enhancedPerformanceTracker } from '../../src/middleware/performance-enhanced.js';
-import { CachingService } from '../../src/services/CachingService.js';
-import { UniversalUtilityService } from '../../src/services/UniversalUtilityService.js';
-import { getCompanyDetails } from '../../src/objects/companies/index.js';
-import { getPersonDetails } from '../../src/objects/people/index.js';
+import { UniversalRetrievalService } from '@services/UniversalRetrievalService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord, AttioTask } from '@shared-types/attio.js';
+import { enhancedPerformanceTracker } from '@/middleware/performance-enhanced.js';
+import { CachingService } from '@services/CachingService.js';
+import { UniversalUtilityService } from '@services/UniversalUtilityService.js';
+import { getCompanyDetails } from '@/objects/companies/index.js';
+import { getPersonDetails } from '@/objects/people/index.js';
 import * as lists from '@/objects/lists.js';
-import { getObjectRecord } from '../../src/objects/records/index.js';
-import * as tasks from '../../src/objects/tasks.js';
-import { shouldUseMockData } from '../../src/services/create/index.js';
+import { getObjectRecord } from '@/objects/records/index.js';
+import * as tasks from '@/objects/tasks.js';
+import { shouldUseMockData } from '@services/create/index.js';
 
 describe('UniversalRetrievalService', () => {
   beforeEach(() => {

--- a/test/services/UniversalRetrievalService-validation.test.ts
+++ b/test/services/UniversalRetrievalService-validation.test.ts
@@ -3,13 +3,13 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 // Inline mocks matching this file's specifiers
-vi.mock('../../src/services/CachingService.js', () => ({
+vi.mock('@services/CachingService.js', () => ({
   CachingService: { isCached404: vi.fn(), cache404Response: vi.fn() },
 }));
-vi.mock('../../src/services/ValidationService.js', () => ({
+vi.mock('@services/ValidationService.js', () => ({
   ValidationService: { validateUUID: vi.fn() },
 }));
-vi.mock('../../src/middleware/performance-enhanced.js', () => ({
+vi.mock('@/middleware/performance-enhanced.js', () => ({
   enhancedPerformanceTracker: {
     startOperation: vi.fn(() => 'perf-123'),
     markTiming: vi.fn(),
@@ -18,10 +18,10 @@ vi.mock('../../src/middleware/performance-enhanced.js', () => ({
     endOperation: vi.fn(),
   },
 }));
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@services/create/index.js', () => ({
   shouldUseMockData: vi.fn(() => false),
 }));
-vi.mock('../../src/utils/validation/uuid-validation.js', () => ({
+vi.mock('@utils/validation/uuid-validation.js', () => ({
   isValidUUID: vi.fn(() => true),
   createRecordNotFoundError: vi.fn(
     () =>
@@ -34,7 +34,7 @@ vi.mock('../../src/utils/validation/uuid-validation.js', () => ({
       })()
   ),
 }));
-vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
+vi.mock('@/errors/enhanced-api-errors.js', () => ({
   ErrorEnhancer: {
     autoEnhance: (e: any) => e,
     getErrorMessage: (e: any) => (e && e.message) || String(e),
@@ -61,24 +61,24 @@ vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
     }
   },
 }));
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   getCompanyDetails: vi.fn(),
 }));
 vi.mock('@/objects/lists.js', () => ({ getListDetails: vi.fn() }));
-vi.mock('../../src/objects/tasks.js', () => ({ getTask: vi.fn() }));
-vi.mock('../../src/objects/notes.js', () => ({ getNote: vi.fn() }));
-import { UniversalRetrievalService } from '../../src/services/UniversalRetrievalService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
-import { EnhancedApiError } from '../../src/errors/enhanced-api-errors.js';
-import { CachingService } from '../../src/services/CachingService.js';
-import { shouldUseMockData } from '../../src/services/create/index.js';
-import { createRecordNotFoundError } from '../../src/utils/validation/uuid-validation.js';
-import { enhancedPerformanceTracker } from '../../src/middleware/performance-enhanced.js';
-import { getCompanyDetails } from '../../src/objects/companies/index.js';
-import * as tasks from '../../src/objects/tasks.js';
+vi.mock('@/objects/tasks.js', () => ({ getTask: vi.fn() }));
+vi.mock('@/objects/notes.js', () => ({ getNote: vi.fn() }));
+import { UniversalRetrievalService } from '@services/UniversalRetrievalService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { EnhancedApiError } from '@/errors/enhanced-api-errors.js';
+import { CachingService } from '@services/CachingService.js';
+import { shouldUseMockData } from '@services/create/index.js';
+import { createRecordNotFoundError } from '@utils/validation/uuid-validation.js';
+import { enhancedPerformanceTracker } from '@/middleware/performance-enhanced.js';
+import { getCompanyDetails } from '@/objects/companies/index.js';
+import * as tasks from '@/objects/tasks.js';
 import * as lists from '@/objects/lists.js';
-import * as companies from '../../src/objects/companies/index.js';
-import * as notes from '../../src/objects/notes.js';
+import * as companies from '@/objects/companies/index.js';
+import * as notes from '@/objects/notes.js';
 
 describe('UniversalRetrievalService', () => {
   beforeEach(() => {

--- a/test/services/UniversalSearchService-companies-people-lists.test.ts
+++ b/test/services/UniversalSearchService-companies-people-lists.test.ts
@@ -2,17 +2,17 @@
  * Split: UniversalSearchService companies/people/lists
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-vi.mock('../../src/services/ValidationService.js', () => ({
+vi.mock('@services/ValidationService.js', () => ({
   ValidationService: {
     validatePaginationParameters: vi.fn(),
     validateFiltersSchema: vi.fn(),
     validateUUIDForSearch: vi.fn().mockReturnValue(true),
   },
 }));
-vi.mock('../../src/services/CachingService.js', () => ({
+vi.mock('@services/CachingService.js', () => ({
   CachingService: { getOrLoadTasks: vi.fn(), getCachedTasks: vi.fn() },
 }));
-vi.mock('../../src/middleware/performance-enhanced.js', () => ({
+vi.mock('@/middleware/performance-enhanced.js', () => ({
   enhancedPerformanceTracker: {
     startOperation: vi.fn(() => 'perf-123'),
     markTiming: vi.fn(),
@@ -21,32 +21,32 @@ vi.mock('../../src/middleware/performance-enhanced.js', () => ({
     endOperation: vi.fn(),
   },
 }));
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   advancedSearchCompanies: vi.fn(),
 }));
-vi.mock('../../src/objects/people/index.js', () => ({
+vi.mock('@/objects/people/index.js', () => ({
   advancedSearchPeople: vi.fn(),
 }));
-vi.mock('../../src/objects/lists.js', () => ({ searchLists: vi.fn() }));
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@/objects/lists.js', () => ({ searchLists: vi.fn() }));
+vi.mock('@services/create/index.js', () => ({
   shouldUseMockData: vi.fn(() => false),
 }));
-vi.mock('../../src/services/UniversalUtilityService.js', () => ({
+vi.mock('@services/UniversalUtilityService.js', () => ({
   UniversalUtilityService: { convertListToRecord: vi.fn() },
 }));
-vi.mock('../../src/api/operations/search.js', () => ({
+vi.mock('@api/operations/search.js', () => ({
   searchObject: vi.fn(),
 }));
 
-import { UniversalSearchService } from '../../src/services/UniversalSearchService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord } from '../../src/types/attio.js';
-import { advancedSearchCompanies } from '../../src/objects/companies/index.js';
-import { advancedSearchPeople } from '../../src/objects/people/index.js';
-import { searchLists } from '../../src/objects/lists.js';
-import { UniversalUtilityService } from '../../src/services/UniversalUtilityService.js';
-import { shouldUseMockData } from '../../src/services/create/index.js';
-import { searchObject } from '../../src/api/operations/search.js';
+import { UniversalSearchService } from '@services/UniversalSearchService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord } from '@shared-types/attio.js';
+import { advancedSearchCompanies } from '@/objects/companies/index.js';
+import { advancedSearchPeople } from '@/objects/people/index.js';
+import { searchLists } from '@/objects/lists.js';
+import { UniversalUtilityService } from '@services/UniversalUtilityService.js';
+import { shouldUseMockData } from '@services/create/index.js';
+import { searchObject } from '@api/operations/search.js';
 
 describe('UniversalSearchService', () => {
   beforeEach(() => {

--- a/test/services/UniversalUpdateService-core-operations.test.ts
+++ b/test/services/UniversalUpdateService-core-operations.test.ts
@@ -3,23 +3,23 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 // Inline mocks (must match specifiers in this file)
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   updateCompany: vi.fn(),
 }));
-vi.mock('../../src/objects/lists.js', () => ({ updateList: vi.fn() }));
-vi.mock('../../src/objects/people-write.js', () => ({ updatePerson: vi.fn() }));
-vi.mock('../../src/objects/records/index.js', () => ({
+vi.mock('@/objects/lists.js', () => ({ updateList: vi.fn() }));
+vi.mock('@/objects/people-write.js', () => ({ updatePerson: vi.fn() }));
+vi.mock('@/objects/records/index.js', () => ({
   updateObjectRecord: vi.fn(),
 }));
-vi.mock('../../src/config/deal-defaults.js', () => ({
+vi.mock('@config/deal-defaults.js', () => ({
   applyDealDefaultsWithValidation: vi.fn(),
   applyDealDefaultsWithValidationLegacy: vi.fn(),
 }));
-vi.mock('../../src/objects/tasks.js', () => ({
+vi.mock('@/objects/tasks.js', () => ({
   getTask: vi.fn(),
   updateTask: vi.fn(),
 }));
-vi.mock('../../src/handlers/tool-configs/universal/field-mapper.js', () => ({
+vi.mock('@handlers/tool-configs/universal/field-mapper.js', () => ({
   mapRecordFields: vi.fn(),
   mapTaskFields: vi.fn((_: string, i: any) => i),
   validateResourceType: vi.fn(),
@@ -29,16 +29,16 @@ vi.mock('../../src/handlers/tool-configs/universal/field-mapper.js', () => ({
     () => 'companies, people, lists, records, deals, tasks'
   ),
 }));
-vi.mock('../../src/utils/validation-utils.js', () => ({
+vi.mock('@utils/validation-utils.js', () => ({
   validateRecordFields: vi.fn(),
 }));
-vi.mock('../../src/services/ValidationService.js', () => ({
+vi.mock('@services/ValidationService.js', () => ({
   ValidationService: {
     truncateSuggestions: vi.fn((s: string[]) => s),
     validateEmailAddresses: vi.fn(),
   },
 }));
-vi.mock('../../src/services/MockService.js', () => ({
+vi.mock('@services/MockService.js', () => ({
   MockService: {
     updateTask: vi.fn(),
     isUsingMockData: vi.fn().mockReturnValue(true),
@@ -55,24 +55,24 @@ vi.mock('@/utils/config-loader.js', () => ({
     },
   })),
 }));
-import { UniversalUpdateService } from '../../src/services/UniversalUpdateService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord } from '../../src/types/attio.js';
-import { updateCompany } from '../../src/objects/companies/index.js';
-import { updateList } from '../../src/objects/lists.js';
-import { updatePerson } from '../../src/objects/people-write.js';
-import { updateObjectRecord } from '../../src/objects/records/index.js';
+import { UniversalUpdateService } from '@services/UniversalUpdateService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord } from '@shared-types/attio.js';
+import { updateCompany } from '@/objects/companies/index.js';
+import { updateList } from '@/objects/lists.js';
+import { updatePerson } from '@/objects/people-write.js';
+import { updateObjectRecord } from '@/objects/records/index.js';
 import {
   applyDealDefaultsWithValidation,
   applyDealDefaultsWithValidationLegacy,
-} from '../../src/config/deal-defaults.js';
-import { ValidationService } from '../../src/services/ValidationService.js';
-import { MockService } from '../../src/services/MockService.js';
+} from '@config/deal-defaults.js';
+import { ValidationService } from '@services/ValidationService.js';
+import { MockService } from '@services/MockService.js';
 import {
   mapRecordFields,
   validateFields,
-} from '../../src/handlers/tool-configs/universal/field-mapper.js';
-import { validateRecordFields } from '../../src/utils/validation-utils.js';
+} from '@handlers/tool-configs/universal/field-mapper.js';
+import { validateRecordFields } from '@utils/validation-utils.js';
 
 describe('UniversalUpdateService', () => {
   beforeEach(() => {


### PR DESCRIPTION
## What

- Migrates the first current #745 hotspot batch from deep relative imports to existing aliases.
- Covers production object/service modules plus paired service tests.
- Adds a plan artifact documenting why this is batch 1 rather than a repo-wide churn PR.
- Preserves NodeNext `.js` import suffixes and avoids adding new aliases.

## Why

The original #745 Tier 1 files are already migrated in this checkout, but the repo still has a large tail of deep relative imports. This batch reduces the current highest-impact hotspots while keeping the review surface small enough to audit mechanically.

## Tests

Passed:

- `rg -n "^\\s*(import|export)\\s+(type\\s+)?(.+?\\s+from\\s+)?['\"]\\.\\./|import\\(['\"]\\.\\./" <changed files>` returned no matches
- Alias target resolver over changed imports and `vi.mock()` specifiers: `Alias targets resolve for changed imports and mocks`
- `git diff --check`
- Browser route mapping via `ce-test-browser mode:pipeline`: no browser routes affected

Attempted but blocked by local repo/tooling state:

- `bun run typecheck` exits before checking changed files: `tsconfig.json(32,27): error TS5103: Invalid value for '--ignoreDeprecations'`
- `bun run lint:src ...` cannot load ESLint config in this checkout because `@eslint/js` is unavailable
- `bun run test:offline:run -- test/services/UniversalDeleteService.test.ts` cannot start because `vitest` is not installed in this checkout

## AI Assistance

AI-assisted implementation and review were used. Testing level: static/import-resolution verification plus attempted local validation; full typecheck/lint/Vitest should run in CI or after restoring local dependencies/toolchain. I understand the final diff and behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
