### PR TITLE
Fix: Align prompt tool names

### DIFF
--- a/docs/api/prompts-api.md
+++ b/docs/api/prompts-api.md
@@ -13,9 +13,11 @@ GET /prompts/list
 Lists all available prompts or filters by category.
 
 **Parameters:**
+
 - `category` (optional): Filter prompts by category (e.g., "people", "companies", "lists", "notes")
 
 **Response:**
+
 ```json
 {
   "success": true,
@@ -50,6 +52,7 @@ GET /prompts/categories
 Lists all available prompt categories.
 
 **Response:**
+
 ```json
 {
   "success": true,
@@ -66,9 +69,11 @@ GET /prompts/:id
 Gets details for a specific prompt.
 
 **Parameters:**
+
 - `id`: ID of the prompt to get details for
 
 **Response:**
+
 ```json
 {
   "success": true,
@@ -100,9 +105,11 @@ POST /prompts/:id/execute
 Executes a prompt with provided parameters.
 
 **Parameters:**
+
 - `id`: ID of the prompt to execute
 
 **Request Body:**
+
 ```json
 {
   "parameters": {
@@ -114,6 +121,7 @@ Executes a prompt with provided parameters.
 ```
 
 **Response:**
+
 ```json
 {
   "success": true,
@@ -131,6 +139,7 @@ The MCP Prompts API includes templates for the following categories:
 ### People
 
 Prompts for working with people records in Attio:
+
 - Create a new person
 - Find a person by email
 - Update person details
@@ -139,6 +148,7 @@ Prompts for working with people records in Attio:
 ### Companies
 
 Prompts for working with company records in Attio:
+
 - Create a new company
 - Find a company by name
 - Update company details
@@ -147,6 +157,7 @@ Prompts for working with company records in Attio:
 ### Lists
 
 Prompts for working with lists in Attio:
+
 - Create a new list
 - Add a record to a list
 - Remove a record from a list
@@ -156,6 +167,7 @@ Prompts for working with lists in Attio:
 ### Notes
 
 Prompts for working with notes in Attio:
+
 - Create a new note
 - Get notes for a record
 - Update a note
@@ -190,14 +202,18 @@ After collecting the necessary parameters, Claude can use the `prompts/execute` 
 ## Extending Prompts
 
 To add new prompt templates, you can extend the templates in the following files:
+
 - `src/prompts/templates/people.ts`
 - `src/prompts/templates/companies.ts`
 - `src/prompts/templates/lists.ts`
 - `src/prompts/templates/notes.ts`
 
 Each template should include:
+
 - A unique ID
 - A title and description
 - A category
 - A list of parameters with types, descriptions, and whether they are required
 - A template string using Handlebars syntax
+
+Prompt instructions that mention MCP tools should use names exposed by the active registry. Prefer canonical universal names such as `search_records`, `get_record_details`, `create_record`, and `update_record`; use exposed compatibility tools such as `search` and `fetch` only when the prompt is intentionally using that compatibility surface. Do not introduce dotted pseudo-tool names in prompt text.

--- a/docs/plans/2026-06-09-002-fix-prompt-tool-name-catalog-plan.md
+++ b/docs/plans/2026-06-09-002-fix-prompt-tool-name-catalog-plan.md
@@ -1,0 +1,99 @@
+---
+title: Fix prompt tool-name catalog drift
+type: fix
+status: active
+date: 2026-06-09
+---
+
+# Fix prompt tool-name catalog drift
+
+## Summary
+
+Fix issue #1189 by aligning bundled prompt instructions and prompt-facing docs with the active tool surface. The work should remove stale tool names from generated v1 prompt text, add a registry-backed regression test, and update docs that describe the prompt/tool naming contract.
+
+---
+
+## Problem Frame
+
+The v1 prompt catalog still teaches agents to call names such as `records_query`, `tasks.create`, `deals.list`, and `web.search`. The current server exposes canonical snake_case names in `src/constants/tool-names.ts`, search/fetch compatibility tools in `src/handlers/tool-configs/openai/index.ts`, and limited compatibility aliases in `src/config/tool-aliases.ts`. The stale prompt text can cause avoidable tool-call failures even though the underlying server capabilities exist.
+
+---
+
+## Requirements
+
+- R1. Prompt-generated tool references must resolve through the default registry or through explicitly supported aliases.
+- R2. Bundled v1 prompt instructions must stop recommending stale names such as `records_query`, dotted Attio verbs, and `web.search` / `web.fetch`.
+- R3. The prompt wording must stay user-facing and task-oriented rather than exposing internal implementation jargon.
+- R4. Tests must catch future prompt/tool-name drift across the full v1 prompt catalog, not only one prompt.
+- R5. Prompt-facing documentation and examples must match the active tool surface.
+
+---
+
+## Key Technical Decisions
+
+- **Use canonical names in prompts:** Prefer current canonical names from `src/constants/tool-names.ts` over adding new compatibility aliases for stale prompt wording. The aliases in `src/config/tool-aliases.ts` are for backward compatibility with external callers, while bundled prompts should model the current API.
+- **Validate prompt output, not only source text:** Build representative messages from every prompt in `src/prompts/v1/index.ts` and inspect generated text. This catches interpolation paths and conditional instructions that a source-only scan can miss.
+- **Allowlist true non-Attio tool references narrowly:** `search` and `fetch` are exposed by the OpenAI compatibility configs, but `web.search` and `web.fetch` are not. The regression test should allow only names that resolve through the registry/alias set or are documented as prose-only non-tools.
+- **Keep the fix local to prompt/catalog surfaces:** Do not redesign the prompt system or broaden the compatibility alias registry unless implementation proves the active registry itself is incomplete.
+
+---
+
+## Implementation Units
+
+### U1. Audit and replace stale v1 prompt references
+
+- **Goal:** Replace stale prompt tool names with active canonical names while preserving the workflow intent of each prompt.
+- **Files:** `src/prompts/v1/*.ts`
+- **Patterns:** Follow current prompt builders such as `buildPeopleSearchMessages` and existing dry-run wording in write prompts.
+- **Expected changes:** Use `search_records` for record resolution/search instructions, `update_record` for record updates, `create_record` for task creation where tasks are represented as records, `list_notes` for notes, and `search` / `fetch` for OpenAI compatibility search instructions.
+- **Test Scenarios:** Generated messages for all v1 prompts contain no `records_query`, no dotted Attio names such as `tasks.create`, and no `web.search` / `web.fetch`.
+
+### U2. Add registry-backed prompt tool-name validation
+
+- **Goal:** Add a regression test that validates tool-like references emitted by prompt builders against the active tool registry and alias registry.
+- **Files:** `test/prompts/v1/tool-name-catalog.test.ts`, `test/prompts/v1/people-search.test.ts`
+- **Patterns:** Reuse v1 prompt registry from `src/prompts/v1/index.ts`; use existing Vitest style from `test/prompts/v1/people-search.test.ts`.
+- **Test Scenarios:** The test extracts backticked tool-like tokens from representative prompt output and fails when a token does not resolve through canonical tools, supported aliases, or a narrow explicit allowlist. The existing people-search test should assert `search_records` instead of `records_query`.
+
+### U3. Update prompt-facing docs and standards
+
+- **Goal:** Align user-facing docs and tool quality guidance with the current naming contract.
+- **Files:** `README.md`, `docs/api/prompts-api.md`, `docs/usage/playbooks/*.md`, `docs/tools/tool-quality-standards.md`
+- **Patterns:** Keep docs concise and oriented around user-visible tool names. Avoid documenting internal aliases as the preferred path.
+- **Test Scenarios:** Repository scan for stale prompt/tool names returns no active-source matches outside historical migration docs or intentional test fixtures.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add new Attio capabilities.
+- This plan does not remove existing compatibility aliases.
+- This plan does not redesign prompt schemas, prompt discovery, or tool-mode behavior.
+- Historical docs may keep old names only when explicitly framed as deprecated migration context.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a user runs `people_search.v1`, when the prompt message is generated, then it instructs the agent to call `search_records` rather than `records_query`.
+- AE2. Given a prompt asks for a follow-up task, when the message is generated, then it uses an active record-creation/update path rather than `tasks.create`.
+- AE3. Given the prompt catalog gains a new prompt later, when that prompt emits a stale backticked tool name, then the new catalog validation test fails.
+- AE4. Given prompt-facing docs mention tool naming, when a reader follows the examples, then the examples use names exposed by the default server surface.
+
+---
+
+## Risks & Dependencies
+
+- The prompt text compresses complex workflows into short instructions, so replacing dotted names with universal tools must preserve enough argument guidance for agents to act.
+- Some docs may contain historical stale names. The implementation should distinguish active guidance from migration history rather than deleting useful historical context.
+- Local validation depends on installed dependencies and the repo's Bun toolchain. If local dependencies are unavailable, CI must be treated as the final validation gate and local blockers must be disclosed in the PR.
+
+---
+
+## Sources
+
+- Issue #1189 describes the stale prompt catalog and acceptance criteria.
+- `src/constants/tool-names.ts` defines canonical MCP-compliant tool names.
+- `src/config/tool-aliases.ts` defines supported compatibility aliases.
+- `src/handlers/tool-configs/openai/index.ts` exposes `search` and `fetch` compatibility tools.
+- `src/prompts/v1/index.ts` defines the v1 prompt catalog to validate.

--- a/docs/tools/attio-tools-reference.md
+++ b/docs/tools/attio-tools-reference.md
@@ -15,29 +15,29 @@ Universal tools provide consistent operations across all resource types (compani
 
 | Need to...                  | Use This Tool                    | Key Parameters                            |
 | --------------------------- | -------------------------------- | ----------------------------------------- |
-| **Search any resource**     | `records.search`                 | `resource_type`, `query`                  |
-| **Get record details**      | `records.get_details`            | `resource_type`, `record_id`              |
-| **Create new record**       | `create-record`                  | `resource_type`, `record_data`            |
-| **Update existing record**  | `update-record`                  | `resource_type`, `record_id`, `updates`   |
-| **Delete record**           | `delete-record`                  | `resource_type`, `record_id`              |
-| **Complex searches**        | `records.search_advanced`        | `resource_type`, `filters`                |
-| **Cross-resource searches** | `records.search_by_relationship` | `resource_type`, `related_resource_type`  |
-| **Content-based searches**  | `records.search_by_content`      | `resource_type`, `content_query`          |
-| **Time-based searches**     | `records.search_by_timeframe`    | `resource_type`, `date_range`             |
-| **Bulk operations**         | `records.batch`                  | `operation_type`, `records`               |
-| **Get attributes**          | `records.get_attributes`         | `resource_type`, `record_id`              |
-| **Discover schema**         | `records.discover_attributes`    | `resource_type`                           |
-| **Get specialized info**    | `records.get_info`               | `resource_type`, `record_id`, `info_type` |
+| **Search any resource**     | `search_records`                 | `resource_type`, `query`                  |
+| **Get record details**      | `get_record_details`             | `resource_type`, `record_id`              |
+| **Create new record**       | `create_record`                  | `resource_type`, `record_data`            |
+| **Update existing record**  | `update_record`                  | `resource_type`, `record_id`, `updates`   |
+| **Delete record**           | `delete_record`                  | `resource_type`, `record_id`              |
+| **Complex searches**        | `search_records_advanced`        | `resource_type`, `filters`                |
+| **Cross-resource searches** | `search_records_by_relationship` | `resource_type`, `related_resource_type`  |
+| **Content-based searches**  | `search_records_by_content`      | `resource_type`, `content_query`          |
+| **Time-based searches**     | `search_records_by_timeframe`    | `resource_type`, `date_range`             |
+| **Bulk operations**         | `batch_records`                  | `operation_type`, `records`               |
+| **Get attributes**          | `get_record_attributes`          | `resource_type`, `record_id`              |
+| **Discover schema**         | `discover_record_attributes`     | `resource_type`                           |
+| **Get specialized info**    | `get_record_info`                | `resource_type`, `record_id`, `info_type` |
 
 ## 🛠 Core Operations (8 Tools)
 
-### 1. `records.search`
+### 1. `search_records`
 
 **Universal search across all resource types**
 
 ```typescript
 {
-  "name": "records.search",
+  "name": "search_records",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "query": "search term",
@@ -53,13 +53,13 @@ Universal tools provide consistent operations across all resource types (compani
 - Find people by email: `resource_type: "people", query: "john@example.com"`
 - Find tasks by title: `resource_type: "tasks", query: "follow up"`
 
-### 2. `records.get_details`
+### 2. `get_record_details`
 
 **Get comprehensive information for any record type**
 
 ```typescript
 {
-  "name": "records.get_details",
+  "name": "get_record_details",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "record_id": "record_123456",
@@ -68,13 +68,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 3. `create-record`
+### 3. `create_record`
 
 **Create new records of any supported type**
 
 ```typescript
 {
-  "name": "create-record",
+  "name": "create_record",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "record_data": {
@@ -86,13 +86,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 4. `update-record`
+### 4. `update_record`
 
 **Update existing records**
 
 ```typescript
 {
-  "name": "update-record",
+  "name": "update_record",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "record_id": "record_123456",
@@ -104,13 +104,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 5. `delete-record`
+### 5. `delete_record`
 
 **Delete records safely**
 
 ```typescript
 {
-  "name": "delete-record",
+  "name": "delete_record",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "record_id": "record_123456",
@@ -119,13 +119,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 6. `records.get_attributes`
+### 6. `get_record_attributes`
 
 **Get all attributes for a specific record**
 
 ```typescript
 {
-  "name": "records.get_attributes",
+  "name": "get_record_attributes",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "record_id": "record_123456",
@@ -134,13 +134,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 7. `records.discover_attributes`
+### 7. `discover_record_attributes`
 
 **Discover available attributes for a resource type**
 
 ```typescript
 {
-  "name": "records.discover_attributes",
+  "name": "discover_record_attributes",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "include_schema": true // Optional: include attribute schemas
@@ -148,13 +148,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 8. `records.get_info`
+### 8. `get_record_info`
 
 **Get specialized information (contact, business, social)**
 
 ```typescript
 {
-  "name": "records.get_info",
+  "name": "get_record_info",
   "arguments": {
     "resource_type": "companies" | "people",
     "record_id": "record_123456",
@@ -165,13 +165,13 @@ Universal tools provide consistent operations across all resource types (compani
 
 ## 🚀 Advanced Operations (5 Tools)
 
-### 9. `records.search_advanced`
+### 9. `search_records_advanced`
 
 **Complex searches with sorting and advanced filtering**
 
 ```typescript
 {
-  "name": "records.search_advanced",
+  "name": "search_records_advanced",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "filters": {
@@ -195,13 +195,13 @@ Universal tools provide consistent operations across all resource types (compani
 - `$in`, `$nin` (arrays)
 - `$and`, `$or` (logical)
 
-### 10. `records.search_by_relationship`
+### 10. `search_records_by_relationship`
 
 **Cross-resource relationship searches**
 
 ```typescript
 {
-  "name": "records.search_by_relationship",
+  "name": "search_records_by_relationship",
   "arguments": {
     "resource_type": "people",
     "related_resource_type": "companies",
@@ -213,13 +213,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 11. `records.search_by_content`
+### 11. `search_records_by_content`
 
 **Content-based searches (notes, activity)**
 
 ```typescript
 {
-  "name": "records.search_by_content",
+  "name": "search_records_by_content",
   "arguments": {
     "resource_type": "companies" | "people",
     "content_query": "quarterly review",
@@ -232,13 +232,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 12. `records.search_by_timeframe`
+### 12. `search_records_by_timeframe`
 
 **Time-based searches with date ranges**
 
 ```typescript
 {
-  "name": "records.search_by_timeframe",
+  "name": "search_records_by_timeframe",
   "arguments": {
     "resource_type": "companies" | "people" | "tasks",
     "date_field": "created_at" | "updated_at" | "last_contacted",
@@ -251,13 +251,13 @@ Universal tools provide consistent operations across all resource types (compani
 }
 ```
 
-### 13. `records.batch`
+### 13. `batch_records`
 
 **Bulk operations on multiple records**
 
 ```typescript
 {
-  "name": "records.batch",
+  "name": "batch_records",
   "arguments": {
     "operation_type": "create" | "update" | "delete" | "search",
     "resource_type": "companies" | "people" | "tasks" | "records",
@@ -295,44 +295,44 @@ Generic records with custom attributes defined in your Attio workspace
 
 ### For Simple Operations
 
-- **Basic search**: Use `records.search`
-- **Get details**: Use `records.get_details`
-- **CRUD operations**: Use `create-record`, `update-record`, `delete-record`
+- **Basic search**: Use `search_records`
+- **Get details**: Use `get_record_details`
+- **CRUD operations**: Use `create_record`, `update_record`, `delete_record`
 
 ### For Complex Searches
 
-- **Multi-criteria**: Use `records.search_advanced`
-- **Cross-resource**: Use `records.search_by_relationship`
-- **Content-based**: Use `records.search_by_content`
-- **Time-based**: Use `records.search_by_timeframe`
+- **Multi-criteria**: Use `search_records_advanced`
+- **Cross-resource**: Use `search_records_by_relationship`
+- **Content-based**: Use `search_records_by_content`
+- **Time-based**: Use `search_records_by_timeframe`
 
 ### For Bulk Operations
 
-- **Multiple records**: Use `records.batch`
-- **Schema discovery**: Use `records.discover_attributes`
-- **Specialized info**: Use `records.get_info`
+- **Multiple records**: Use `batch_records`
+- **Schema discovery**: Use `discover_record_attributes`
+- **Specialized info**: Use `get_record_info`
 
 ## 🔄 Migration from Individual Tools
 
 All previous individual tools have been consolidated:
 
-| Old Pattern                         | New Universal Pattern                                       |
-| ----------------------------------- | ----------------------------------------------------------- |
-| `search-companies`                  | `records.search` with `resource_type: "companies"`          |
-| `search-people`                     | `records.search` with `resource_type: "people"`             |
-| `get-company-details`               | `records.get_details` with `resource_type: "companies"`     |
-| `create-person`                     | `create-record` with `resource_type: "people"`              |
-| `records.search_advanced-companies` | `records.search_advanced` with `resource_type: "companies"` |
+| Old Pattern                 | New Universal Pattern                                       |
+| --------------------------- | ----------------------------------------------------------- |
+| `search-companies`          | `search_records` with `resource_type: "companies"`          |
+| `search-people`             | `search_records` with `resource_type: "people"`             |
+| `get-company-details`       | `get_record_details` with `resource_type: "companies"`      |
+| `create-person`             | `create_record` with `resource_type: "people"`              |
+| `advanced-search-companies` | `search_records_advanced` with `resource_type: "companies"` |
 
 **Complete Migration Guide**: See [Migration Guide](../universal-tools/migration-guide.md) for all 40+ tool mappings.
 
 ## 🚀 Best Practices
 
-1. **Start with Basic Tools**: Use `records.search` and `records.get_details` for most operations
+1. **Start with Basic Tools**: Use `search_records` and `get_record_details` for most operations
 2. **Use Appropriate Resource Types**: Always specify the correct `resource_type`
-3. **Leverage Advanced Search**: Use `records.search_advanced` for complex filtering
-4. **Batch for Efficiency**: Use `records.batch` for multiple records
-5. **Discover Schema**: Use `records.discover_attributes` to understand available fields
+3. **Leverage Advanced Search**: Use `search_records_advanced` for complex filtering
+4. **Batch for Efficiency**: Use `batch_records` for multiple records
+5. **Discover Schema**: Use `discover_record_attributes` to understand available fields
 6. **Handle Errors**: All tools include comprehensive error handling
 
 ## 🔗 Additional Resources

--- a/docs/tools/attio-tools-reference.md
+++ b/docs/tools/attio-tools-reference.md
@@ -13,21 +13,21 @@ Universal tools provide consistent operations across all resource types (compani
 
 ## 📚 Quick Navigation
 
-| Need to...                  | Use This Tool                    | Key Parameters                            |
-| --------------------------- | -------------------------------- | ----------------------------------------- |
-| **Search any resource**     | `search_records`                 | `resource_type`, `query`                  |
-| **Get record details**      | `get_record_details`             | `resource_type`, `record_id`              |
-| **Create new record**       | `create_record`                  | `resource_type`, `record_data`            |
-| **Update existing record**  | `update_record`                  | `resource_type`, `record_id`, `updates`   |
-| **Delete record**           | `delete_record`                  | `resource_type`, `record_id`              |
-| **Complex searches**        | `search_records_advanced`        | `resource_type`, `filters`                |
-| **Cross-resource searches** | `search_records_by_relationship` | `resource_type`, `related_resource_type`  |
-| **Content-based searches**  | `search_records_by_content`      | `resource_type`, `content_query`          |
-| **Time-based searches**     | `search_records_by_timeframe`    | `resource_type`, `date_range`             |
-| **Bulk operations**         | `batch_records`                  | `operation_type`, `records`               |
-| **Get attributes**          | `get_record_attributes`          | `resource_type`, `record_id`              |
-| **Discover schema**         | `discover_record_attributes`     | `resource_type`                           |
-| **Get specialized info**    | `get_record_info`                | `resource_type`, `record_id`, `info_type` |
+| Need to...                  | Use This Tool                    | Key Parameters                                  |
+| --------------------------- | -------------------------------- | ----------------------------------------------- |
+| **Search any resource**     | `search_records`                 | `resource_type`, `query`                        |
+| **Get record details**      | `get_record_details`             | `resource_type`, `record_id`                    |
+| **Create new record**       | `create_record`                  | `resource_type`, `record_data`                  |
+| **Update existing record**  | `update_record`                  | `resource_type`, `record_id`, `record_data`     |
+| **Delete record**           | `delete_record`                  | `resource_type`, `record_id`                    |
+| **Complex searches**        | `search_records_advanced`        | `resource_type`, `filters`                      |
+| **Cross-resource searches** | `search_records_by_relationship` | `relationship_type`, `source_id`                |
+| **Content-based searches**  | `search_records_by_content`      | `resource_type`, `content_type`, `search_query` |
+| **Time-based searches**     | `search_records_by_timeframe`    | `resource_type`, `date_range`                   |
+| **Bulk operations**         | `batch_records`                  | `operation_type`, `records`                     |
+| **Get attributes**          | `get_record_attributes`          | `resource_type`, `record_id`                    |
+| **Discover schema**         | `discover_record_attributes`     | `resource_type`                                 |
+| **Get specialized info**    | `get_record_info`                | `resource_type`, `record_id`, `info_type`       |
 
 ## 🛠 Core Operations (8 Tools)
 

--- a/docs/tools/attio-tools-reference.md
+++ b/docs/tools/attio-tools-reference.md
@@ -23,7 +23,7 @@ Universal tools provide consistent operations across all resource types (compani
 | **Complex searches**        | `search_records_advanced`        | `resource_type`, `filters`                      |
 | **Cross-resource searches** | `search_records_by_relationship` | `relationship_type`, `source_id`                |
 | **Content-based searches**  | `search_records_by_content`      | `resource_type`, `content_type`, `search_query` |
-| **Time-based searches**     | `search_records_by_timeframe`    | `resource_type`, `date_range`                   |
+| **Time-based searches**     | `search_records_by_timeframe`    | `resource_type`, `start_date`, `end_date`       |
 | **Bulk operations**         | `batch_records`                  | `operation_type`, `records`                     |
 | **Get attributes**          | `get_record_attributes`          | `resource_type`, `record_id`                    |
 | **Discover schema**         | `discover_record_attributes`     | `resource_type`                                 |
@@ -175,12 +175,19 @@ Universal tools provide consistent operations across all resource types (compani
   "arguments": {
     "resource_type": "companies" | "people" | "tasks" | "records",
     "filters": {
-      "name": { "$contains": "tech" },
-      "employees": { "$gte": 50 },
-      "$or": [
-        { "industry": "Technology" },
-        { "industry": "Software" }
-      ]
+      "filters": [
+        {
+          "attribute": { "slug": "name" },
+          "condition": "contains",
+          "value": "tech"
+        },
+        {
+          "attribute": { "slug": "employees" },
+          "condition": "gte",
+          "value": 50
+        }
+      ],
+      "matchAny": false
     },
     "sort": [{ "name": "asc" }],
     "limit": 50
@@ -190,10 +197,10 @@ Universal tools provide consistent operations across all resource types (compani
 
 **Filter Operators:**
 
-- `$contains`, `$starts_with`, `$ends_with` (text)
-- `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte` (comparisons)
-- `$in`, `$nin` (arrays)
-- `$and`, `$or` (logical)
+- `contains`, `starts_with`, `ends_with` (text)
+- `equals`, `gt`, `gte`, `lt`, `lte` (comparisons)
+- `is_empty`, `is_not_empty` (presence)
+- `matchAny: true` for OR logic across filters
 
 ### 10. `search_records_by_relationship`
 
@@ -203,12 +210,10 @@ Universal tools provide consistent operations across all resource types (compani
 {
   "name": "search_records_by_relationship",
   "arguments": {
-    "resource_type": "people",
-    "related_resource_type": "companies",
-    "relationship_filter": {
-      "company_name": { "$contains": "acme" }
-    },
-    "include_related": true
+    "relationship_type": "company_to_people",
+    "source_id": "company_record_id",
+    "target_resource_type": "people",
+    "limit": 50
   }
 }
 ```
@@ -222,12 +227,9 @@ Universal tools provide consistent operations across all resource types (compani
   "name": "search_records_by_content",
   "arguments": {
     "resource_type": "companies" | "people",
-    "content_query": "quarterly review",
-    "content_types": ["notes", "activities"],
-    "date_range": {
-      "start": "2023-01-01",
-      "end": "2023-12-31"
-    }
+    "content_type": "notes" | "activity" | "interactions",
+    "search_query": "quarterly review",
+    "limit": 20
   }
 }
 ```
@@ -242,11 +244,8 @@ Universal tools provide consistent operations across all resource types (compani
   "arguments": {
     "resource_type": "companies" | "people" | "tasks",
     "date_field": "created_at" | "updated_at" | "last_contacted",
-    "date_range": {
-      "start": "2023-01-01",
-      "end": "2023-12-31"
-    },
-    "relative_range": "last_30_days" // Alternative to absolute dates
+    "start_date": "2023-01-01",
+    "end_date": "2023-12-31"
   }
 }
 ```

--- a/docs/tools/tool-discovery-baseline.json
+++ b/docs/tools/tool-discovery-baseline.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "create-note",
-      "description": "Create note for companies, people, or deals. | WRITE: requires approval | Does not: update or delete notes; creates only. | Requires resource_type, record_id, title, content. | If errors occur: If record not found, use records_search first.",
+      "description": "Create note for companies, people, or deals. | WRITE: requires approval | Does not: update or delete notes; creates only. | Requires resource_type, record_id, title, content. | If errors occur: If record not found, use search_records first.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -341,7 +341,7 @@
     },
     {
       "name": "filter-list-entries-by-parent",
-      "description": "Filter entries by parent record attributes (industry, role). | Does not: search multiple lists or modify records. | Requires listId, parentObjectType, parentAttributeSlug, condition, value. | If errors occur: Use records_discover_attributes for valid slugs.",
+      "description": "Filter entries by parent record attributes (industry, role). | Does not: search multiple lists or modify records. | Requires listId, parentObjectType, parentAttributeSlug, condition, value. | If errors occur: Use discover_record_attributes for valid slugs.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -491,7 +491,7 @@
     },
     {
       "name": "get-record-list-memberships",
-      "description": "Find all lists containing a specific company or person record. | Does not: modify list memberships or retrieve list entries. | Requires recordId; processes 5 lists in parallel by default (max 20). | If errors occur: If record not found, verify recordId with records_search first.",
+      "description": "Find all lists containing a specific company or person record. | Does not: modify list memberships or retrieve list entries. | Requires recordId; processes 5 lists in parallel by default (max 20). | If errors occur: If record not found, verify recordId with search_records first.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -544,7 +544,7 @@
     },
     {
       "name": "list-notes",
-      "description": "Retrieve notes for a record with timestamps. | Does not: create or modify notes; read-only. | Requires resource_type, record_id; sorted by creation date. | If errors occur: If empty, verify record has notes with records_get_details.",
+      "description": "Retrieve notes for a record with timestamps. | Does not: create or modify notes; read-only. | Requires resource_type, record_id; sorted by creation date. | If errors occur: If empty, verify record has notes with get_record_details.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -628,7 +628,7 @@
     },
     {
       "name": "records_batch",
-      "description": "Execute batched record operations (create/update/delete/get/search). | WRITE: requires approval | Does not: ignore approval guardrails; hosts may require confirmation. | operation_type must be specified; enforce per-operation limits. | If errors occur: Run records.search first to stage IDs or payloads for batching.",
+      "description": "Execute batched record operations (create/update/delete/get/search). | WRITE: requires approval | Does not: ignore approval guardrails; hosts may require confirmation. | operation_type must be specified; enforce per-operation limits. | If errors occur: Run search_records first to stage IDs or payloads for batching.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -767,7 +767,7 @@
     },
     {
       "name": "records_get_attributes",
-      "description": "Retrieve attribute metadata for a given resource type. | Does not: modify schema definitions or record data. | Requires resource_type; optional categories narrows groups. | If errors occur: Use records.discover_attributes for grouped schema discovery.",
+      "description": "Retrieve attribute metadata for a given resource type. | Does not: modify schema definitions or record data. | Requires resource_type; optional categories narrows groups. | If errors occur: Use discover_record_attributes for grouped schema discovery.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -819,7 +819,7 @@
     },
     {
       "name": "records_get_details",
-      "description": "Fetch a single record with enriched attribute formatting. | Does not: search or filter result sets; use records.search* tools instead. | Requires resource_type and record_id; optional fields filter output. | If errors occur: Validate record IDs with records.search before retrying.",
+      "description": "Fetch a single record with enriched attribute formatting. | Does not: search or filter result sets; use search_records tools instead. | Requires resource_type and record_id; optional fields filter output. | If errors occur: Validate record IDs with search_records before retrying.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -865,7 +865,7 @@
     },
     {
       "name": "records_get_info",
-      "description": "Retrieve enriched info subsets (contact, business, social) for a record. | Does not: search lists of records or mutate data. | Requires resource_type, record_id, and info_type (contact|business|social). | If errors occur: Use records.get_details if you need the full record payload.",
+      "description": "Retrieve enriched info subsets (contact, business, social) for a record. | Does not: search lists of records or mutate data. | Requires resource_type, record_id, and info_type (contact|business|social). | If errors occur: Use get_record_details if you need the full record payload.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -903,7 +903,7 @@
     },
     {
       "name": "records_search",
-      "description": "Search across companies, people, tasks, and records | Does not: create or modify records | Returns max 100 results (default: 10) | If errors occur: use records.discover_attributes to find searchable fields",
+      "description": "Search across companies, people, tasks, and records | Does not: create or modify records | Returns max 100 results (default: 10) | If errors occur: use discover_record_attributes to find searchable fields",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1033,7 +1033,7 @@
     },
     {
       "name": "records_search_advanced",
-      "description": "Run complex searches with nested filters across resource types. | Does not: mutate records; use records.update or records.delete. | Supports filter groups, scoring, pagination, and up to 100 items. | If errors occur: If filters fail, fetch valid attributes via records.discover_attributes.",
+      "description": "Run complex searches with nested filters across resource types. | Does not: mutate records; use update_record or delete_record. | Supports filter groups, scoring, pagination, and up to 100 items. | If errors occur: If filters fail, fetch valid attributes via discover_record_attributes.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1110,7 +1110,7 @@
     },
     {
       "name": "records_search_batch",
-      "description": "Execute multiple searches in parallel and return grouped results. | Does not: mutate or import data; use records.batch for write operations. | Provide queries array (1–10 items recommended) and resource_type. | If errors occur: If queries fail, retry individually using records.search.",
+      "description": "Execute multiple searches in parallel and return grouped results. | Does not: mutate or import data; use batch_records for write operations. | Provide queries array (1–10 items recommended) and resource_type. | If errors occur: If queries fail, retry individually using search_records.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1164,7 +1164,7 @@
     },
     {
       "name": "records_search_by_content",
-      "description": "Search record content (notes, activity, communications). | Does not: modify note content or attachments. | Requires resource_type and content_query; optional fields array. | If errors occur: Narrow scope with fields or switch to records.search_advanced.",
+      "description": "Search record content (notes, activity, communications). | Does not: modify note content or attachments. | Requires resource_type and content_query; optional fields array. | If errors occur: Narrow scope with fields or switch to search_records_advanced.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1222,7 +1222,7 @@
     },
     {
       "name": "records_search_by_relationship",
-      "description": "Search records using relationship anchors (list, company, people). | Does not: modify memberships; use list tools for writes. | Requires resource_type and related resource identifier. | If errors occur: Use records.search to resolve IDs before calling.",
+      "description": "Search records using relationship anchors (list, company, people). | Does not: modify memberships; use list tools for writes. | Requires resource_type and related resource identifier. | If errors occur: Use search_records to resolve IDs before calling.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1291,7 +1291,7 @@
     },
     {
       "name": "records_search_by_timeframe",
-      "description": "Filter records by creation, update, or interaction timeframes. | Does not: modify lifecycle state or scheduling follow-ups. | Requires resource_type; provide timeframe or explicit date boundaries. | If errors occur: Call records.search if timeframe filters are too restrictive.",
+      "description": "Filter records by creation, update, or interaction timeframes. | Does not: modify lifecycle state or scheduling follow-ups. | Requires resource_type; provide timeframe or explicit date boundaries. | If errors occur: Call search_records if timeframe filters are too restrictive.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1376,7 +1376,7 @@
     },
     {
       "name": "search",
-      "description": "Simple search by query string across companies, people, lists, and tasks. For advanced filtering, date ranges, or relationships, use records.search instead.",
+      "description": "Simple search by query string across companies, people, lists, and tasks. For advanced filtering, date ranges, or relationships, use search_records instead.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/docs/tools/tool-quality-standards.md
+++ b/docs/tools/tool-quality-standards.md
@@ -4,7 +4,8 @@ This guide captures the engineering guardrails introduced in Issue #776 Phase 0.
 
 ## 1. Naming & Aliases
 
-- **Verb-first pattern**: Follow `<resource>.<action>` (e.g., `people.search`, `deals.update_stage`). See `src/handlers/tools/standards/index.ts` for the template.
+- **Canonical pattern**: Prefer verb-first snake_case names exposed by the active registry (e.g., `search_records`, `update_record`, `discover_record_attributes`). See `src/constants/tool-names.ts` for canonical universal names and `src/handlers/tools/registry.ts` for the exposed tool surface.
+- **Prompt-facing examples**: Bundled prompts and docs should teach canonical exposed names, not deprecated aliases or dotted pseudo-tools.
 - **Alias registry**: `src/config/tool-aliases.ts` holds deprecated → canonical mappings.
   - Aliases are enabled by default; set `MCP_DISABLE_TOOL_ALIASES=true` to disable at runtime.
   - Every alias entry must document `target`, optional `reason`, and planned `removal` release.
@@ -30,7 +31,7 @@ This guide captures the engineering guardrails introduced in Issue #776 Phase 0.
 
 ## 4. Automation & CI
 
-- **Schema linter**: `npm run lint:tools` executes `scripts/tool-schema-lint.ts` against all tool definitions.
+- **Schema linter**: `bun run lint:tools` executes `scripts/tool-schema-lint.ts` against all tool definitions.
   - Default mode records errors but exits 0; set `MCP_TOOL_LINT_MODE=strict` locally/CI to fail on violations.
   - Phase 1+ must drive error count toward zero as tools are remediated.
 - **Discovery snapshot**: `scripts/generate-tools-snapshot.ts` writes `docs/tools/tool-discovery-baseline.json` for golden tests and quick diffing.
@@ -48,7 +49,7 @@ This guide captures the engineering guardrails introduced in Issue #776 Phase 0.
 - [ ] Update descriptions with capability/boundary/recovery segments.
 - [ ] Ensure schemas declare `additionalProperties`, examples, enums, and pagination hints as needed.
 - [ ] Add/update tests (golden discovery snapshot, routing smoke tests, targeted unit suites).
-- [ ] Run `npm run lint:tools` (consider `MCP_TOOL_LINT_MODE=strict`) and resolve new violations.
+- [ ] Run `bun run lint:tools` (consider `MCP_TOOL_LINT_MODE=strict`) and resolve new violations.
 - [ ] Update documentation (developer guide, migration notes) and reference acceptance criteria in PR.
 
 Keep this document tight; revise it at the end of each phase after we harden additional quality gates.

--- a/src/handlers/tool-configs/lists.ts
+++ b/src/handlers/tool-configs/lists.ts
@@ -253,7 +253,7 @@ export const listsToolDefinitions = [
       constraints:
         'Requires recordId; processes 5 lists in parallel by default (max 20).',
       recoveryHint:
-        'If record not found, verify recordId with records_search first.',
+        'If record not found, verify recordId with search_records first.',
     }),
     inputSchema: {
       type: 'object',
@@ -900,7 +900,7 @@ ${formatToolDescription({
   boundaries: 'search multiple lists or modify records.',
   constraints:
     'Requires listId, parentObjectType, parentAttributeSlug, condition, value.',
-  recoveryHint: 'Use records_discover_attributes for valid slugs.',
+  recoveryHint: 'Use discover_record_attributes for valid slugs.',
 })}`,
     inputSchema: {
       type: 'object',

--- a/src/handlers/tool-configs/openai/index.ts
+++ b/src/handlers/tool-configs/openai/index.ts
@@ -142,11 +142,11 @@ export const openAiToolDefinitions = {
       capability:
         'Run lightweight compatibility search across companies, people, lists, and tasks for ChatGPT MCP.',
       boundaries:
-        'support complex filters, batch queries, or return rich record payloads (use records_search* tools).',
+        'support complex filters, batch queries, or return rich record payloads (use search_records* tools).',
       constraints:
         'Requires query string (min 1 char); optional type filter; limit up to 25 results per call.',
       recoveryHint:
-        'When you need pagination or attribute filtering, switch to records_search or records_search_advanced.',
+        'When you need pagination or attribute filtering, switch to search_records or search_records_advanced.',
     }),
     inputSchema: searchInputSchema,
     annotations: {

--- a/src/handlers/tool-configs/universal/batch-search.ts
+++ b/src/handlers/tool-configs/universal/batch-search.ts
@@ -215,10 +215,10 @@ export const batchSearchToolDefinition = {
     capability:
       'Execute multiple searches in parallel and return grouped results.',
     boundaries:
-      'mutate or import data; use records.batch for write operations.',
+      'mutate or import data; use batch_records for write operations.',
     constraints:
       'Provide queries array (1–10 items recommended) and resource_type.',
-    recoveryHint: 'If queries fail, retry individually using records.search.',
+    recoveryHint: 'If queries fail, retry individually using search_records.',
   }),
   inputSchema: batchSearchSchema,
   annotations: {

--- a/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
+++ b/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
@@ -68,7 +68,7 @@ import {
  *
  * @example
  * createErrorResult(
- *   "Missing required field: stage. Valid options: MQL, SQL, Demo. Use records_get_attribute_options to see all.",
+ *   "Missing required field: stage. Valid options: MQL, SQL, Demo. Use get_record_attribute_options to see all.",
  *   "validation_error",
  *   { context: { operation: "create", resourceType: "deals" } }
  * )

--- a/src/handlers/tool-configs/universal/core/crud-operations.ts
+++ b/src/handlers/tool-configs/universal/core/crud-operations.ts
@@ -315,7 +315,7 @@ export const createRecordDefinition = {
       'Requires resource_type plus record_data that matches discover_record_attributes output.',
     requiresApproval: true,
     recoveryHint:
-      'If validation fails, call records_discover_attributes to confirm required fields and enums. If a select/status value is rejected, call records_get_attribute_options for that attribute to list valid options before retrying.',
+      'If validation fails, call discover_record_attributes to confirm required fields and enums. If a select/status value is rejected, call get_record_attribute_options for that attribute to list valid options before retrying.',
   }),
   inputSchema: createRecordSchema,
   annotations: {
@@ -334,7 +334,7 @@ export const updateRecordDefinition = {
       'Requires resource_type, record_id, and record_data; supports partial updates with schema validation.',
     requiresApproval: true,
     recoveryHint:
-      'Call records_get_details first to inspect the latest values before editing. If a select/status value is rejected, call records_get_attribute_options for that attribute to list valid options.',
+      'Call get_record_details first to inspect the latest values before editing. If a select/status value is rejected, call get_record_attribute_options for that attribute to list valid options.',
   }),
   inputSchema: updateRecordSchema,
   annotations: {
@@ -354,7 +354,7 @@ export const deleteRecordDefinition = {
       'Requires record_id and resource_type; operation is irreversible once confirmed.',
     requiresApproval: true,
     recoveryHint:
-      'If uncertain, fetch with records_get_details to confirm the target before deletion.',
+      'If uncertain, fetch with get_record_details to confirm the target before deletion.',
   }),
   inputSchema: deleteRecordSchema,
   annotations: {

--- a/src/handlers/tool-configs/universal/core/detailed-info-operations.ts
+++ b/src/handlers/tool-configs/universal/core/detailed-info-operations.ts
@@ -88,8 +88,7 @@ export const getDetailedInfoDefinition = {
     boundaries: 'search lists of records or mutate data.',
     constraints:
       'Requires resource_type, record_id, and info_type (contact|business|social).',
-    recoveryHint:
-      'Use records.get_details if you need the full record payload.',
+    recoveryHint: 'Use get_record_details if you need the full record payload.',
   }),
   inputSchema: getDetailedInfoSchema,
   annotations: {

--- a/src/handlers/tool-configs/universal/core/error-enhancers/attribute-enhancer.ts
+++ b/src/handlers/tool-configs/universal/core/error-enhancers/attribute-enhancer.ts
@@ -115,7 +115,7 @@ const enhanceAttributeNotFoundError = async (
       message += `Did you mean: ${suggestions.map((s) => `"${s}"`).join(', ')}?\n\n`;
     }
 
-    message += `Next step: Call records_discover_attributes with\n`;
+    message += `Next step: Call discover_record_attributes with\n`;
     message += `  resource_type: "${resourceType}"\n`;
     message += `to see all valid attributes.`;
 
@@ -134,7 +134,7 @@ const enhanceAttributeNotFoundError = async (
     );
     return (
       `Attribute "${invalidAttr}" does not exist on ${resourceType}.\n\n` +
-      `Next step: Use records_discover_attributes to see valid attributes.`
+      `Next step: Use discover_record_attributes to see valid attributes.`
     );
   }
 };

--- a/src/handlers/tool-configs/universal/core/error-enhancers/required-fields-enhancer.ts
+++ b/src/handlers/tool-configs/universal/core/error-enhancers/required-fields-enhancer.ts
@@ -72,7 +72,7 @@ const buildMissingDealStageMessage = async (
     return (
       `Required field "stage" is missing for deals.\n\n` +
       `Common stage values: ${preview}${hasMore}\n\n` +
-      `For the full list, call: records_get_attribute_options(resource_type="deals", attribute="stage").`
+      `For the full list, call: get_record_attribute_options(resource_type="deals", attribute="stage").`
     );
   } catch (err) {
     sanitizedLog(
@@ -88,7 +88,7 @@ const buildMissingDealStageMessage = async (
     );
     return (
       `Required field "stage" is missing for deals.\n\n` +
-      `Call records_get_attribute_options(resource_type="deals", attribute="stage") to retrieve valid stage values, then retry.`
+      `Call get_record_attribute_options(resource_type="deals", attribute="stage") to retrieve valid stage values, then retry.`
     );
   }
 };

--- a/src/handlers/tool-configs/universal/core/error-enhancers/select-status-enhancer.ts
+++ b/src/handlers/tool-configs/universal/core/error-enhancers/select-status-enhancer.ts
@@ -48,7 +48,7 @@ const enhanceSelectStatusError = async (
           return `Value is not valid for ${attributeType} attribute "${selectErr.field}" on ${resourceType}.
 Expected one of: ${validList}${hasMore}
 
-Next step: Call records_get_attribute_options with
+Next step: Call get_record_attribute_options with
   resource_type: "${resourceType}"
   attribute: "${selectErr.field}"
 to list all valid values, then retry.`;
@@ -65,7 +65,7 @@ to list all valid values, then retry.`;
             }
           );
           return `Value is not valid for attribute "${selectErr.field}" on ${resourceType}.
-Next step: Call records_get_attribute_options with
+Next step: Call get_record_attribute_options with
   resource_type: "${resourceType}"
   attribute: "${selectErr.field}"
 to see valid options, then retry.`;
@@ -102,7 +102,7 @@ to see valid options, then retry.`;
         return (
           `Value "${invalidValue}" is not valid for ${attributeType} attribute "${fieldName}" on ${resourceType}.\n\n` +
           `Valid options: ${validList}${hasMore}\n\n` +
-          `Next step: Call records_get_attribute_options with\n` +
+          `Next step: Call get_record_attribute_options with\n` +
           `  resource_type: "${resourceType}"\n` +
           `  attribute: "${fieldName}"\n` +
           `to list all valid values, then retry.`
@@ -121,7 +121,7 @@ to see valid options, then retry.`;
         );
         return (
           `Value "${invalidValue}" is not valid for attribute "${fieldName}" on ${resourceType}.\n\n` +
-          `Next step: Call records_get_attribute_options with\n` +
+          `Next step: Call get_record_attribute_options with\n` +
           `  resource_type: "${resourceType}"\n` +
           `  attribute: "${fieldName}"\n` +
           `to see valid options, then retry.`
@@ -133,7 +133,7 @@ to see valid options, then retry.`;
   // Couldn't match to a specific field, return generic hint
   return (
     `Value "${invalidValue}" is not valid for an attribute on ${resourceType}.\n\n` +
-    `Next step: Use records_get_attribute_options to discover valid options for the attribute.`
+    `Next step: Use get_record_attribute_options to discover valid options for the attribute.`
   );
 };
 

--- a/src/handlers/tool-configs/universal/core/error-enhancers/uniqueness-enhancer.ts
+++ b/src/handlers/tool-configs/universal/core/error-enhancers/uniqueness-enhancer.ts
@@ -119,7 +119,7 @@ function formatUniquenessErrorMessage(
     `EXISTING RECORD ID: ${recordId}\n\n` +
     `OPTIONS:\n` +
     `1. Update existing: update-record(resource_type="${resourceType}", record_id="${recordId}", record_data={...})\n` +
-    `2. View existing: records_get_details(resource_type="${resourceType}", record_id="${recordId}")\n` +
+    `2. View existing: get_record_details(resource_type="${resourceType}", record_id="${recordId}")\n` +
     `3. Use a different ${field} value`
   );
 }

--- a/src/handlers/tool-configs/universal/core/metadata-operations.ts
+++ b/src/handlers/tool-configs/universal/core/metadata-operations.ts
@@ -266,7 +266,7 @@ export const getAttributesDefinition = {
     boundaries: 'modify schema definitions or record data.',
     constraints: 'Requires resource_type; optional categories narrows groups.',
     recoveryHint:
-      'Use records.discover_attributes for grouped schema discovery.',
+      'Use discover_record_attributes for grouped schema discovery.',
   }),
   inputSchema: getAttributesSchema,
   annotations: {

--- a/src/handlers/tool-configs/universal/core/notes-operations.ts
+++ b/src/handlers/tool-configs/universal/core/notes-operations.ts
@@ -173,7 +173,7 @@ export const createNoteDefinition = {
     requiresApproval: true,
     constraints:
       'Requires resource_type, record_id, title, content. Set format="markdown" for rich formatting: headings (# ## ###), lists (- or 1.), nested bullets (2-space indent), bold (**text**), code blocks. Use \\n for line breaks.',
-    recoveryHint: 'If record not found, use records_search first.',
+    recoveryHint: 'If record not found, use search_records first.',
   }),
   inputSchema: createNoteSchema,
   annotations: {
@@ -188,7 +188,7 @@ export const listNotesDefinition = {
     capability: 'Retrieve notes for a record with timestamps.',
     boundaries: 'create or modify notes; read-only.',
     constraints: 'Requires resource_type, record_id; sorted by creation date.',
-    recoveryHint: 'If empty, verify record has notes with records_get_details.',
+    recoveryHint: 'If empty, verify record has notes with get_record_details.',
   }),
   inputSchema: listNotesSchema,
   annotations: {

--- a/src/handlers/tool-configs/universal/core/record-details-operations.ts
+++ b/src/handlers/tool-configs/universal/core/record-details-operations.ts
@@ -216,10 +216,10 @@ export const getRecordDetailsDefinition = {
   description: formatToolDescription({
     capability: 'Fetch a single record with enriched attribute formatting.',
     boundaries:
-      'search or filter result sets; use records.search* tools instead.',
+      'search or filter result sets; use search_records tools instead.',
     constraints:
       'Requires resource_type and record_id; optional fields filter output.',
-    recoveryHint: 'Validate record IDs with records.search before retrying.',
+    recoveryHint: 'Validate record IDs with search_records before retrying.',
   }),
   inputSchema: getRecordDetailsSchema,
   annotations: {

--- a/src/handlers/tool-configs/universal/field-mapper/validators/field-validator.ts
+++ b/src/handlers/tool-configs/universal/field-mapper/validators/field-validator.ts
@@ -22,7 +22,7 @@ function getRequiredFieldErrorMessage(
   if (resourceType === UniversalResourceType.DEALS && fieldName === 'stage') {
     // Don't hard-code stage examples - they vary by workspace
     // Instead, guide users to discover valid options
-    return `${baseMessage}. Tip: Use records_get_attribute_options(resource_type="deals", attribute="stage") to see valid stages for your workspace.`;
+    return `${baseMessage}. Tip: Use get_record_attribute_options(resource_type="deals", attribute="stage") to see valid stages for your workspace.`;
   }
 
   if (resourceType === UniversalResourceType.DEALS && fieldName === 'name') {

--- a/src/handlers/tool-configs/universal/operations/index.ts
+++ b/src/handlers/tool-configs/universal/operations/index.ts
@@ -32,11 +32,11 @@ export const advancedOperationsToolDefinitions = {
     description: formatToolDescription({
       capability:
         'Search companies, people, deals, or tasks with complex nested filters (e.g., find deals by owner+stage, companies by industry+location).',
-      boundaries: 'mutate records; use records.update or records.delete.',
+      boundaries: 'mutate records; use update_record or delete_record.',
       constraints:
         'Supports filter groups, scoring, pagination, and up to 100 items. Requires resource_type parameter.',
       recoveryHint:
-        'If filters fail, fetch valid attributes via records.discover_attributes.',
+        'If filters fail, fetch valid attributes via discover_record_attributes.',
     }),
     inputSchema: advancedSearchSchema,
     annotations: {
@@ -51,7 +51,7 @@ export const advancedOperationsToolDefinitions = {
         'Search records using relationship anchors (list, company, people).',
       boundaries: 'modify memberships; use list tools for writes.',
       constraints: 'Requires resource_type and related resource identifier.',
-      recoveryHint: 'Use records.search to resolve IDs before calling.',
+      recoveryHint: 'Use search_records to resolve IDs before calling.',
     }),
     inputSchema: searchByRelationshipSchema,
     annotations: {
@@ -67,7 +67,7 @@ export const advancedOperationsToolDefinitions = {
       constraints:
         'Requires resource_type and content_query; optional fields array.',
       recoveryHint:
-        'Narrow scope with fields or switch to records.search_advanced.',
+        'Narrow scope with fields or switch to search_records_advanced.',
     }),
     inputSchema: searchByContentSchema,
     annotations: {
@@ -84,7 +84,7 @@ export const advancedOperationsToolDefinitions = {
       constraints:
         'Requires resource_type; provide timeframe or explicit date boundaries.',
       recoveryHint:
-        'Call records.search if timeframe filters are too restrictive.',
+        'Call search_records if timeframe filters are too restrictive.',
     }),
     inputSchema: searchByTimeframeSchema,
     annotations: {
@@ -102,7 +102,7 @@ export const advancedOperationsToolDefinitions = {
       constraints:
         'Use scoped single-record tools for one company or deal write. operation_type must be specified for legacy payloads; operations arrays must use explicit create/update/delete entries.',
       recoveryHint:
-        'Run records.search first to stage IDs or payloads for batching.',
+        'Run search_records first to stage IDs or payloads for batching.',
     }),
     inputSchema: batchOperationsSchema,
     annotations: {

--- a/src/handlers/tool-configs/universal/operations/relationship-search.ts
+++ b/src/handlers/tool-configs/universal/operations/relationship-search.ts
@@ -80,7 +80,7 @@ export const searchByRelationshipConfig: UniversalToolConfig<
           throw new Error(
             `Task relationship search (${relationship_type}) is not currently available. ` +
               `This feature requires enhanced API filtering capabilities. ` +
-              `As a workaround, you can use the 'records_search' tool with resource_type='tasks' to find all tasks, ` +
+              `As a workaround, you can use the 'search_records' tool with resource_type='tasks' to find all tasks, ` +
               `then filter the results programmatically.`
           );
 

--- a/src/handlers/tool-configs/universal/shared-handlers.ts
+++ b/src/handlers/tool-configs/universal/shared-handlers.ts
@@ -572,7 +572,7 @@ export async function handleUniversalGetAttributeOptions(
   // TODO: Add list_id parameter to support list attributes (see plan Phase 3B)
   if (resource_type === UniversalResourceType.LISTS) {
     throw new Error(
-      'records_get_attribute_options does not yet support list attributes. ' +
+      'get_record_attribute_options does not yet support list attributes. ' +
         'Use get-list-details to inspect list attribute schemas instead.'
     );
   }
@@ -660,7 +660,7 @@ export async function handleUniversalGetAttributeOptions(
             : '';
         throw new Error(
           `Attribute "${attribute}" not found on ${objectSlug}.${suggestionText}\n\n` +
-            `Use API slugs (e.g., "stage" not "Deal stage"). Run records_discover_attributes(resource_type="${objectSlug}") to see available attribute slugs.`
+            `Use API slugs (e.g., "stage" not "Deal stage"). Run discover_record_attributes(resource_type="${objectSlug}") to see available attribute slugs.`
         );
       }
     } catch (resolutionError) {
@@ -671,7 +671,7 @@ export async function handleUniversalGetAttributeOptions(
 
     throw new Error(
       `${errorMsg}\n\nTip: Use the API slug (e.g., "stage") not the display name (e.g., "Deal stage"). ` +
-        `Run records_discover_attributes to see available attribute slugs.`
+        `Run discover_record_attributes to see available attribute slugs.`
     );
   }
 }

--- a/src/prompts/v1/add-to-list.v1.ts
+++ b/src/prompts/v1/add-to-list.v1.ts
@@ -1,7 +1,7 @@
 /**
  * Add to List v1 Prompt
  *
- * Add person/company/deal(s) to a chosen List by exact name or ID.
+ * Add person/company record(s) to a chosen List by exact name or ID.
  */
 
 import { z } from 'zod';
@@ -15,7 +15,7 @@ export const AddToListArgs = z.object({
   records: z
     .string()
     .min(3)
-    .describe('Comma-separated record URLs, IDs, or "search:<query>"'),
+    .describe('Comma-separated person/company URLs, IDs, or "search:<query>"'),
   list: z.string().min(2).describe('List name or ID to add records to'),
   dry_run: DryRunArg,
 });
@@ -28,7 +28,7 @@ export type AddToListArgsType = z.infer<typeof AddToListArgs>;
 export const addToListArguments: PromptArgument[] = [
   {
     name: 'records',
-    description: 'Comma-separated records or "search:<query>"',
+    description: 'Comma-separated person/company records or "search:<query>"',
     required: true,
     schema: z.string().min(3),
   },
@@ -61,6 +61,7 @@ Steps:
 1. Resolve records: Parse "${validated.records}" (comma-separated). For each:
    - If URL or ID: use directly
    - If starts with "search:": call \`search_records\` with the right resource_type to resolve
+   - Only companies and people are supported for list-entry adds. If a deal is requested, explain that this list tool cannot add deals and STOP.
    If ambiguous, disambiguate with user.
 
 2. Resolve list: If "${validated.list}" is not a UUID, call \`search_records\` with resource_type="lists" to find one list by exact name.
@@ -68,7 +69,7 @@ Steps:
 3. Call \`manage-list-entry\` with Mode 1 (add) parameters:
    - List ID from step 2
    - Each record ID from step 1
-   - objectType matching each record's resource type
+   - objectType matching each record's supported resource type ("companies" or "people")
 
 ${validated.dry_run ? 'DRY RUN MODE: Output proposed tool call as JSON only. Do NOT execute write.' : 'Execute the list addition after showing proposed action.'}
 

--- a/src/prompts/v1/add-to-list.v1.ts
+++ b/src/prompts/v1/add-to-list.v1.ts
@@ -60,14 +60,14 @@ export function buildAddToListMessages(
 Steps:
 1. Resolve records: Parse "${validated.records}" (comma-separated). For each:
    - If URL or ID: use directly
-   - If starts with "search:": call \`records_query\` to resolve
+   - If starts with "search:": call \`search_records\` with the right resource_type to resolve
    If ambiguous, disambiguate with user.
 
-2. Resolve list: If "${validated.list}" is not a UUID, call \`lists.list\` to find list by name (exact match).
+2. Resolve list: If "${validated.list}" is not a UUID, call \`get-lists\` to find list by name (exact match).
 
-3. Call \`lists.add_entries\` (or \`entries.create\`) with:
+3. Call \`add-record-to-list\` with:
    - List ID from step 2
-   - Record IDs from step 1 (array)
+   - Each record ID from step 1
 
 ${validated.dry_run ? 'DRY RUN MODE: Output proposed tool call as JSON only. Do NOT execute write.' : 'Execute the list addition after showing proposed action.'}
 

--- a/src/prompts/v1/add-to-list.v1.ts
+++ b/src/prompts/v1/add-to-list.v1.ts
@@ -63,11 +63,12 @@ Steps:
    - If starts with "search:": call \`search_records\` with the right resource_type to resolve
    If ambiguous, disambiguate with user.
 
-2. Resolve list: If "${validated.list}" is not a UUID, call \`get-lists\` to find list by name (exact match).
+2. Resolve list: If "${validated.list}" is not a UUID, call \`search_records\` with resource_type="lists" to find one list by exact name.
 
-3. Call \`add-record-to-list\` with:
+3. Call \`manage-list-entry\` with Mode 1 (add) parameters:
    - List ID from step 2
    - Each record ID from step 1
+   - objectType matching each record's resource type
 
 ${validated.dry_run ? 'DRY RUN MODE: Output proposed tool call as JSON only. Do NOT execute write.' : 'Execute the list addition after showing proposed action.'}
 

--- a/src/prompts/v1/add-to-list.v1.ts
+++ b/src/prompts/v1/add-to-list.v1.ts
@@ -66,9 +66,9 @@ Steps:
 
 2. Resolve list: If "${validated.list}" is not a UUID, call \`search_records\` with resource_type="lists" to find one list by exact name.
 
-3. Call \`manage-list-entry\` with Mode 1 (add) parameters:
+3. For each resolved record, call \`manage-list-entry\` once with Mode 1 (add) parameters:
    - List ID from step 2
-   - Each record ID from step 1
+   - One recordId from step 1
    - objectType matching each record's supported resource type ("companies" or "people")
 
 ${validated.dry_run ? 'DRY RUN MODE: Output proposed tool call as JSON only. Do NOT execute write.' : 'Execute the list addition after showing proposed action.'}
@@ -94,7 +94,7 @@ export const addToListPrompt: PromptV1Definition = {
     name: 'add_to_list.v1',
     title: 'Add records to list',
     description:
-      'Add person/company/deal(s) to a chosen List by exact name or ID.',
+      'Add person/company record(s) to a chosen List by exact name or ID.',
     category: 'workflow',
     version: 'v1',
   },

--- a/src/prompts/v1/advance-deal.v1.ts
+++ b/src/prompts/v1/advance-deal.v1.ts
@@ -70,13 +70,13 @@ export function buildAdvanceDealMessages(
   const instructions = `You are a CRM assistant. Advance deal "${validated.deal}" to stage "${validated.target_stage}".
 
 Steps:
-1. Resolve deal: If starts with "search:", call \`records_query\` to find one deal. If multiple matches, disambiguate.
+1. Resolve deal: If starts with "search:", call \`search_records\` with resource_type="deals" to find one deal. If multiple matches, disambiguate.
 
-2. Call \`deals.update\` (or \`records.update\` for object='deals') with:
+2. Call \`update_record\` with resource_type="deals" and:
    - Record ID from step 1
-   - stage: "${validated.target_stage}"
+   - record_data.stage: "${validated.target_stage}"
 
-3. ${validated.create_task ? 'Suggest a concrete next-action task based on the new stage and, only on approval, call `tasks.create`.' : 'No follow-up task needed.'}
+3. ${validated.create_task ? 'Suggest a concrete next-action task based on the new stage and, only on approval, call `create_record` with resource_type="tasks".' : 'No follow-up task needed.'}
 
 ${validated.dry_run ? 'DRY RUN MODE: Output proposed tool calls as JSON only. Do NOT execute writes.' : 'Execute the stage change after showing proposed action.'}
 

--- a/src/prompts/v1/company-search.v1.ts
+++ b/src/prompts/v1/company-search.v1.ts
@@ -82,7 +82,7 @@ export function buildCompanySearchMessages(
 ): PromptMessage[] {
   const validated = CompanySearchArgs.parse(args);
 
-  const instructions = `Call \`records_query\` for object='companies' with filters derived from "${validated.query}".
+  const instructions = `Call \`search_records\` with resource_type="companies" and filters derived from "${validated.query}".
 
 Output format=${validated.format}:
 - If table: Markdown table with columns: id, name, domain, industry, employee_count, region, owner (max ${validated.limit} rows)

--- a/src/prompts/v1/create-task.v1.ts
+++ b/src/prompts/v1/create-task.v1.ts
@@ -99,7 +99,7 @@ export function buildCreateTaskMessages(
   const validated = CreateTaskArgs.parse(args);
 
   const targetResolution = validated.target
-    ? `\n1. Resolve target: If target="${validated.target}" starts with "search:", call \`records_query\` to find one record. If multiple matches, disambiguate.`
+    ? `\n1. Resolve target: If target="${validated.target}" starts with "search:", call \`search_records\` with the right resource_type to find one record. If multiple matches, disambiguate.`
     : '';
 
   const dueDateParsing = validated.due_date
@@ -112,7 +112,7 @@ export function buildCreateTaskMessages(
 - Priority: ${validated.priority}
 - Owner: ${validated.owner}${dueDateParsing}${targetResolution}
 
-${targetResolution ? '2' : '1'}. Call \`tasks.create\` with:
+${targetResolution ? '2' : '1'}. Call \`create_record\` with resource_type="tasks" and record_data:
    - title, content (required)
    - assignees: [owner]
    - deadline: parsed due_date (if provided)

--- a/src/prompts/v1/create-task.v1.ts
+++ b/src/prompts/v1/create-task.v1.ts
@@ -115,8 +115,8 @@ export function buildCreateTaskMessages(
 ${targetResolution ? '2' : '1'}. Call \`create_record\` with resource_type="tasks" and record_data:
    - title, content (required)
    - assignees: [owner]
-   - deadline: parsed due_date (if provided)
-   - linked_records: [resolved target] (if provided)
+   - deadline_at: parsed due_date (if provided)
+   - linked_records: [{ target_object: resolved target resource type, target_record_id: resolved target record ID }] (if provided)
 
 ${validated.dry_run ? 'DRY RUN MODE: Output proposed tool call as JSON only. Do NOT execute write.' : 'Execute the task creation after showing proposed action.'}
 

--- a/src/prompts/v1/deal-search.v1.ts
+++ b/src/prompts/v1/deal-search.v1.ts
@@ -80,7 +80,7 @@ export function buildDealSearchMessages(
 ): PromptMessage[] {
   const validated = DealSearchArgs.parse(args);
 
-  const instructions = `Call \`records_query\` for object='deals' with filters derived from "${validated.query}".
+  const instructions = `Call \`search_records\` with resource_type="deals" and filters derived from "${validated.query}".
 
 Output format=${validated.format}:
 - If table: Markdown table with columns: id, name, stage, value, close_date, owner, company (max ${validated.limit} rows)

--- a/src/prompts/v1/log-activity.v1.ts
+++ b/src/prompts/v1/log-activity.v1.ts
@@ -92,15 +92,15 @@ export function buildLogActivityMessages(
   const instructions = `You are a CRM assistant. Log a ${validated.type} activity to "${validated.target}".
 
 Steps:
-1. Resolve target: If starts with "search:", call \`records_query\` to find one record (prefer exact domain/email or name match). If multiple matches, list up to 5 for disambiguation and STOP.
+1. Resolve target: If starts with "search:", call \`search_records\` with the right resource_type to find one record (prefer exact domain/email or name match). If multiple matches, list up to 5 for disambiguation and STOP.
 
-2. Create activity note: Call \`notes.create\` (or appropriate write tool) with:
+2. Create activity note: Call \`create_note\` (or appropriate write tool) with:
    - Type: ${validated.type}
    - Summary: "${validated.summary}"
    - Visibility: ${validated.visibility}
    - Link to resolved record
 
-3. ${validated.create_follow_up ? 'Suggest a concrete follow-up task and, only on approval, call `tasks.create`.' : 'No follow-up task needed.'}
+3. ${validated.create_follow_up ? 'Suggest a concrete follow-up task and, only on approval, call `create_record` with resource_type="tasks".' : 'No follow-up task needed.'}
 
 ${validated.dry_run ? 'DRY RUN MODE: Output proposed tool calls as JSON only. Do NOT execute writes.' : 'Execute the writes after showing proposed actions.'}
 

--- a/src/prompts/v1/log-activity.v1.ts
+++ b/src/prompts/v1/log-activity.v1.ts
@@ -94,11 +94,12 @@ export function buildLogActivityMessages(
 Steps:
 1. Resolve target: If starts with "search:", call \`search_records\` with the right resource_type to find one record (prefer exact domain/email or name match). If multiple matches, list up to 5 for disambiguation and STOP.
 
-2. Create activity note: Call \`create_note\` (or appropriate write tool) with:
-   - Type: ${validated.type}
-   - Summary: "${validated.summary}"
-   - Visibility: ${validated.visibility}
-   - Link to resolved record
+2. Create activity note: Call \`create_note\` with:
+   - resource_type: resolved target resource type
+   - record_id: resolved target record ID
+   - title: "${validated.type}: activity"
+   - content: "${validated.summary}" plus "Visibility: ${validated.visibility}"
+   - format: "plaintext"
 
 3. ${validated.create_follow_up ? 'Suggest a concrete follow-up task and, only on approval, call `create_record` with resource_type="tasks".' : 'No follow-up task needed.'}
 

--- a/src/prompts/v1/meeting-prep.v1.ts
+++ b/src/prompts/v1/meeting-prep.v1.ts
@@ -66,12 +66,12 @@ export function buildMeetingPrepMessages(
   const instructions = `Goal: Create a 360° meeting prep sheet for ${validated.target}.
 
 Steps:
-1. Resolve target: If starts with "search:", call \`records_query\` to find one Person or Company record (prefer exact domain/email or name match). If multiple matches, list up to 5 for disambiguation and STOP.
+1. Resolve target: If starts with "search:", call \`search_records\` with resource_type="people" or resource_type="companies" to find one record (prefer exact domain/email or name match). If multiple matches, list up to 5 for disambiguation and STOP.
 
 2. Gather context (call these in parallel):
-   - \`notes.list\` for the record (last 5 notes)
-   - \`tasks.list\` for the record (open tasks only)
-   - \`deals.list\` for related deals (active deals)
+   - \`list_notes\` for the record (last 5 notes)
+   - \`search_records\` with resource_type="tasks" for open tasks
+   - \`search_records\` with resource_type="deals" for related active deals
 
 3. Output format=${validated.format}:
    - If table: Markdown sections: "Contact Info", "Recent Notes", "Open Tasks", "Active Deals", "Suggested Agenda"

--- a/src/prompts/v1/meeting-prep.v1.ts
+++ b/src/prompts/v1/meeting-prep.v1.ts
@@ -70,8 +70,9 @@ Steps:
 
 2. Gather context (call these in parallel):
    - \`list_notes\` for the record (last 5 notes)
-   - \`search_records\` with resource_type="tasks" for candidate tasks, then keep only open/not-completed statuses from the returned task fields
-   - \`search_records\` with resource_type="deals" for related active deals
+   - \`get_record_details\` for the resolved record with relationships included when supported
+   - \`search_records\` with resource_type="tasks" for candidate tasks, then keep only open/not-completed tasks whose linked_records or related record fields reference the resolved record ID
+   - \`search_records\` with resource_type="deals" for candidate deals, then keep only active deals whose associated people/company fields reference the resolved record ID
 
 3. Output format=${validated.format}:
    - If table: Markdown sections: "Contact Info", "Recent Notes", "Open Tasks", "Active Deals", "Suggested Agenda"

--- a/src/prompts/v1/meeting-prep.v1.ts
+++ b/src/prompts/v1/meeting-prep.v1.ts
@@ -70,7 +70,7 @@ Steps:
 
 2. Gather context (call these in parallel):
    - \`list_notes\` for the record (last 5 notes)
-   - \`search_records\` with resource_type="tasks" for open tasks
+   - \`search_records\` with resource_type="tasks" for candidate tasks, then keep only open/not-completed statuses from the returned task fields
    - \`search_records\` with resource_type="deals" for related active deals
 
 3. Output format=${validated.format}:

--- a/src/prompts/v1/meeting-prep.v1.ts
+++ b/src/prompts/v1/meeting-prep.v1.ts
@@ -71,8 +71,9 @@ Steps:
 2. Gather context (call these in parallel):
    - \`list_notes\` for the record (last 5 notes)
    - \`get_record_details\` for the resolved record with relationships included when supported
-   - \`search_records\` with resource_type="tasks" for candidate tasks, then keep only open/not-completed tasks whose linked_records or related record fields reference the resolved record ID
-   - \`search_records\` with resource_type="deals" for candidate deals, then keep only active deals whose associated people/company fields reference the resolved record ID
+   - Prefer \`search_records_by_relationship\` from the resolved record for related tasks and deals; if relationship lookup is unavailable, paginate and accumulate \`search_records\` candidates before filtering by resolved record ID
+   - Keep only open/not-completed tasks whose linked_records or related record fields reference the resolved record ID
+   - Keep only active deals whose associated people/company fields reference the resolved record ID
 
 3. Output format=${validated.format}:
    - If table: Markdown sections: "Contact Info", "Recent Notes", "Open Tasks", "Active Deals", "Suggested Agenda"

--- a/src/prompts/v1/meeting-prep.v1.ts
+++ b/src/prompts/v1/meeting-prep.v1.ts
@@ -71,8 +71,8 @@ Steps:
 2. Gather context (call these in parallel):
    - \`list_notes\` for the record (last 5 notes)
    - \`get_record_details\` for the resolved record with relationships included when supported
-   - Prefer \`search_records_by_relationship\` from the resolved record for related tasks and deals; if relationship lookup is unavailable, paginate and accumulate \`search_records\` candidates before filtering by resolved record ID
-   - Keep only open/not-completed tasks whose linked_records or related record fields reference the resolved record ID
+   - For tasks, paginate and accumulate \`search_records\` candidates, then keep only open/not-completed tasks whose linked_records or related record fields reference the resolved record ID
+   - For deals, prefer \`search_records_by_relationship\` from the resolved record; if relationship lookup is unavailable, paginate and accumulate \`search_records\` candidates before filtering by resolved record ID
    - Keep only active deals whose associated people/company fields reference the resolved record ID
 
 3. Output format=${validated.format}:

--- a/src/prompts/v1/people-search.v1.ts
+++ b/src/prompts/v1/people-search.v1.ts
@@ -81,7 +81,7 @@ export function buildPeopleSearchMessages(
 ): PromptMessage[] {
   const validated = PeopleSearchArgs.parse(args);
 
-  const instructions = `Call \`records_query\` for object='people' with filters derived from "${validated.query}".
+  const instructions = `Call \`search_records\` with resource_type="people" and filters derived from "${validated.query}".
 
 Output format=${validated.format}:
 - If table: Markdown table with columns: id, name, title, company, email, owner (max ${validated.limit} rows)

--- a/src/prompts/v1/pipeline-health.v1.ts
+++ b/src/prompts/v1/pipeline-health.v1.ts
@@ -92,7 +92,7 @@ export function buildPipelineHealthMessages(
   const instructions = `Goal: Create a pipeline health snapshot for owner="${validated.owner}" over the last ${validated.timeframe}${segmentFilter}.
 
 Steps:
-1. Call \`deals.list\` or \`records_query\` for deals matching: owner="${validated.owner}", modified_date within ${validated.timeframe}${segmentFilter}
+1. Call \`search_records\` with resource_type="deals" for deals matching: owner="${validated.owner}", modified_date within ${validated.timeframe}${segmentFilter}
 
 2. Analyze and categorize deals:
    - Created: New deals in timeframe

--- a/src/prompts/v1/qualify-lead.v1.ts
+++ b/src/prompts/v1/qualify-lead.v1.ts
@@ -124,7 +124,7 @@ ${icpContext}
 Steps:
 1) Resolve \`target\`: If starts with \`search:\`, call \`search_records\` with resource_type="people" or resource_type="companies" to find one record (prefer exact domain/email + title+company). If multiple, list up to 5 for disambiguation and STOP.
 
-2) Build a tiny web plan (token-light): At most ${validated.limit_web} pages total. Prioritize: company homepage (domain), LinkedIn company page, product/pricing page. Call \`search\` only if domain is unknown; otherwise skip search. Call \`fetch\` and extract readable text only (strip nav/boilerplate). Truncate each page to the first ~${WEB_RESEARCH_LIMITS.maxWordsPerPage} words.
+2) Build a tiny web plan (token-light): At most ${validated.limit_web} pages total. Prioritize: company homepage (domain), LinkedIn company page, product/pricing page. Use the host assistant's web browsing/search capability only when available; do not use Attio MCP search/fetch tools for external webpages. Extract readable text only (strip nav/boilerplate). Truncate each page to the first ~${WEB_RESEARCH_LIMITS.maxWordsPerPage} words.
 
 3) Extract key facts for ${validated.framework.toUpperCase()}:
    - Firmographic: industry, employee bucket, region; ICP match

--- a/src/prompts/v1/qualify-lead.v1.ts
+++ b/src/prompts/v1/qualify-lead.v1.ts
@@ -122,9 +122,9 @@ export function buildQualifyLeadMessages(
 ${icpContext}
 
 Steps:
-1) Resolve \`target\`: If starts with \`search:\`, call \`records_query\` to find one Person/Company (prefer exact domain/email + title+company). If multiple, list up to 5 for disambiguation and STOP.
+1) Resolve \`target\`: If starts with \`search:\`, call \`search_records\` with resource_type="people" or resource_type="companies" to find one record (prefer exact domain/email + title+company). If multiple, list up to 5 for disambiguation and STOP.
 
-2) Build a tiny web plan (token-light): At most ${validated.limit_web} pages total. Prioritize: company homepage (domain), LinkedIn company page, product/pricing page. Call \`web.search\` only if domain is unknown; otherwise skip search. Call \`web.fetch\` and extract readable text only (strip nav/boilerplate). Truncate each page to the first ~${WEB_RESEARCH_LIMITS.maxWordsPerPage} words.
+2) Build a tiny web plan (token-light): At most ${validated.limit_web} pages total. Prioritize: company homepage (domain), LinkedIn company page, product/pricing page. Call \`search\` only if domain is unknown; otherwise skip search. Call \`fetch\` and extract readable text only (strip nav/boilerplate). Truncate each page to the first ~${WEB_RESEARCH_LIMITS.maxWordsPerPage} words.
 
 3) Extract key facts for ${validated.framework.toUpperCase()}:
    - Firmographic: industry, employee bucket, region; ICP match
@@ -138,7 +138,7 @@ Steps:
    - If table: return a 2-column table
    Verbosity=${validated.verbosity} → no preamble
 
-5) Propose actions: Suggest a single \`records.update\` and optionally \`tasks.create\`. ${validated.dry_run ? 'Output proposed tool call(s) as JSON only.' : 'Ask for approval before any write.'}
+5) Propose actions: Suggest a single \`update_record\` and optionally \`create_record\` with resource_type="tasks". ${validated.dry_run ? 'Output proposed tool call(s) as JSON only.' : 'Ask for approval before any write.'}
 
 Constraints: Pages ≤ ${validated.limit_web}, each ≤ ~${WEB_RESEARCH_LIMITS.maxWordsPerPage} words; evidence max ${WEB_RESEARCH_LIMITS.maxEvidence}. Keep answers short and structured; no raw dumps; JSON under ~120 lines. MORE_AVAILABLE: true when results exceed limits.`;
 

--- a/test/handlers/tool-configs/universal/core/crud-error-handlers.test.ts
+++ b/test/handlers/tool-configs/universal/core/crud-error-handlers.test.ts
@@ -314,7 +314,7 @@ describe('crud-error-handlers', () => {
         )
       ).rejects.toMatchObject({
         name: 'attribute_not_found',
-        message: expect.stringContaining('records_discover_attributes'),
+        message: expect.stringContaining('discover_record_attributes'),
       });
     });
   });
@@ -399,7 +399,7 @@ describe('crud-error-handlers', () => {
       ).rejects.toMatchObject({
         name: 'duplicate_error',
         message: expect.stringMatching(
-          /OPTIONS.*update-record.*records_get_details/s
+          /OPTIONS.*update-record.*get_record_details/s
         ),
       });
     });

--- a/test/handlers/tool-configs/universal/core/error-enhancers/attribute-enhancer.test.ts
+++ b/test/handlers/tool-configs/universal/core/error-enhancers/attribute-enhancer.test.ts
@@ -98,7 +98,7 @@ describe('attribute-enhancer', () => {
       expect(result).toContain('Attribute "compny_name" does not exist');
       expect(result).toContain('Did you mean:');
       expect(result).toContain('"company_name"');
-      expect(result).toContain('records_discover_attributes');
+      expect(result).toContain('discover_record_attributes');
       expect(result).toContain('resource_type: "companies"');
       expect(mockHandleUniversalDiscoverAttributes).toHaveBeenCalledWith(
         'companies'
@@ -184,7 +184,7 @@ describe('attribute-enhancer', () => {
 
       expect(result).toContain('Attribute "xyz_abc_123" does not exist');
       expect(result).not.toContain('Did you mean:');
-      expect(result).toContain('records_discover_attributes');
+      expect(result).toContain('discover_record_attributes');
     });
 
     it('should be case-insensitive when finding similar attributes', async () => {
@@ -255,7 +255,7 @@ describe('attribute-enhancer', () => {
         'Attribute "completely_different_field" does not exist'
       );
       expect(result).not.toContain('Did you mean:');
-      expect(result).toContain('records_discover_attributes');
+      expect(result).toContain('discover_record_attributes');
     });
 
     it('should fallback when handleUniversalDiscoverAttributes fails', async () => {
@@ -273,7 +273,7 @@ describe('attribute-enhancer', () => {
 
       expect(result).toContain('Attribute "test" does not exist on companies');
       expect(result).not.toContain('Did you mean:');
-      expect(result).toContain('records_discover_attributes');
+      expect(result).toContain('discover_record_attributes');
     });
 
     it('should return null when pattern does not match', async () => {
@@ -306,7 +306,7 @@ describe('attribute-enhancer', () => {
 
       expect(result).toContain('Attribute "test" does not exist');
       expect(result).not.toContain('Did you mean:');
-      expect(result).toContain('records_discover_attributes');
+      expect(result).toContain('discover_record_attributes');
     });
 
     it('should handle attributes with missing name/title/api_slug', async () => {

--- a/test/handlers/tool-configs/universal/core/error-enhancers/required-fields-enhancer.test.ts
+++ b/test/handlers/tool-configs/universal/core/error-enhancers/required-fields-enhancer.test.ts
@@ -101,7 +101,7 @@ describe('required-fields-enhancer', () => {
       expect(result).toContain('"MQL"');
       expect(result).toContain('"SQL"');
       expect(result).toContain('"Opportunity"');
-      expect(result).toContain('records_get_attribute_options');
+      expect(result).toContain('get_record_attribute_options');
       expect(mockGetOptions).toHaveBeenCalledWith('deals', 'stage');
     });
 
@@ -144,7 +144,7 @@ describe('required-fields-enhancer', () => {
       const result = await requiredFieldsEnhancer.enhance(error, context);
 
       expect(result).toContain('Required field "stage" is missing for deals');
-      expect(result).toContain('records_get_attribute_options');
+      expect(result).toContain('get_record_attribute_options');
       expect(result).not.toContain('Common stage values');
     });
 

--- a/test/handlers/tool-configs/universal/core/error-enhancers/select-status-enhancer.test.ts
+++ b/test/handlers/tool-configs/universal/core/error-enhancers/select-status-enhancer.test.ts
@@ -110,7 +110,7 @@ describe('select-status-enhancer', () => {
         'Value "Invalid" is not valid for select attribute "status" on companies'
       );
       expect(result).toContain('Valid options: Active, Inactive, Pending');
-      expect(result).toContain('records_get_attribute_options');
+      expect(result).toContain('get_record_attribute_options');
       expect(result).toContain('resource_type: "companies"');
       expect(result).toContain('attribute: "status"');
       expect(mockGetOptions).toHaveBeenCalledWith('companies', 'status');
@@ -181,7 +181,7 @@ describe('select-status-enhancer', () => {
       expect(result).not.toBeNull();
       expect(result).toContain('Value is not valid for attribute "status"');
       expect(result).not.toContain('Valid options:');
-      expect(result).toContain('records_get_attribute_options');
+      expect(result).toContain('get_record_attribute_options');
     });
   });
 
@@ -248,7 +248,7 @@ describe('select-status-enhancer', () => {
       expect(result).toContain('Value "Test" is not valid');
       expect(result).toContain('an attribute on companies');
       expect(result).not.toContain('attribute "');
-      expect(result).toContain('records_get_attribute_options');
+      expect(result).toContain('get_record_attribute_options');
     });
 
     it('should return null when no recordData', async () => {

--- a/test/handlers/tool-configs/universal/core/error-enhancers/uniqueness-enhancer.test.ts
+++ b/test/handlers/tool-configs/universal/core/error-enhancers/uniqueness-enhancer.test.ts
@@ -143,7 +143,7 @@ describe('uniqueness-enhancer', () => {
         'update-record(resource_type="companies", record_id="comp-789"'
       );
       expect(result).toContain(
-        'records_get_details(resource_type="companies", record_id="comp-789"'
+        'get_record_details(resource_type="companies", record_id="comp-789"'
       );
     });
 

--- a/test/prompts/v1/people-search.test.ts
+++ b/test/prompts/v1/people-search.test.ts
@@ -99,7 +99,7 @@ describe('people_search.v1', () => {
       expect(messages).toHaveLength(1);
       expect(messages[0].role).toBe('user');
       expect(messages[0].content.type).toBe('text');
-      expect((messages[0].content as any).text).toContain('records_query');
+      expect((messages[0].content as any).text).toContain('search_records');
       expect((messages[0].content as any).text).toContain('AE in fintech');
       expect((messages[0].content as any).text).toContain('format=table');
     });

--- a/test/prompts/v1/tool-name-catalog.test.ts
+++ b/test/prompts/v1/tool-name-catalog.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { findToolConfig } from '@/handlers/tools/registry.js';
+import { getToolAliasRegistry } from '@/config/tool-aliases.js';
+import { getAllPromptsV1 } from '@/prompts/v1/index.js';
+import { PromptMessage, TextContent } from '@/prompts/v1/types.js';
+
+const SAMPLE_ARGS_BY_PROMPT: Record<string, Record<string, unknown>> = {
+  'people_search.v1': {
+    query: 'Account Executives in fintech',
+  },
+  'company_search.v1': {
+    query: 'SaaS companies over 100 employees',
+  },
+  'deal_search.v1': {
+    query: 'deals over 50000 closing this quarter',
+  },
+  'meeting_prep.v1': {
+    target: 'search:Acme Corp',
+  },
+  'pipeline_health.v1': {
+    owner: '@me',
+    timeframe: '30d',
+    segment: 'enterprise',
+  },
+  'log_activity.v1': {
+    target: 'search:Acme Corp',
+    type: 'call',
+    summary: 'Discussed Q1 pricing',
+    create_follow_up: true,
+  },
+  'create_task.v1': {
+    title: 'Follow up',
+    content: 'Send pricing recap',
+    target: 'search:Acme Corp',
+    due_date: 'tomorrow',
+  },
+  'advance_deal.v1': {
+    deal: 'search:Acme enterprise deal',
+    target_stage: 'Proposal Sent',
+    create_task: true,
+  },
+  'add_to_list.v1': {
+    records: 'search:AI companies in SF',
+    list: 'Q1 Outreach',
+  },
+  'qualify_lead.v1': {
+    target: 'search:Acme Corp',
+    icp_preset: 'SaaS mid-market NA',
+  },
+};
+
+const NON_TOOL_TOKENS = new Set(['target', 'search:']);
+
+const TOOL_TOKEN_PATTERN = /^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)?$/;
+
+function textFromMessages(messages: PromptMessage[]): string {
+  return messages
+    .map((message) =>
+      message.content.type === 'text'
+        ? (message.content as TextContent).text
+        : ''
+    )
+    .join('\n');
+}
+
+function extractBacktickedTokens(text: string): string[] {
+  return Array.from(text.matchAll(/`([^`]+)`/g), (match) => match[1]).filter(
+    (token) => TOOL_TOKEN_PATTERN.test(token)
+  );
+}
+
+function resolvesAsTool(token: string): boolean {
+  return Boolean(findToolConfig(token) || getToolAliasRegistry()[token]);
+}
+
+describe('v1 prompt tool-name catalog', () => {
+  it('only references resolvable tool names in generated prompt instructions', () => {
+    const unresolved: Array<{ prompt: string; token: string }> = [];
+
+    for (const prompt of getAllPromptsV1()) {
+      const sampleArgs = SAMPLE_ARGS_BY_PROMPT[prompt.metadata.name];
+      expect(
+        sampleArgs,
+        `Missing sample args for ${prompt.metadata.name}`
+      ).toBeDefined();
+
+      const text = textFromMessages(prompt.buildMessages(sampleArgs));
+      const tokens = extractBacktickedTokens(text);
+
+      for (const token of tokens) {
+        if (NON_TOOL_TOKENS.has(token)) {
+          continue;
+        }
+
+        if (!resolvesAsTool(token)) {
+          unresolved.push({ prompt: prompt.metadata.name, token });
+        }
+      }
+    }
+
+    expect(unresolved).toEqual([]);
+  });
+});

--- a/test/prompts/v1/tool-name-catalog.test.ts
+++ b/test/prompts/v1/tool-name-catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getToolAliasRegistry } from '@/config/tool-aliases.js';
 import { findToolConfig } from '@/handlers/tools/registry.js';
 import { getAllPromptsV1 } from '@/prompts/v1/index.js';
 import { PromptMessage, TextContent } from '@/prompts/v1/types.js';
@@ -49,6 +50,7 @@ const SAMPLE_ARGS_BY_PROMPT: Record<string, Record<string, unknown>> = {
 };
 
 const NON_TOOL_TOKENS = new Set(['target', 'search:']);
+const DEPRECATED_TOOL_ALIASES = new Set(Object.keys(getToolAliasRegistry()));
 
 const TOOL_TOKEN_PATTERN = /^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)*$/;
 const STALE_TOOL_TOKEN_PATTERN =
@@ -107,6 +109,11 @@ describe('v1 prompt tool-name catalog', () => {
       }
 
       for (const token of toolTokens) {
+        if (DEPRECATED_TOOL_ALIASES.has(token)) {
+          unresolved.push({ prompt: prompt.metadata.name, token });
+          continue;
+        }
+
         if (!resolvedTokens.get(token)) {
           unresolved.push({ prompt: prompt.metadata.name, token });
         }

--- a/test/prompts/v1/tool-name-catalog.test.ts
+++ b/test/prompts/v1/tool-name-catalog.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { findToolConfig } from '@/handlers/tools/registry.js';
-import { getToolAliasRegistry } from '@/config/tool-aliases.js';
 import { getAllPromptsV1 } from '@/prompts/v1/index.js';
 import { PromptMessage, TextContent } from '@/prompts/v1/types.js';
 
@@ -51,7 +50,9 @@ const SAMPLE_ARGS_BY_PROMPT: Record<string, Record<string, unknown>> = {
 
 const NON_TOOL_TOKENS = new Set(['target', 'search:']);
 
-const TOOL_TOKEN_PATTERN = /^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)?$/;
+const TOOL_TOKEN_PATTERN = /^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)*$/;
+const STALE_TOOL_TOKEN_PATTERN =
+  /\b(?:records_query|tasks\.create|records\.update|records\.search|records\.discover_attributes|web\.search|web\.fetch|notes\.create|deals\.list|get-lists|add-record-to-list)\b/g;
 
 function textFromMessages(messages: PromptMessage[]): string {
   return messages
@@ -69,8 +70,20 @@ function extractBacktickedTokens(text: string): string[] {
   );
 }
 
-function resolvesAsTool(token: string): boolean {
-  return Boolean(findToolConfig(token) || getToolAliasRegistry()[token]);
+function extractStaleToolTokens(text: string): string[] {
+  return Array.from(
+    text.matchAll(STALE_TOOL_TOKEN_PATTERN),
+    (match) => match[0]
+  );
+}
+
+function resolveTokens(tokens: string[]): Map<string, boolean> {
+  return new Map(
+    Array.from(new Set(tokens), (token) => [
+      token,
+      Boolean(findToolConfig(token)),
+    ])
+  );
 }
 
 describe('v1 prompt tool-name catalog', () => {
@@ -86,13 +99,15 @@ describe('v1 prompt tool-name catalog', () => {
 
       const text = textFromMessages(prompt.buildMessages(sampleArgs));
       const tokens = extractBacktickedTokens(text);
+      const toolTokens = tokens.filter((token) => !NON_TOOL_TOKENS.has(token));
+      const resolvedTokens = resolveTokens(toolTokens);
 
-      for (const token of tokens) {
-        if (NON_TOOL_TOKENS.has(token)) {
-          continue;
-        }
+      for (const token of extractStaleToolTokens(text)) {
+        unresolved.push({ prompt: prompt.metadata.name, token });
+      }
 
-        if (!resolvesAsTool(token)) {
+      for (const token of toolTokens) {
+        if (!resolvedTokens.get(token)) {
           unresolved.push({ prompt: prompt.metadata.name, token });
         }
       }


### PR DESCRIPTION
## What
- Replaces stale prompt-facing tool names with the active server names used by the registry.
- Adds a catalog test that builds every v1 prompt and rejects unresolved backticked tool references.
- Updates prompt docs, tool-quality guidance, baseline discovery data, and error-helper expectations to use the same canonical naming contract.

## Why
Bundled prompts could still tell agents to call retired names such as `records_query`, dotted Attio verbs, or `web.search`. Agents following those instructions would fail even though the server exposes the needed capabilities under canonical names like `search_records`, `create_record`, `create_note`, `search`, and `fetch`.

This PR is stacked on #1235 so the offline suite includes the search-object mock fix needed by current `main`.

## Tests
- `bun run typecheck`
- `bun run test:offline`
- `bunx prettier --check docs/plans/2026-06-09-002-fix-prompt-tool-name-catalog-plan.md test/prompts/v1/tool-name-catalog.test.ts src/prompts/v1/log-activity.v1.ts test/handlers/tool-configs/universal/core/crud-error-handlers.test.ts test/handlers/tool-configs/universal/core/error-enhancers/attribute-enhancer.test.ts test/handlers/tool-configs/universal/core/error-enhancers/required-fields-enhancer.test.ts test/handlers/tool-configs/universal/core/error-enhancers/select-status-enhancer.test.ts test/handlers/tool-configs/universal/core/error-enhancers/uniqueness-enhancer.test.ts`
- pre-push hook: TypeScript check + offline fast tests

## AI Assistance
Used Codex to audit prompt-generated tool references, align stale names to the active registry, add/format tests, and run local validation. I understand this code.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
