### PR TITLE
Refactor: Migrate alias imports current batch

### DIFF
--- a/docs/plans/2026-06-11-001-refactor-alias-imports-current-batch-plan.md
+++ b/docs/plans/2026-06-11-001-refactor-alias-imports-current-batch-plan.md
@@ -1,0 +1,231 @@
+---
+title: 'refactor: Alias Imports Current Batch'
+type: refactor
+date: 2026-06-11
+origin: https://github.com/kesslerio/attio-mcp-server/issues/745
+---
+
+# refactor: Alias Imports Current Batch
+
+## Summary
+
+Migrate the current highest-signal batch of remaining deep relative imports for issue #745 to the repository's existing TypeScript path aliases. This batch targets create/update services, legacy dispatcher operations, and paired service tests while keeping the change mechanical and reviewable.
+
+---
+
+## Problem Frame
+
+Issue #745 asks the repo to finish replacing deep relative imports such as `../../../types/attio.js` and `../../src/services/...` with configured aliases. The issue body is stale: its original top files are already migrated in this checkout, but a fresh scan still reports 903 deep relative import lines across `src/` and `test/`. The useful next step is a bounded batch based on the current hotspots, not a repo-wide sweep.
+
+---
+
+## Requirements
+
+- R1. Replace deep relative import and dynamic-import specifiers in the selected batch with existing aliases.
+- R2. Preserve ESM `.js` suffixes for TypeScript source imports under NodeNext.
+- R3. Do not add or change path aliases; use the existing `tsconfig.json` and Vitest alias surface.
+- R4. Keep the diff mechanical: no behavior changes, no cleanup beyond import specifiers and formatter fallout.
+- R5. Validate with Bun-based repo commands rather than the stale npm/npx commands in the issue body.
+- R6. Leave a clear residual accounting for remaining issue #745 batches.
+
+---
+
+## Scope Boundaries
+
+- In scope: selected high-count production files in `src/services/create`, `src/services/update`, and `src/handlers/tools/dispatcher/operations`, plus paired service tests in `test/services`.
+- Out of scope: E2E-wide migration, low-count scattered imports, alias design, runtime behavior changes, dependency updates, and GitHub issue label cleanup.
+- Out of scope: generated output, `dist/`, historical manual test artifacts, and non-TypeScript files unless validation proves they are necessary for this batch.
+
+---
+
+## Context & Research
+
+- `tsconfig.json` already defines `@/*`, `@api/*`, `@config/*`, `@constants/*`, `@handlers/*`, `@services/*`, `@errors/*`, `@shared-types/*`, `@utils/*`, `@test-support/*`, and `@test/*`.
+- `configs/vitest/aliases.ts` maps the same aliases for test execution and includes `.js` to `.ts` handling.
+- Current highest production hotspots include `src/services/create/mock-create.service.ts`, `src/services/create/strategies/PersonCreateStrategy.ts`, `src/services/create/strategies/DealCreateStrategy.ts`, `src/services/update/strategies/PersonUpdateStrategy.ts`, and the legacy dispatcher operation files under `src/handlers/tools/dispatcher/operations`.
+- Current highest paired service-test hotspots include `test/services/UniversalCreateService-core-resources.test.ts`, `test/services/UniversalCreateService-objects-deals-tasks.test.ts`, `test/services/UniversalUpdateService-validation.test.ts`, `test/services/UniversalSearchService-records-tasks.test.ts`, `test/services/content-search.test.ts`, and search-strategy tests.
+- The repo requires Bun for validation and uses NodeNext module resolution, so alias imports must keep their `.js` suffixes.
+
+---
+
+## Key Technical Decisions
+
+- **Use existing aliases only:** Use dedicated aliases for configured source roots (`@services`, `@handlers`, `@api`, `@config`, `@utils`, `@shared-types`) and `@/` for source areas without a dedicated alias such as `src/objects` or `src/middleware`.
+- **Batch current hotspots:** Ignore stale issue counts and the June 9 batch's already-cleared targets; select files from the fresh scan to avoid no-op work.
+- **Update dynamic imports when they target source modules:** Dynamic `await import('../../utils/task-debug.js')` calls should move to aliases too, because they are part of the same resolver surface.
+- **Keep mocks honest:** Change `vi.mock()` paths only when they refer to the same source module being imported through an alias; do not change local helper paths unnecessarily.
+
+---
+
+## Implementation Units
+
+### U1. Create and Update Service Imports
+
+**Goal:** Convert deep relative imports in the create/update service hotspots to existing source aliases.
+
+**Requirements:** R1, R2, R3, R4
+
+**Files:**
+
+- Modify: `src/services/create/mock-create.service.ts`
+- Modify: `src/services/create/strategies/PersonCreateStrategy.ts`
+- Modify: `src/services/create/strategies/DealCreateStrategy.ts`
+- Modify: `src/services/update/strategies/PersonUpdateStrategy.ts`
+- Optional Modify: nearby `src/services/create/**` or `src/services/update/**` files only when a same-pattern import is needed to keep the batch coherent.
+
+**Approach:**
+
+- Map `src/types/**` imports to `@shared-types/...`.
+- Map `src/services/**` imports to `@services/...`.
+- Map `src/handlers/**` imports to `@handlers/...`.
+- Map `src/config/**` imports to `@config/...`.
+- Map `src/utils/**` imports to `@utils/...`.
+- Map `src/objects/**` imports to `@/objects/...`.
+- Preserve `.js` suffixes and import type/value distinctions.
+
+**Patterns to follow:**
+
+- `src/services/UniversalCreateService.ts`
+- `src/services/UniversalUpdateService.ts`
+- `src/services/search-strategies/interfaces.ts`
+
+**Test scenarios:**
+
+- TypeScript resolves every changed create/update service import.
+- Dynamic imports still target the same modules.
+- No runtime statements change except module specifiers.
+
+**Verification:**
+
+- `bun run typecheck`
+- `bun run lint:file -- "src/services/create/mock-create.service.ts src/services/create/strategies/PersonCreateStrategy.ts src/services/create/strategies/DealCreateStrategy.ts src/services/update/strategies/PersonUpdateStrategy.ts"`
+
+### U2. Legacy Dispatcher Operation Imports
+
+**Goal:** Convert deep relative imports in the legacy dispatcher operation files to aliases without changing dispatcher behavior.
+
+**Requirements:** R1, R2, R3, R4
+
+**Files:**
+
+- Modify: `src/handlers/tools/dispatcher/operations/lists.ts`
+- Modify: `src/handlers/tools/dispatcher/operations/search.ts`
+- Modify: `src/handlers/tools/dispatcher/operations/notes.ts`
+- Modify: `src/handlers/tools/dispatcher/operations/details.ts`
+- Modify: `src/handlers/tools/dispatcher/operations/advanced-search.ts`
+- Optional Modify: adjacent dispatcher operation files if the same import pattern is directly repeated.
+
+**Approach:**
+
+- Map dispatcher-local shared imports to `@handlers/tools/...` rather than fragile relative hops.
+- Map API, object, type, and utility imports to their configured aliases.
+- Keep the existing operation exports and function bodies unchanged.
+
+**Patterns to follow:**
+
+- `src/handlers/tools/dispatcher/core.ts`
+- `src/handlers/tools/registry.ts`
+- `src/handlers/tool-configs/universal/core/notes-operations.ts`
+
+**Test scenarios:**
+
+- `findToolConfig` and dispatcher execution still resolve operation modules.
+- List, search, note, detail, and advanced-search operation imports compile.
+- No handler behavior changes appear in the diff.
+
+**Verification:**
+
+- `bun run typecheck`
+- `bun run lint:file -- "src/handlers/tools/dispatcher/operations/lists.ts src/handlers/tools/dispatcher/operations/search.ts src/handlers/tools/dispatcher/operations/notes.ts src/handlers/tools/dispatcher/operations/details.ts src/handlers/tools/dispatcher/operations/advanced-search.ts"`
+
+### U3. Paired Service Test Imports
+
+**Goal:** Convert high-count paired service-test imports to aliases and preserve Vitest mock identity.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Files:**
+
+- Modify: `test/services/UniversalCreateService-core-resources.test.ts`
+- Modify: `test/services/UniversalCreateService-objects-deals-tasks.test.ts`
+- Modify: `test/services/UniversalUpdateService-validation.test.ts`
+- Modify: `test/services/UniversalSearchService-records-tasks.test.ts`
+- Modify: `test/services/content-search.test.ts`
+- Modify: `test/services/search-strategies/TaskSearchStrategy.test.ts`
+- Modify: `test/services/search-strategies/CompanySearchStrategy.test.ts`
+
+**Approach:**
+
+- Replace `../../src/...` and `../../../src/...` imports with source aliases.
+- Preserve test-local relative imports only when they point to neighboring test helpers.
+- Align `vi.mock()` module names with the aliased import names when the mock targets a source module.
+
+**Patterns to follow:**
+
+- `test/services/openai-compatibility.service.test.ts`
+- `test/handlers/tools/registry-mode.test.ts`
+- `test/configs/vitest/aliases.test.ts`
+
+**Test scenarios:**
+
+- The selected tests still import the same production modules.
+- Mocked modules still match the implementation imports they replace.
+- Targeted service tests pass or any failures are documented as pre-existing or unrelated.
+
+**Verification:**
+
+- `bun run test:offline:run -- test/services/UniversalCreateService-core-resources.test.ts`
+- `bun run test:offline:run -- test/services/UniversalCreateService-objects-deals-tasks.test.ts`
+- `bun run test:offline:run -- test/services/UniversalUpdateService-validation.test.ts`
+- `bun run test:offline:run -- test/services/UniversalSearchService-records-tasks.test.ts`
+- `bun run test:offline:run -- test/services/content-search.test.ts`
+- `bun run test:offline:run -- test/services/search-strategies/TaskSearchStrategy.test.ts test/services/search-strategies/CompanySearchStrategy.test.ts`
+
+### U4. Batch Validation and Residual Accounting
+
+**Goal:** Prove this alias batch is coherent and document what remains for later #745 work.
+
+**Requirements:** R5, R6
+
+**Files:**
+
+- Modify: no additional source files expected.
+- Optional Modify: `CHANGELOG.md` only if repo policy requires an Unreleased entry for this internal refactor.
+
+**Approach:**
+
+- Run a fresh scan over changed files and confirm no selected file still has deep relative imports.
+- Run targeted tests first, then broad typecheck and lint as time allows.
+- Mention in the PR body that this is a current-hotspot batch and does not close all of #745.
+
+**Test scenarios:**
+
+- Fresh scan reports zero deep relative imports in changed files.
+- Typecheck passes after alias conversion.
+- Targeted tests covering changed service imports pass.
+
+**Verification:**
+
+- `rg -n "from ['\\\"](\\.\\./){2,}|import\\(['\\\"](\\.\\./){2,}" <changed-files>`
+- `bun run typecheck`
+- Targeted commands from U1, U2, and U3.
+
+---
+
+## Risks and Mitigations
+
+- **Alias mismatch risk:** Use only aliases already present in `tsconfig.json` and `configs/vitest/aliases.ts`; verify with typecheck and targeted tests.
+- **Vitest mock identity risk:** Keep mock specifiers aligned with implementation imports and run the selected tests directly.
+- **Oversized PR risk:** Stop at the current batch and leave E2E-wide and scattered low-count files for later.
+- **False completion risk:** Treat this as a #745 batch, not the whole issue; include residual scan context in the PR.
+
+---
+
+## Verification Checklist
+
+- [ ] Selected production files use aliases instead of deep relative imports.
+- [ ] Selected service tests use aliases and preserve mock behavior.
+- [ ] Fresh scan reports no deep relative imports in changed files.
+- [ ] `bun run typecheck` passes.
+- [ ] Targeted service tests pass or unrelated failures are documented.
+- [ ] PR body references issue #745 and says this is a current-hotspot batch, not the full migration.

