### PR TITLE
Fix: Mock global context in search tests

### DIFF
--- a/test/unit/api/search-object.test.ts
+++ b/test/unit/api/search-object.test.ts
@@ -8,6 +8,7 @@ type PostMock = ReturnType<typeof vi.fn>;
 const postMock: PostMock = vi.fn();
 
 vi.mock('@api/lazy-client.js', () => ({
+  getGlobalContext: () => null,
   getLazyAttioClient: () => ({
     post: postMock,
   }),


### PR DESCRIPTION
## What
- Adds the missing `getGlobalContext` export to the `@api/lazy-client.js` mock used by search-object unit tests.

## Why
The security cache-scoping changes made `searchObject` read request/global client context while building its tenant cache key. The unit test mock only exposed `getLazyAttioClient`, so the offline suite failed before it could exercise the search filter assertions.

## Tests
- `bun run typecheck`
- `bun run test:offline -- --run test/unit/api/search-object.test.ts`
- `bun run test:offline`
- `bunx prettier --check test/unit/api/search-object.test.ts`

## AI Assistance
Used Codex to inspect the failing mock, make the one-line test fix, and run local validation. I understand this code.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