--- a/src/handlers/tools/dispatcher/operations/advanced-search.ts
+++ b/src/handlers/tools/dispatcher/operations/advanced-search.ts
@@ -5,12 +5,12 @@
  */
 
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
-import { createErrorResult } from '../../../../utils/error-handler.js';
-import { ResourceType } from '../../../../types/attio.js';
-import { AdvancedSearchToolConfig } from '../../../tool-types.js';
-import { formatResponse } from '../../formatters.js';
-import { hasResponseData } from '../../error-types.js';
-import { ListEntryFilters } from '../../../../api/operations/index.js';
+import { createErrorResult } from '@utils/error-handler.js';
+import { ResourceType } from '@shared-types/attio.js';
+import { AdvancedSearchToolConfig } from '@handlers/tool-types.js';
+import { formatResponse } from '@handlers/tools/formatters.js';
+import { hasResponseData } from '@handlers/tools/error-types.js';
+import { ListEntryFilters } from '@api/operations/index.js';
 
 /**
  * Handle advanced search operations

--- a/src/handlers/tools/dispatcher/operations/details.ts
+++ b/src/handlers/tools/dispatcher/operations/details.ts
@@ -5,12 +5,12 @@
  */
 
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
-import { createErrorResult } from '../../../../utils/error-handler.js';
-import { parseResourceUri } from '../../../../utils/uri-parser.js';
-import { ResourceType } from '../../../../types/attio.js';
-import { DetailsToolConfig } from '../../../tool-types.js';
-import { formatResponse } from '../../formatters.js';
-import { hasResponseData } from '../../error-types.js';
+import { createErrorResult } from '@utils/error-handler.js';
+import { parseResourceUri } from '@utils/uri-parser.js';
+import { ResourceType } from '@shared-types/attio.js';
+import { DetailsToolConfig } from '@handlers/tool-types.js';
+import { formatResponse } from '@handlers/tools/formatters.js';
+import { hasResponseData } from '@handlers/tools/error-types.js';
 
 /**
  * Handle details operations

--- a/src/handlers/tools/dispatcher/operations/lists.ts
+++ b/src/handlers/tools/dispatcher/operations/lists.ts
@@ -5,22 +5,22 @@
  */
 
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
-import { createErrorResult } from '../../../../utils/error-handler.js';
-import { ToolConfig, GetListsToolConfig } from '../../../tool-types.js';
-import { formatResponse } from '../../formatters.js';
-import { hasResponseData } from '../../error-types.js';
+import { createErrorResult } from '@utils/error-handler.js';
+import { ToolConfig, GetListsToolConfig } from '@handlers/tool-types.js';
+import { formatResponse } from '@handlers/tools/formatters.js';
+import { hasResponseData } from '@handlers/tools/error-types.js';
 import {
   filterListEntries,
   advancedFilterListEntries,
   filterListEntriesByParent,
   filterListEntriesByParentId,
-} from '../../../../objects/lists/filtering.js';
+} from '@/objects/lists/filtering.js';
 import {
   addRecordToList,
   removeRecordFromList,
   updateListEntry,
-} from '../../../../objects/lists/entries.js';
-import { ListEntryFilters } from '../../../../api/operations/index.js';
+} from '@/objects/lists/entries.js';
+import { ListEntryFilters } from '@api/operations/index.js';
 import { warn, OperationType } from '@/utils/logger.js';
 import { ListConfigurationValidator } from '@/services/lists/ListConfigurationValidator.js';
 import { createList, updateList } from '@/objects/lists/base.js';

--- a/src/handlers/tools/dispatcher/operations/notes.ts
+++ b/src/handlers/tools/dispatcher/operations/notes.ts
@@ -5,12 +5,12 @@
  */
 
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
-import { createErrorResult } from '../../../../utils/error-handler.js';
-import { parseResourceUri } from '../../../../utils/uri-parser.js';
-import { ResourceType } from '../../../../types/attio.js';
-import { NotesToolConfig, CreateNoteToolConfig } from '../../../tool-types.js';
-import { formatResponse } from '../../formatters.js';
-import { hasResponseData } from '../../error-types.js';
+import { createErrorResult } from '@utils/error-handler.js';
+import { parseResourceUri } from '@utils/uri-parser.js';
+import { ResourceType } from '@shared-types/attio.js';
+import { NotesToolConfig, CreateNoteToolConfig } from '@handlers/tool-types.js';
+import { formatResponse } from '@handlers/tools/formatters.js';
+import { hasResponseData } from '@handlers/tools/error-types.js';
 
 /**
  * Handle notes operations

--- a/src/handlers/tools/dispatcher/operations/search.ts
+++ b/src/handlers/tools/dispatcher/operations/search.ts
@@ -5,12 +5,12 @@
  */
 
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
-import { createErrorResult } from '../../../../utils/error-handler.js';
-import { ResourceType } from '../../../../types/attio.js';
-import { SearchToolConfig } from '../../../tool-types.js';
-import { formatResponse } from '../../formatters.js';
-import { hasResponseData } from '../../error-types.js';
-import { createScopedLogger } from '../../../../utils/logger.js';
+import { createErrorResult } from '@utils/error-handler.js';
+import { ResourceType } from '@shared-types/attio.js';
+import { SearchToolConfig } from '@handlers/tool-types.js';
+import { formatResponse } from '@handlers/tools/formatters.js';
+import { hasResponseData } from '@handlers/tools/error-types.js';
+import { createScopedLogger } from '@utils/logger.js';
 
 /**
  * Check if the formatted results already contain a header to avoid duplication

--- a/src/services/create/mock-create.service.ts
+++ b/src/services/create/mock-create.service.ts
@@ -6,10 +6,10 @@
  */
 
 import type { CreateService } from './types.js';
-import type { AttioRecord } from '../../types/attio.js';
-import type { E2EMeta, UnknownRecord } from '../../types/service-types.js';
-import { extractRecordId } from '../../utils/validation/uuid-validation.js';
-import { isValidId } from '../../utils/validation.js';
+import type { AttioRecord } from '@shared-types/attio.js';
+import type { E2EMeta, UnknownRecord } from '@shared-types/service-types.js';
+import { extractRecordId } from '@utils/validation/uuid-validation.js';
+import { isValidId } from '@utils/validation.js';
 import { generateMockId } from './extractor.js';
 
 /**
@@ -76,7 +76,7 @@ export class MockCreateService implements CreateService {
     // Issue #480 compatible mock task
     try {
       const { logTaskDebug, sanitizePayload } =
-        await import('../../utils/task-debug.js');
+        await import('@utils/task-debug.js');
       logTaskDebug(
         'mock.createTask',
         'Incoming taskData',
@@ -151,7 +151,7 @@ export class MockCreateService implements CreateService {
 
     try {
       const { logTaskDebug, inspectTaskRecordShape } =
-        await import('../../utils/task-debug.js');
+        await import('@utils/task-debug.js');
       logTaskDebug(
         'mock.createTask',
         'Returning mock task',
@@ -256,7 +256,7 @@ export class MockCreateService implements CreateService {
 
     try {
       const { logTaskDebug, inspectTaskRecordShape } =
-        await import('../../utils/task-debug.js');
+        await import('@utils/task-debug.js');
       logTaskDebug(
         'mock.updateTask',
         'Returning updated mock task',

--- a/src/services/create/strategies/DealCreateStrategy.ts
+++ b/src/services/create/strategies/DealCreateStrategy.ts
@@ -1,4 +1,4 @@
-import type { AttioRecord } from '../../../types/attio.js';
+import type { AttioRecord } from '@shared-types/attio.js';
 import type {
   CreateStrategy,
   CreateStrategyParams,
@@ -6,11 +6,11 @@ import type {
 import {
   applyDealDefaultsWithValidation,
   validateDealInput,
-} from '../../../config/deal-defaults.js';
-import { convertAttributeFormats } from '../../../utils/attribute-format-helpers.js';
-import { createObjectRecord as createObjectRecordApi } from '../../../objects/records/index.js';
-import { getDealDefaults } from '../../../config/deal-defaults.js';
-import { debug } from '../../../utils/logger.js';
+} from '@config/deal-defaults.js';
+import { convertAttributeFormats } from '@utils/attribute-format-helpers.js';
+import { createObjectRecord as createObjectRecordApi } from '@/objects/records/index.js';
+import { getDealDefaults } from '@config/deal-defaults.js';
+import { debug } from '@utils/logger.js';
 
 export class DealCreateStrategy implements CreateStrategy {
   async create(params: CreateStrategyParams): Promise<AttioRecord> {

--- a/src/services/create/strategies/PersonCreateStrategy.ts
+++ b/src/services/create/strategies/PersonCreateStrategy.ts
@@ -1,18 +1,18 @@
-import type { AttioRecord } from '../../../types/attio.js';
+import type { AttioRecord } from '@shared-types/attio.js';
 import type {
   CreateStrategy,
   CreateStrategyParams,
 } from './BaseCreateStrategy.js';
-import { getCreateService } from '../../create/index.js';
-import { ValidationService } from '../../ValidationService.js';
-import { getFieldSuggestions } from '../../../handlers/tool-configs/universal/field-mapper.js';
+import { getCreateService } from '@services/create/index.js';
+import { ValidationService } from '@services/ValidationService.js';
+import { getFieldSuggestions } from '@handlers/tool-configs/universal/field-mapper.js';
 import {
   UniversalValidationError,
   ErrorType,
-} from '../../../handlers/tool-configs/universal/schemas.js';
-import type { PersonCreateAttributes } from '../../../types/attio.js';
-import { PeopleDataNormalizer } from '../../../utils/normalization/people-normalization.js';
-import { convertAttributeFormats } from '../../../utils/attribute-format-helpers.js';
+} from '@handlers/tool-configs/universal/schemas.js';
+import type { PersonCreateAttributes } from '@shared-types/attio.js';
+import { PeopleDataNormalizer } from '@utils/normalization/people-normalization.js';
+import { convertAttributeFormats } from '@utils/attribute-format-helpers.js';
 
 export class PersonCreateStrategy implements CreateStrategy<AttioRecord> {
   async create(params: CreateStrategyParams): Promise<AttioRecord> {

--- a/src/services/update/strategies/PersonUpdateStrategy.ts
+++ b/src/services/update/strategies/PersonUpdateStrategy.ts
@@ -1,13 +1,13 @@
-import type { AttioRecord } from '../../../types/attio.js';
-import type { PersonAttributes } from '../../../objects/people/types.js';
-import { updatePerson } from '../../../objects/people-write.js';
-import { getFieldSuggestions } from '../../../handlers/tool-configs/universal/field-mapper.js';
+import type { AttioRecord } from '@shared-types/attio.js';
+import type { PersonAttributes } from '@/objects/people/types.js';
+import { updatePerson } from '@/objects/people-write.js';
+import { getFieldSuggestions } from '@handlers/tool-configs/universal/field-mapper.js';
 import {
   UniversalValidationError,
   ErrorType,
-} from '../../../handlers/tool-configs/universal/schemas.js';
+} from '@handlers/tool-configs/universal/schemas.js';
 import type { UpdateStrategy } from './BaseUpdateStrategy.js';
-import { ValidationService } from '../../ValidationService.js';
+import { ValidationService } from '@services/ValidationService.js';
 
 /**
  * PersonUpdateStrategy - Handles updates for People (with email validation)

--- a/test/services/UniversalCreateService-core-resources.test.ts
+++ b/test/services/UniversalCreateService-core-resources.test.ts
@@ -2,16 +2,16 @@
  * Split: UniversalCreateService core resources (companies, people, lists)
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-vi.mock('../../src/services/ValidationService.js', () => ({
+vi.mock('@services/ValidationService.js', () => ({
   ValidationService: {
     truncateSuggestions: vi.fn((s: string[]) => s),
     validateEmailAddresses: vi.fn(),
   },
 }));
-vi.mock('../../src/services/UniversalUtilityService.js', () => ({
+vi.mock('@services/UniversalUtilityService.js', () => ({
   UniversalUtilityService: { convertTaskToRecord: vi.fn() },
 }));
-vi.mock('../../src/handlers/tool-configs/universal/field-mapper.js', () => ({
+vi.mock('@handlers/tool-configs/universal/field-mapper.js', () => ({
   mapRecordFields: vi.fn(),
   validateResourceType: vi.fn(),
   getFieldSuggestions: vi.fn(),
@@ -25,17 +25,17 @@ vi.mock('../../src/handlers/tool-configs/universal/field-mapper.js', () => ({
     lists: { validFields: ['name', 'description'] },
   },
 }));
-vi.mock('../../src/utils/validation-utils.js', () => ({
+vi.mock('@utils/validation-utils.js', () => ({
   validateRecordFields: vi.fn(),
 }));
-vi.mock('../../src/utils/attribute-format-helpers.js', () => ({
+vi.mock('@utils/attribute-format-helpers.js', () => ({
   convertAttributeFormats: vi.fn((type: string, data: any) => data),
   getFormatErrorHelp: vi.fn(
     (type: string, field: string, message: string) => `Enhanced: ${message}`
   ),
   validatePeopleAttributesPrePost: vi.fn(),
 }));
-vi.mock('../../src/config/deal-defaults.js', () => ({
+vi.mock('@config/deal-defaults.js', () => ({
   applyDealDefaultsWithValidation: vi.fn(),
   getDealDefaults: vi.fn(() => ({ stage: 'default-stage' })),
   validateDealInput: vi.fn(() => ({
@@ -44,10 +44,10 @@ vi.mock('../../src/config/deal-defaults.js', () => ({
     warnings: [],
   })),
 }));
-vi.mock('../../src/utils/normalization/people-normalization.js', () => ({
+vi.mock('@utils/normalization/people-normalization.js', () => ({
   PeopleDataNormalizer: { normalizePeopleData: vi.fn((d: any) => d) },
 }));
-vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
+vi.mock('@errors/enhanced-api-errors.js', () => ({
   EnhancedApiError: vi
     .fn()
     .mockImplementation(
@@ -73,7 +73,7 @@ vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
   },
   ErrorEnhancer: { autoEnhance: vi.fn((e: any) => e) },
 }));
-vi.mock('../../src/utils/logger.js', () => ({
+vi.mock('@utils/logger.js', () => ({
   debug: vi.fn(),
   createScopedLogger: vi.fn(() => ({
     debug: vi.fn(),
@@ -83,12 +83,12 @@ vi.mock('../../src/utils/logger.js', () => ({
   })),
   OperationType: { API_CALL: 'api_call' },
 }));
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   createCompany: vi.fn(),
 }));
-vi.mock('../../src/objects/lists.js', () => ({ createList: vi.fn() }));
-vi.mock('../../src/objects/people/index.js', () => ({ createPerson: vi.fn() }));
-vi.mock('../../src/objects/records/index.js', () => ({
+vi.mock('@/objects/lists.js', () => ({ createList: vi.fn() }));
+vi.mock('@/objects/people/index.js', () => ({ createPerson: vi.fn() }));
+vi.mock('@/objects/records/index.js', () => ({
   createObjectRecord: vi.fn(),
 }));
 // Mock the create service factory to return a mock service
@@ -102,23 +102,23 @@ const mockCreateService = {
   updateTask: vi.fn(),
 };
 
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@services/create/index.js', () => ({
   getCreateService: vi.fn(() => mockCreateService),
   shouldUseMockData: vi.fn(() => true),
 }));
 
-import { UniversalCreateService } from '../../src/services/UniversalCreateService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord } from '../../src/types/attio.js';
-import { ValidationService } from '../../src/services/ValidationService.js';
-import { PeopleDataNormalizer } from '../../src/utils/normalization/people-normalization.js';
-import { convertAttributeFormats } from '../../src/utils/attribute-format-helpers.js';
-import { createList } from '../../src/objects/lists.js';
-import { getCreateService } from '../../src/services/create/index.js';
+import { UniversalCreateService } from '@services/UniversalCreateService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord } from '@shared-types/attio.js';
+import { ValidationService } from '@services/ValidationService.js';
+import { PeopleDataNormalizer } from '@utils/normalization/people-normalization.js';
+import { convertAttributeFormats } from '@utils/attribute-format-helpers.js';
+import { createList } from '@/objects/lists.js';
+import { getCreateService } from '@services/create/index.js';
 import {
   validateFields,
   mapRecordFields,
-} from '../../src/handlers/tool-configs/universal/field-mapper.js';
+} from '@handlers/tool-configs/universal/field-mapper.js';
 
 describe('UniversalCreateService', () => {
   beforeEach(() => {

--- a/test/services/UniversalCreateService-objects-deals-tasks.test.ts
+++ b/test/services/UniversalCreateService-objects-deals-tasks.test.ts
@@ -2,13 +2,13 @@
  * Split: UniversalCreateService objects/deals/tasks operations
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-vi.mock('../../src/services/ValidationService.js', () => ({
+vi.mock('@services/ValidationService.js', () => ({
   ValidationService: {
     truncateSuggestions: vi.fn((s: string[]) => s),
     validateEmailAddresses: vi.fn(),
   },
 }));
-vi.mock('../../src/handlers/tool-configs/universal/field-mapper.js', () => ({
+vi.mock('@handlers/tool-configs/universal/field-mapper.js', () => ({
   mapRecordFields: vi.fn(),
   validateResourceType: vi.fn(),
   getFieldSuggestions: vi.fn(),
@@ -18,16 +18,16 @@ vi.mock('../../src/handlers/tool-configs/universal/field-mapper.js', () => ({
   ),
   FIELD_MAPPINGS: {},
 }));
-vi.mock('../../src/utils/validation-utils.js', () => ({
+vi.mock('@utils/validation-utils.js', () => ({
   validateRecordFields: vi.fn(),
 }));
-vi.mock('../../src/utils/attribute-format-helpers.js', () => ({
+vi.mock('@utils/attribute-format-helpers.js', () => ({
   convertAttributeFormats: vi.fn((t: string, d: any) => d),
   getFormatErrorHelp: vi.fn(
     (t: string, f: string, m: string) => `Enhanced: ${m}`
   ),
 }));
-vi.mock('../../src/config/deal-defaults.js', () => ({
+vi.mock('@config/deal-defaults.js', () => ({
   applyDealDefaultsWithValidation: vi.fn(),
   applyDealDefaultsWithValidationLegacy: vi.fn(),
   getDealDefaults: vi.fn(() => ({ stage: 'default-stage' })),
@@ -37,7 +37,7 @@ vi.mock('../../src/config/deal-defaults.js', () => ({
     warnings: [],
   })),
 }));
-vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
+vi.mock('@errors/enhanced-api-errors.js', () => ({
   EnhancedApiError: vi
     .fn()
     .mockImplementation(
@@ -62,7 +62,7 @@ vi.mock('../../src/errors/enhanced-api-errors.js', () => ({
     ),
   },
 }));
-vi.mock('../../src/objects/records/index.js', () => ({
+vi.mock('@/objects/records/index.js', () => ({
   createObjectRecord: vi.fn(),
 }));
 vi.mock('@/utils/config-loader.js', () => ({
@@ -87,26 +87,26 @@ const mockCreateService = {
   updateTask: vi.fn(),
 };
 
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@services/create/index.js', () => ({
   getCreateService: vi.fn(() => mockCreateService),
   shouldUseMockData: vi.fn(() => true),
 }));
 
-import { UniversalCreateService } from '../../src/services/UniversalCreateService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord } from '../../src/types/attio.js';
+import { UniversalCreateService } from '@services/UniversalCreateService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord } from '@shared-types/attio.js';
 import {
   applyDealDefaultsWithValidation,
   validateDealInput,
-} from '../../src/config/deal-defaults.js';
-import { createObjectRecord } from '../../src/objects/records/index.js';
-import { getCreateService } from '../../src/services/create/index.js';
+} from '@config/deal-defaults.js';
+import { createObjectRecord } from '@/objects/records/index.js';
+import { getCreateService } from '@services/create/index.js';
 import {
   mapRecordFields,
   getFieldSuggestions,
   validateFields,
-} from '../../src/handlers/tool-configs/universal/field-mapper.js';
-import { getFormatErrorHelp } from '../../src/utils/attribute-format-helpers.js';
+} from '@handlers/tool-configs/universal/field-mapper.js';
+import { getFormatErrorHelp } from '@utils/attribute-format-helpers.js';
 
 describe('UniversalCreateService', () => {
   beforeEach(() => {

--- a/test/services/UniversalSearchService-records-tasks.test.ts
+++ b/test/services/UniversalSearchService-records-tasks.test.ts
@@ -2,23 +2,23 @@
  * Split: UniversalSearchService records/tasks
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-vi.mock('../../src/services/ValidationService.js', () => ({
+vi.mock('@services/ValidationService.js', () => ({
   ValidationService: {
     validatePaginationParameters: vi.fn(),
     validateFiltersSchema: vi.fn(),
     validateUUIDForSearch: vi.fn().mockReturnValue(true),
   },
 }));
-vi.mock('../../src/services/CachingService.js', () => ({
+vi.mock('@services/CachingService.js', () => ({
   CachingService: {
     getOrLoadTasks: vi.fn().mockResolvedValue({ data: [], fromCache: false }),
     getCachedTasks: vi.fn(),
   },
 }));
-vi.mock('../../src/services/UniversalUtilityService.js', () => ({
+vi.mock('@services/UniversalUtilityService.js', () => ({
   UniversalUtilityService: { convertTaskToRecord: vi.fn() },
 }));
-vi.mock('../../src/middleware/performance-enhanced.js', () => ({
+vi.mock('@/middleware/performance-enhanced.js', () => ({
   enhancedPerformanceTracker: {
     startOperation: vi.fn(() => 'perf-123'),
     markTiming: vi.fn(),
@@ -27,21 +27,21 @@ vi.mock('../../src/middleware/performance-enhanced.js', () => ({
     endOperation: vi.fn(),
   },
 }));
-vi.mock('../../src/objects/records/index.js', () => ({
+vi.mock('@/objects/records/index.js', () => ({
   listObjectRecords: vi.fn(),
 }));
-vi.mock('../../src/objects/tasks.js', () => ({ listTasks: vi.fn() }));
-vi.mock('../../src/services/MockService.js', () => ({
+vi.mock('@/objects/tasks.js', () => ({ listTasks: vi.fn() }));
+vi.mock('@services/MockService.js', () => ({
   MockService: { isUsingMockData: vi.fn().mockReturnValue(false) },
 }));
 
-import { UniversalSearchService } from '../../src/services/UniversalSearchService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord, AttioTask } from '../../src/types/attio.js';
-import { listObjectRecords } from '../../src/objects/records/index.js';
-import { listTasks } from '../../src/objects/tasks.js';
-import { UniversalUtilityService } from '../../src/services/UniversalUtilityService.js';
-import { CachingService } from '../../src/services/CachingService.js';
+import { UniversalSearchService } from '@services/UniversalSearchService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord, AttioTask } from '@shared-types/attio.js';
+import { listObjectRecords } from '@/objects/records/index.js';
+import { listTasks } from '@/objects/tasks.js';
+import { UniversalUtilityService } from '@services/UniversalUtilityService.js';
+import { CachingService } from '@services/CachingService.js';
 
 describe('UniversalSearchService - records/tasks', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/test/services/UniversalUpdateService-validation.test.ts
+++ b/test/services/UniversalUpdateService-validation.test.ts
@@ -89,10 +89,7 @@ import {
   validateResourceType,
 } from '@handlers/tool-configs/universal/field-mapper.js';
 import { validateRecordFields } from '@utils/validation-utils.js';
-import {
-  getCreateService,
-  shouldUseMockData,
-} from '@services/create/index.js';
+import { getCreateService, shouldUseMockData } from '@services/create/index.js';
 import * as tasks from '@/objects/tasks.js';
 // Ensure enhanced validation is disabled for these unit tests
 beforeEach(() => {

--- a/test/services/UniversalUpdateService-validation.test.ts
+++ b/test/services/UniversalUpdateService-validation.test.ts
@@ -214,8 +214,7 @@ describe('UniversalUpdateService', () => {
 
     it('should handle attribute not found errors with suggestions', async () => {
       // Simulate downstream update error
-      const { updateCompany } =
-        await import('@/objects/companies/index.js');
+      const { updateCompany } = await import('@/objects/companies/index.js');
       vi.mocked(updateCompany as any).mockRejectedValue(
         new Error('Cannot find attribute with slug/ID "invalid_field"')
       );
@@ -457,8 +456,7 @@ describe('UniversalUpdateService', () => {
 
     it('should handle empty record data', async () => {
       // Reset the updateCompany mock from previous tests
-      const { updateCompany } =
-        await import('@/objects/companies/index.js');
+      const { updateCompany } = await import('@/objects/companies/index.js');
       vi.mocked(updateCompany).mockResolvedValue({
         id: { record_id: 'comp_123' },
         values: {},

--- a/test/services/UniversalUpdateService-validation.test.ts
+++ b/test/services/UniversalUpdateService-validation.test.ts
@@ -2,21 +2,21 @@
  * Split: UniversalUpdateService validation & error handling
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-vi.mock('../../src/objects/tasks.js', () => ({
+vi.mock('@/objects/tasks.js', () => ({
   getTask: vi.fn(),
   updateTask: vi.fn(),
 }));
-vi.mock('../../src/handlers/tool-configs/universal/field-mapper.js', () => ({
+vi.mock('@handlers/tool-configs/universal/field-mapper.js', () => ({
   mapRecordFields: vi.fn(),
   mapTaskFields: vi.fn((_: string, i: any) => i),
   validateResourceType: vi.fn(),
   getFieldSuggestions: vi.fn(),
   validateFields: vi.fn(),
 }));
-vi.mock('../../src/utils/validation-utils.js', () => ({
+vi.mock('@utils/validation-utils.js', () => ({
   validateRecordFields: vi.fn(),
 }));
-vi.mock('../../src/utils/logger.js', () => ({
+vi.mock('@utils/logger.js', () => ({
   debug: vi.fn(),
   error: vi.fn(),
   info: vi.fn(),
@@ -53,14 +53,14 @@ const mockCreateService = {
   updateTask: vi.fn(),
 };
 
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@services/create/index.js', () => ({
   getCreateService: vi.fn(() => mockCreateService),
   shouldUseMockData: vi.fn(() => true),
 }));
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   updateCompany: vi.fn(() => ({ id: { record_id: 'comp_123' }, values: {} })),
 }));
-vi.mock('../../src/objects/lists.js', () => ({
+vi.mock('@/objects/lists.js', () => ({
   updateList: vi.fn(() => ({
     id: { list_id: 'list_123' },
     title: 'Test List',
@@ -71,29 +71,29 @@ vi.mock('../../src/objects/lists.js', () => ({
     updated_at: '2024-01-01T00:00:00Z',
   })),
 }));
-vi.mock('../../src/objects/people-write.js', () => ({
+vi.mock('@/objects/people-write.js', () => ({
   updatePerson: vi.fn(() => ({ id: { record_id: 'person_123' }, values: {} })),
 }));
-vi.mock('../../src/objects/records/index.js', () => ({
+vi.mock('@/objects/records/index.js', () => ({
   updateObjectRecord: vi.fn(() => ({
     id: { record_id: 'record_123' },
     values: {},
   })),
 }));
-import { UniversalUpdateService } from '../../src/services/UniversalUpdateService.js';
-import { UniversalResourceType } from '../../src/handlers/tool-configs/universal/types.js';
+import { UniversalUpdateService } from '@services/UniversalUpdateService.js';
+import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
 import {
   getFieldSuggestions,
   mapRecordFields,
   validateFields,
   validateResourceType,
-} from '../../src/handlers/tool-configs/universal/field-mapper.js';
-import { validateRecordFields } from '../../src/utils/validation-utils.js';
+} from '@handlers/tool-configs/universal/field-mapper.js';
+import { validateRecordFields } from '@utils/validation-utils.js';
 import {
   getCreateService,
   shouldUseMockData,
-} from '../../src/services/create/index.js';
-import * as tasks from '../../src/objects/tasks.js';
+} from '@services/create/index.js';
+import * as tasks from '@/objects/tasks.js';
 // Ensure enhanced validation is disabled for these unit tests
 beforeEach(() => {
   delete process.env.ENABLE_ENHANCED_VALIDATION;
@@ -148,7 +148,7 @@ describe('UniversalUpdateService', () => {
       } as any);
 
       // Mock the debug logger to verify structured logging is used
-      const { debug } = await import('../../src/utils/logger.js');
+      const { debug } = await import('@utils/logger.js');
       const debugSpy = vi.mocked(debug);
 
       mockCreateService.updateTask.mockResolvedValue({
@@ -215,7 +215,7 @@ describe('UniversalUpdateService', () => {
     it('should handle attribute not found errors with suggestions', async () => {
       // Simulate downstream update error
       const { updateCompany } =
-        await import('../../src/objects/companies/index.js');
+        await import('@/objects/companies/index.js');
       vi.mocked(updateCompany as any).mockRejectedValue(
         new Error('Cannot find attribute with slug/ID "invalid_field"')
       );
@@ -458,7 +458,7 @@ describe('UniversalUpdateService', () => {
     it('should handle empty record data', async () => {
       // Reset the updateCompany mock from previous tests
       const { updateCompany } =
-        await import('../../src/objects/companies/index.js');
+        await import('@/objects/companies/index.js');
       vi.mocked(updateCompany).mockResolvedValue({
         id: { record_id: 'comp_123' },
         values: {},

--- a/test/services/content-search.test.ts
+++ b/test/services/content-search.test.ts
@@ -4,33 +4,33 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { UniversalSearchService } from '../../src/services/UniversalSearchService.js';
+import { UniversalSearchService } from '@services/UniversalSearchService.js';
 import {
   UniversalResourceType,
   SearchType,
   MatchType,
   SortType,
-} from '../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord, AttioTask, AttioList } from '../../src/types/attio.js';
+} from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord, AttioTask, AttioList } from '@shared-types/attio.js';
 
 // Mock the imported modules
-vi.mock('../../src/objects/companies/index.js', () => ({
+vi.mock('@/objects/companies/index.js', () => ({
   advancedSearchCompanies: vi.fn(),
 }));
 
-vi.mock('../../src/objects/people/index.js', () => ({
+vi.mock('@/objects/people/index.js', () => ({
   advancedSearchPeople: vi.fn(),
 }));
 
-vi.mock('../../src/objects/tasks.js', () => ({
+vi.mock('@/objects/tasks.js', () => ({
   listTasks: vi.fn(),
 }));
 
-vi.mock('../../src/objects/lists.js', () => ({
+vi.mock('@/objects/lists.js', () => ({
   searchLists: vi.fn(),
 }));
 
-vi.mock('../../src/services/CachingService.js', () => ({
+vi.mock('@services/CachingService.js', () => ({
   CachingService: {
     getOrLoadTasks: vi.fn().mockImplementation(async (loadFn) => {
       const data = await loadFn();
@@ -39,7 +39,7 @@ vi.mock('../../src/services/CachingService.js', () => ({
   },
 }));
 
-vi.mock('../../src/services/UniversalUtilityService.js', () => ({
+vi.mock('@services/UniversalUtilityService.js', () => ({
   UniversalUtilityService: {
     convertTaskToRecord: vi.fn().mockImplementation((task) => ({
       id: { record_id: task.id.task_id, task_id: task.id.task_id },
@@ -55,17 +55,17 @@ vi.mock('../../src/services/UniversalUtilityService.js', () => ({
   },
 }));
 
-vi.mock('../../src/services/create/index.js', () => ({
+vi.mock('@services/create/index.js', () => ({
   shouldUseMockData: vi.fn(() => false),
 }));
 
-vi.mock('../../src/api/attio-client.js', () => ({
+vi.mock('@api/attio-client.js', () => ({
   getAttioClient: vi.fn(() => ({
     post: vi.fn(),
   })),
 }));
 
-vi.mock('../../src/middleware/performance-enhanced.js', () => ({
+vi.mock('@/middleware/performance-enhanced.js', () => ({
   enhancedPerformanceTracker: {
     startOperation: vi.fn(() => 'test-perf-id'),
     markApiStart: vi.fn(() => Date.now()),
@@ -75,15 +75,15 @@ vi.mock('../../src/middleware/performance-enhanced.js', () => ({
   },
 }));
 
-vi.mock('../../src/api/operations/search.js', () => ({
+vi.mock('@api/operations/search.js', () => ({
   searchObject: vi.fn(),
 }));
 
-import { advancedSearchCompanies } from '../../src/objects/companies/index.js';
-import { advancedSearchPeople } from '../../src/objects/people/index.js';
-import { listTasks } from '../../src/objects/tasks.js';
-import { searchLists } from '../../src/objects/lists.js';
-import { searchObject } from '../../src/api/operations/search.js';
+import { advancedSearchCompanies } from '@/objects/companies/index.js';
+import { advancedSearchPeople } from '@/objects/people/index.js';
+import { listTasks } from '@/objects/tasks.js';
+import { searchLists } from '@/objects/lists.js';
+import { searchObject } from '@api/operations/search.js';
 
 describe('Content Search Functionality', () => {
   beforeEach(() => {

--- a/test/services/search-strategies/CompanySearchStrategy.test.ts
+++ b/test/services/search-strategies/CompanySearchStrategy.test.ts
@@ -6,21 +6,21 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // Mock searchObject before importing CompanySearchStrategy
-vi.mock('../../../src/api/operations/search.js', () => ({
+vi.mock('@api/operations/search.js', () => ({
   searchObject: vi.fn(),
 }));
 
-import { CompanySearchStrategy } from '../../../src/services/search-strategies/CompanySearchStrategy.js';
+import { CompanySearchStrategy } from '@services/search-strategies/CompanySearchStrategy.js';
 import {
   SearchType,
   MatchType,
   SortType,
   UniversalResourceType,
-} from '../../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord } from '../../../src/types/attio.js';
-import { StrategyDependencies } from '../../../src/services/search-strategies/interfaces.js';
-import { FilterValidationError } from '../../../src/errors/api-errors.js';
-import { searchObject } from '../../../src/api/operations/search.js';
+} from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord } from '@shared-types/attio.js';
+import { StrategyDependencies } from '@services/search-strategies/interfaces.js';
+import { FilterValidationError } from '@errors/api-errors.js';
+import { searchObject } from '@api/operations/search.js';
 
 describe('CompanySearchStrategy', () => {
   let strategy: CompanySearchStrategy;

--- a/test/services/search-strategies/TaskSearchStrategy.test.ts
+++ b/test/services/search-strategies/TaskSearchStrategy.test.ts
@@ -4,33 +4,33 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { TaskSearchStrategy } from '../../../src/services/search-strategies/TaskSearchStrategy.js';
+import { TaskSearchStrategy } from '@services/search-strategies/TaskSearchStrategy.js';
 import {
   SearchType,
   MatchType,
   SortType,
   UniversalResourceType,
-} from '../../../src/handlers/tool-configs/universal/types.js';
-import { AttioRecord, AttioTask } from '../../../src/types/attio.js';
-import { StrategyDependencies } from '../../../src/services/search-strategies/interfaces.js';
-import { UniversalUtilityService } from '../../../src/services/UniversalUtilityService.js';
-import { SearchUtilities } from '../../../src/services/search-utilities/SearchUtilities.js';
-import { enhancedPerformanceTracker } from '../../../src/middleware/performance-enhanced.js';
+} from '@handlers/tool-configs/universal/types.js';
+import { AttioRecord, AttioTask } from '@shared-types/attio.js';
+import { StrategyDependencies } from '@services/search-strategies/interfaces.js';
+import { UniversalUtilityService } from '@services/UniversalUtilityService.js';
+import { SearchUtilities } from '@services/search-utilities/SearchUtilities.js';
+import { enhancedPerformanceTracker } from '@/middleware/performance-enhanced.js';
 
 // Mock dependencies
-vi.mock('../../../src/middleware/performance-enhanced.js', () => ({
+vi.mock('@/middleware/performance-enhanced.js', () => ({
   enhancedPerformanceTracker: {
     markTiming: vi.fn(),
   },
 }));
 
-vi.mock('../../../src/services/UniversalUtilityService.js', () => ({
+vi.mock('@services/UniversalUtilityService.js', () => ({
   UniversalUtilityService: {
     convertTaskToRecord: vi.fn(),
   },
 }));
 
-vi.mock('../../../src/services/search-utilities/SearchUtilities.js', () => ({
+vi.mock('@services/search-utilities/SearchUtilities.js', () => ({
   SearchUtilities: {
     getTaskFieldValue: vi.fn(),
     rankByRelevance: vi.fn(),


### PR DESCRIPTION
## Summary

This continues issue #745 by moving the current high-signal alias-import batch onto the repo's configured path aliases. The selected service, dispatcher, and paired test files no longer depend on deep relative source paths, and the test mocks now use the same alias names as the imports they replace.

## What

- Migrates create/update service imports to existing source aliases.
- Migrates legacy dispatcher operation imports to `@handlers`, `@utils`, `@api`, `@shared-types`, and `@/objects` aliases.
- Migrates paired service-test imports and source-targeting `vi.mock()` specifiers to matching aliases.
- Adds a current-batch plan for issue #745 based on the fresh hotspot scan.

## Why

The original #745 scan is stale: the previous top files are already migrated, but the repo still has remaining deep relative imports. This PR keeps the migration reviewable by targeting one current hotspot batch instead of trying to close the whole issue in a large sweep.

## Tests

- `rg -n "from ['\"](\.\./){2,}|import\(['\"](\.\./){2,}|vi\.mock\(['\"](\.\./){2,}" <changed-files>` - passed, no matches
- `git diff --check` - passed
- `bun run typecheck` - blocked locally: `/opt/homebrew/bin/tsc` 5.8.3 rejects `tsconfig.json` with `TS5103: Invalid value for '--ignoreDeprecations'`
- `bun run test:offline:run -- test/services/UniversalCreateService-core-resources.test.ts test/services/UniversalCreateService-objects-deals-tasks.test.ts test/services/UniversalUpdateService-validation.test.ts test/services/UniversalSearchService-records-tasks.test.ts test/services/content-search.test.ts test/services/search-strategies/TaskSearchStrategy.test.ts test/services/search-strategies/CompanySearchStrategy.test.ts` - blocked locally: `vitest: command not found`
- `bun run lint:check` - blocked locally: `wireit: command not found`

## AI Assistance

AI-assisted implementation and review were used. I understand the final code and behavior. Local verification was limited by the missing/mismatched dependency toolchain described above; static checks and reviewer passes completed.

Refs #745

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
