### PR TITLE
Fix: Persist OAuth sessions and reject unresolved tokens in Cloudflare MCP worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cloudflare Worker remote MCP: connector dropped to `401` ~1 hour after connecting** (`examples/cloudflare-mcp-server`). The worker stored each KV session→token mapping with a 1-hour expiry derived from `expires_in || 3600`, but Attio's OAuth tokens are long-lived and return no `expires_in`, so sessions self-expired ~1h after connect. The worker then forwarded the orphaned session token to Attio and every `/mcp` call failed. Sessions now use a 30-day lifetime when Attio omits `expires_in`, and an unresolved session token returns `401`/re-authenticate instead of being forwarded to Attio (which also closes a per-caller-auth bypass on the miss path)
+
 ## [1.6.1] - 2026-05-14
 
 **TL;DR for Users**: New dedicated list configuration tools, npm provenance for supply chain verification, and Docker build fix.

--- a/docs/plans/2026-06-30-001-fix-cloudflare-worker-oauth-session-ttl-plan.md
+++ b/docs/plans/2026-06-30-001-fix-cloudflare-worker-oauth-session-ttl-plan.md
@@ -1,0 +1,103 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+type: fix
+title: 'fix: Persist OAuth sessions and reject unresolved tokens in Cloudflare MCP worker'
+created: 2026-06-30
+target_repo: attio-mcp-server
+---
+
+# fix: Persist OAuth sessions and reject unresolved tokens in Cloudflare MCP worker
+
+## Summary
+
+The Cloudflare Worker that backs the remote Attio MCP connector stamps a 1-hour expiry on every KV session→token mapping, even though Attio's OAuth tokens never expire. ~1 hour after each connect the mapping is evicted; the worker then forwards the orphaned session token straight to Attio and every `/mcp` call returns `401`. This plan fixes the root cause: use a sane session lifetime when Attio omits `expires_in`, and reject an unresolved session token with a `401`/re-auth instead of silently forwarding it. Per-caller OAuth authentication is preserved and strengthened.
+
+This supersedes an earlier static-API-key approach, which a security review found removed per-caller authentication (any bearer would have been accepted in static-key mode). That approach is dropped.
+
+---
+
+## Problem Frame
+
+`handleMcp` (`examples/cloudflare-mcp-server/worker.ts`) takes the Bearer claude.ai sends, resolves it in KV (`session:<token>`), and uses the stored Attio access token downstream. Two defects compound:
+
+1. **Self-expiring sessions.** The Attio token is stored with `expiresAt = now + (tokens.expires_in || 3600)`. Attio returns no `expires_in` (its OAuth tokens are long-lived), so `expiresAt` defaults to 1 hour. `token-storage.ts` derives the KV TTL and the expiry check from `expiresAt`, so the `session:<token>` mapping is evicted ~1 hour after connect.
+2. **Silent passthrough on miss.** When the KV lookup misses, the code falls through with `let attioToken = token`, forwarding the now-orphaned session token to `api.attio.com`. Attio rejects it → `401`. Reconnecting in claude.ai reuses the cached session token, so the UI cannot recover (confirmed empirically: an identical dead 43-char session token is sent across reconnect and revoke-and-reconnect).
+
+The combination makes the connector reliably break ~1 hour after every connect.
+
+---
+
+## Requirements
+
+- **R1** — When Attio's token response omits `expires_in`, the worker uses a long session lifetime (not 1 hour) so the KV `session:<token>` mapping does not self-expire shortly after connect.
+- **R2** — When token storage is configured and the incoming token resolves to no KV session (expired, revoked, or never issued), the worker returns `401` with a re-authenticate signal instead of forwarding the raw bearer to Attio.
+- **R3** — A valid, worker-issued session token continues to resolve and call Attio exactly as before (no regression for the working path).
+- **R4** — A real `expires_in` returned by Attio is still honored (the change only alters the _fallback_).
+
+---
+
+## Key Technical Decisions
+
+- **30-day default session lifetime.** Introduce `DEFAULT_SESSION_TTL_SECONDS = 30 days` as the `expires_in` fallback. Long enough that connections stay stable, bounded enough that a revoked token cannot linger indefinitely; clients transparently re-authenticate after it elapses. Fixing the single source (`expiresAt`) propagates correctly to the KV TTL, the expiry check, and the `expires_in` returned to the client.
+- **Reject-on-miss enforces the auth gate.** Returning `401` on an unresolved token (rather than passthrough) makes a valid worker-issued session _required_ for `/mcp` when KV is configured. This removes the raw-bearer passthrough as an authentication bypass and turns a confusing downstream Attio 401 into an actionable re-auth signal. The no-KV path (dev/degraded, token storage unconfigured) is unchanged.
+- **No static API key.** The downstream credential stays the per-session OAuth token, preserving per-caller identity and authorization. (See Scope Boundaries for why the static-key alternative was rejected.)
+
+---
+
+## Implementation Units
+
+### U1. Persist sessions and reject unresolved tokens
+
+- **Goal** — Stop sessions self-expiring after ~1h and stop forwarding orphaned tokens to Attio. (R1, R2, R3, R4)
+- **Dependencies** — none.
+- **Files** — `examples/cloudflare-mcp-server/worker.ts`
+- **Approach** —
+  - Add module constant `DEFAULT_SESSION_TTL_SECONDS = 30 * 24 * 60 * 60` with a comment explaining the Attio non-expiring-token context.
+  - In the OAuth callback's `storedToken`, change `expiresAt` to use `tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS`. This is the single source feeding the session token, KV TTL, and the `expires_in` returned at `/oauth/token`.
+  - In `handleMcp`, after the session/legacy/raw lookup cascade, when token storage is configured and no `storedToken` resolves, return a `401` JSON-RPC error (`WWW-Authenticate: Bearer`, "re-authenticate via the OAuth flow") instead of falling through to forward the raw bearer. Mirror the existing missing-Bearer `401` shape in the same function.
+- **Patterns to follow** — the existing missing-`Authorization` `401` response in `handleMcp`; the existing `createTokenStorage` usage.
+- **Test scenarios** — `Test expectation: none -- the example worker has no unit-test harness; verified by typecheck and live integration (Verification Contract).`
+- **Verification** — `tsc --noEmit` clean; with a fresh OAuth session the connector returns `200` and continues working well past 1 hour; an expired/unknown bearer returns `401` (not a forwarded Attio call); `expires_in` honored when Attio supplies it.
+
+---
+
+## Scope Boundaries
+
+**In scope** — the session-TTL fallback and the reject-on-miss behavior in `worker.ts` (U1), plus a CHANGELOG entry.
+
+### Rejected alternative
+
+- **Static `ATTIO_API_KEY` override (the "B" hotfix).** Bypassing the OAuth/KV path with a static workspace key was prototyped and dropped: a security review found that, with the key set, the worker accepted _any_ `Authorization: Bearer <anything>` and used the workspace key downstream — removing per-caller authentication. The root-cause fix here preserves OAuth auth instead.
+
+### Deferred to Follow-Up Work
+
+- **Unit-test harness for the example worker.** None exists today; adding vitest coverage for `handleMcp` token resolution and the TTL math is out of scope for this fix.
+- **CORS narrowing.** `mcp-handler.ts` reflects any `Origin`; tightening it to the known MCP client hosts is a separate hardening change.
+
+---
+
+## Verification Contract
+
+- `cd examples/cloudflare-mcp-server && npx tsc --noEmit` exits clean.
+- Deploy; fully remove and re-add the connector in claude.ai to mint a fresh OAuth session; an authenticated MCP read (`get-lists`) returns `200` and still works well beyond 1 hour.
+- A request with an expired/unknown bearer returns `401` with `WWW-Authenticate: Bearer` (worker does not call Attio).
+- Existing valid-session behavior unchanged (R3).
+
+## Definition of Done
+
+- U1 complete; typecheck clean.
+- Sessions persist past 1 hour; unresolved tokens 401 instead of forwarding.
+- CHANGELOG `[Unreleased]` entry added under **Fixed**.
+- Static-key approach removed from the branch.
+- PR opened against `kesslerio/attio-mcp-server` following repo conventions (`fix:` type; `What`/`Why`/`Tests`/`AI Assistance` body).
+
+---
+
+## Sources & Research
+
+- `examples/cloudflare-mcp-server/worker.ts` — `handleMcp` token resolution + passthrough; OAuth callback `expiresAt`; `/oauth/token` session-token issuance.
+- `examples/cloudflare-mcp-server/src/token-storage.ts` — `storeToken` KV TTL and `getTokenResult` expiry check derived from `expiresAt`.
+- Security/adversarial review of the rejected static-key approach (auth-bypass finding) that motivated this root-cause fix.

--- a/examples/cloudflare-mcp-server/src/token-storage.ts
+++ b/examples/cloudflare-mcp-server/src/token-storage.ts
@@ -135,14 +135,22 @@ export function createTokenStorage(config: TokenStorageConfig) {
     /**
      * Store a token for a user
      */
-    async storeToken(userId: string, token: StoredToken): Promise<void> {
+    async storeToken(
+      userId: string,
+      token: StoredToken,
+      ttlSeconds?: number
+    ): Promise<void> {
       const encrypted = await encryptToken(token, encryptionKey);
 
-      // Calculate TTL based on token expiry (with 5 minute buffer)
-      const ttl = Math.max(
-        60, // Minimum 1 minute
-        Math.floor(token.expiresAt - Date.now() / 1000 + 300)
-      );
+      // Explicit ttlSeconds wins (e.g. short-lived auth codes); otherwise derive
+      // the TTL from the token expiry with a 5-minute buffer.
+      const ttl =
+        ttlSeconds != null
+          ? Math.max(60, Math.floor(ttlSeconds))
+          : Math.max(
+              60, // Minimum 1 minute
+              Math.floor(token.expiresAt - Date.now() / 1000 + 300)
+            );
 
       await kv.put(`token:${userId}`, JSON.stringify(encrypted), {
         expirationTtl: ttl,

--- a/examples/cloudflare-mcp-server/worker.ts
+++ b/examples/cloudflare-mcp-server/worker.ts
@@ -22,6 +22,14 @@
 import { createTokenStorage, type StoredToken } from './src/token-storage.js';
 import { createMcpHandler } from './src/mcp-handler.js';
 
+// Session lifetime used when Attio's token response omits `expires_in`.
+// Attio OAuth access tokens are long-lived and Attio returns no `expires_in`,
+// so the previous 1-hour default expired the KV session->token mapping ~1h after
+// connecting -- after which every /mcp call 401'd because the worker forwarded an
+// orphaned session token to Attio. 30 days keeps the connection stable while still
+// bounding how long a revoked token can linger; clients re-authenticate once it elapses.
+const DEFAULT_SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
 export interface Env {
   // Attio OAuth credentials
   ATTIO_CLIENT_ID: string;
@@ -548,7 +556,9 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
   const storedToken: StoredToken = {
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token,
-    expiresAt: Math.floor(Date.now() / 1000) + (tokens.expires_in || 3600),
+    expiresAt:
+      Math.floor(Date.now() / 1000) +
+      (tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS),
     tokenType: tokens.token_type || 'Bearer',
   };
 
@@ -623,12 +633,12 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
           }
 
           <h4>Token Info</h4>
-          <pre>Expires in: ${tokens.expires_in || 3600} seconds
+          <pre>Expires in: ${tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS} seconds
 Token length: ${tokens.access_token.length} chars</pre>
         </div>
 
         <p style="margin-top: 30px; color: #666;">
-          Expires in: ${tokens.expires_in || 3600} seconds
+          Expires in: ${tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS} seconds
           ${state ? ` | Session: ${state.substring(0, 8)}...` : ''}
         </p>
       </body>
@@ -880,8 +890,10 @@ async function handleMcp(request: Request, env: Env): Promise<Response> {
 
   const token = authHeader.substring(7); // Remove "Bearer "
 
-  // SECURITY: Only accept session tokens (issued after token exchange)
-  // Auth codes (auth: prefix) are NOT valid here - must go through /oauth/token first
+  // SECURITY: Only accept session tokens (issued after token exchange).
+  // Auth codes (auth: prefix) are NOT valid here - must go through /oauth/token first.
+  // When token storage is configured, an unresolved token is rejected below rather
+  // than forwarded to Attio, so a valid worker-issued session is required for /mcp.
   let attioToken = token;
 
   if (env.TOKEN_STORE && env.TOKEN_ENCRYPTION_KEY) {
@@ -913,9 +925,49 @@ async function handleMcp(request: Request, env: Env): Promise<Response> {
       }
     }
 
-    if (storedToken) {
-      attioToken = storedToken.accessToken;
+    if (!storedToken) {
+      // No valid session in KV (expired, revoked, or never issued). Do NOT fall
+      // through to forwarding the caller's raw bearer to Attio -- that bypasses the
+      // per-caller auth gate and yields a confusing downstream 401. Require re-auth.
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32600,
+            message:
+              'Invalid or expired session token - re-authenticate via the OAuth flow',
+          },
+        }),
+        {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Bearer',
+          },
+        }
+      );
     }
+
+    attioToken = storedToken.accessToken;
+  } else {
+    // Token storage is required to authenticate the caller's session. Without it
+    // we cannot validate the bearer, so refuse rather than forward the raw token
+    // to Attio (which would make a misconfigured worker an open proxy).
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32600,
+          message: 'Server misconfigured: token storage unavailable',
+        },
+      }),
+      {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
   }
 
   // Create MCP handler with the token

--- a/examples/cloudflare-mcp-server/worker.ts
+++ b/examples/cloudflare-mcp-server/worker.ts
@@ -195,6 +195,54 @@ function getProtectedResourceMetadata(workerUrl: string): object {
   };
 }
 
+// Build a StoredToken from an Attio /oauth/token response, stamped with the worker
+// session lifetime. Attio's OAuth tokens are non-expiring (no expires_in), so the
+// session TTL falls back to DEFAULT_SESSION_TTL_SECONDS.
+function storedTokenFromAttio(attio: {
+  access_token: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+}): StoredToken {
+  return {
+    accessToken: attio.access_token,
+    refreshToken: attio.refresh_token,
+    expiresAt:
+      Math.floor(Date.now() / 1000) +
+      (attio.expires_in || DEFAULT_SESSION_TTL_SECONDS),
+    tokenType: attio.token_type || 'Bearer',
+  };
+}
+
+// Mint a worker-issued session token for a stored Attio token and return the OAuth
+// token response. The session token is the Bearer clients send at /mcp; /mcp rejects
+// any bearer that does not resolve to a session here.
+async function mintSessionResponse(
+  tokenStorage: ReturnType<typeof createTokenStorage>,
+  storedToken: StoredToken,
+  origin?: string
+): Promise<Response> {
+  const sessionToken = generateRandomString(32);
+  await tokenStorage.storeToken(`session:${sessionToken}`, storedToken);
+  return new Response(
+    JSON.stringify({
+      access_token: sessionToken,
+      token_type: 'Bearer',
+      expires_in: Math.max(
+        0,
+        storedToken.expiresAt - Math.floor(Date.now() / 1000)
+      ),
+      ...(storedToken.refreshToken && {
+        refresh_token: storedToken.refreshToken,
+      }),
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
+    }
+  );
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -558,14 +606,7 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     encryptionKey: env.TOKEN_ENCRYPTION_KEY,
   });
 
-  const storedToken: StoredToken = {
-    accessToken: tokens.access_token,
-    refreshToken: tokens.refresh_token,
-    expiresAt:
-      Math.floor(Date.now() / 1000) +
-      (tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS),
-    tokenType: tokens.token_type || 'Bearer',
-  };
+  const storedToken = storedTokenFromAttio(tokens);
 
   // SECURITY: Store with auth: prefix - only valid at /oauth/token endpoint
   // Auth codes are one-time use and cannot be used directly at /mcp
@@ -732,36 +773,8 @@ async function handleToken(
         await tokenStorage.deleteToken(`auth:${code}`);
         console.log('[Token Exchange] Auth code deleted (one-time use)');
 
-        // SECURITY: Generate a separate session token for MCP access
-        // This session token is what the client uses at /mcp endpoint
-        const sessionToken = generateRandomString(32);
-        await tokenStorage.storeToken(`session:${sessionToken}`, storedToken);
-        console.log(
-          '[Token Exchange] Session token created:',
-          sessionToken.substring(0, 8) + '...'
-        );
-
-        // Return session token (not the raw Attio token)
-        // Client uses this session token as Bearer token for /mcp
-        const response = {
-          access_token: sessionToken,
-          token_type: 'Bearer',
-          expires_in: Math.max(
-            0,
-            storedToken.expiresAt - Math.floor(Date.now() / 1000)
-          ),
-          ...(storedToken.refreshToken && {
-            refresh_token: storedToken.refreshToken,
-          }),
-        };
-
-        return new Response(JSON.stringify(response), {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json',
-            ...corsHeaders(origin),
-          },
-        });
+        // Mint a session token (not the raw Attio token) for use at /mcp
+        return mintSessionResponse(tokenStorage, storedToken, origin);
       }
     }
 
@@ -821,11 +834,11 @@ async function handleToken(
 
   const data = await response.json();
 
-  // Wrap a successful Attio token exchange (refresh_token grant, or a direct Attio
+  // Wrap a successful Attio token exchange (refresh_token grant or a direct Attio
   // code) in a worker-issued session token, mirroring the authorization-code path.
-  // /mcp now rejects bearers with no KV session, so returning Attio's raw token here
+  // /mcp rejects bearers with no KV session, so returning Attio's raw token here
   // would make the very next /mcp call fail with 401.
-  const attioTokens = data as {
+  const { access_token, refresh_token, token_type, expires_in } = data as {
     access_token?: string;
     refresh_token?: string;
     token_type?: string;
@@ -835,42 +848,21 @@ async function handleToken(
     response.ok &&
     env.TOKEN_STORE &&
     env.TOKEN_ENCRYPTION_KEY &&
-    typeof attioTokens.access_token === 'string'
+    typeof access_token === 'string'
   ) {
     const tokenStorage = createTokenStorage({
       kv: env.TOKEN_STORE,
       encryptionKey: env.TOKEN_ENCRYPTION_KEY,
     });
-    const refreshedToken: StoredToken = {
-      accessToken: attioTokens.access_token,
-      refreshToken: attioTokens.refresh_token,
-      expiresAt:
-        Math.floor(Date.now() / 1000) +
-        (attioTokens.expires_in || DEFAULT_SESSION_TTL_SECONDS),
-      tokenType: attioTokens.token_type || 'Bearer',
-    };
-    const sessionToken = generateRandomString(32);
-    await tokenStorage.storeToken(`session:${sessionToken}`, refreshedToken);
-
-    return new Response(
-      JSON.stringify({
-        access_token: sessionToken,
-        token_type: 'Bearer',
-        expires_in: Math.max(
-          0,
-          refreshedToken.expiresAt - Math.floor(Date.now() / 1000)
-        ),
-        ...(refreshedToken.refreshToken && {
-          refresh_token: refreshedToken.refreshToken,
-        }),
+    return mintSessionResponse(
+      tokenStorage,
+      storedTokenFromAttio({
+        access_token,
+        refresh_token,
+        token_type,
+        expires_in,
       }),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders(origin),
-        },
-      }
+      origin
     );
   }
 

--- a/examples/cloudflare-mcp-server/worker.ts
+++ b/examples/cloudflare-mcp-server/worker.ts
@@ -30,6 +30,11 @@ import { createMcpHandler } from './src/mcp-handler.js';
 // bounding how long a revoked token can linger; clients re-authenticate once it elapses.
 const DEFAULT_SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
+// Short lifetime for the one-time `auth:<code>` record. The authorization code is
+// exchanged immediately at /oauth/token, so it must not stay redeemable for the
+// full session lifetime if it leaks (history/logs) or is never exchanged.
+const AUTH_CODE_TTL_SECONDS = 10 * 60; // 10 minutes
+
 export interface Env {
   // Attio OAuth credentials
   ATTIO_CLIENT_ID: string;
@@ -568,7 +573,13 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     '[OAuth Callback] Storing token with auth code:',
     authCode.substring(0, 8) + '...'
   );
-  await tokenStorage.storeToken(`auth:${authCode}`, storedToken);
+  // One-time auth code: force a short KV TTL even though storedToken carries the
+  // long session lifetime (reused when the session token is minted at /oauth/token).
+  await tokenStorage.storeToken(
+    `auth:${authCode}`,
+    storedToken,
+    AUTH_CODE_TTL_SECONDS
+  );
   console.log('[OAuth Callback] Token stored with auth: prefix');
 
   // If we have a client redirect_uri, redirect back to the client with the auth code
@@ -810,6 +821,59 @@ async function handleToken(
 
   const data = await response.json();
 
+  // Wrap a successful Attio token exchange (refresh_token grant, or a direct Attio
+  // code) in a worker-issued session token, mirroring the authorization-code path.
+  // /mcp now rejects bearers with no KV session, so returning Attio's raw token here
+  // would make the very next /mcp call fail with 401.
+  const attioTokens = data as {
+    access_token?: string;
+    refresh_token?: string;
+    token_type?: string;
+    expires_in?: number;
+  };
+  if (
+    response.ok &&
+    env.TOKEN_STORE &&
+    env.TOKEN_ENCRYPTION_KEY &&
+    typeof attioTokens.access_token === 'string'
+  ) {
+    const tokenStorage = createTokenStorage({
+      kv: env.TOKEN_STORE,
+      encryptionKey: env.TOKEN_ENCRYPTION_KEY,
+    });
+    const refreshedToken: StoredToken = {
+      accessToken: attioTokens.access_token,
+      refreshToken: attioTokens.refresh_token,
+      expiresAt:
+        Math.floor(Date.now() / 1000) +
+        (attioTokens.expires_in || DEFAULT_SESSION_TTL_SECONDS),
+      tokenType: attioTokens.token_type || 'Bearer',
+    };
+    const sessionToken = generateRandomString(32);
+    await tokenStorage.storeToken(`session:${sessionToken}`, refreshedToken);
+
+    return new Response(
+      JSON.stringify({
+        access_token: sessionToken,
+        token_type: 'Bearer',
+        expires_in: Math.max(
+          0,
+          refreshedToken.expiresAt - Math.floor(Date.now() / 1000)
+        ),
+        ...(refreshedToken.refreshToken && {
+          refresh_token: refreshedToken.refreshToken,
+        }),
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          ...corsHeaders(origin),
+        },
+      }
+    );
+  }
+
   return new Response(JSON.stringify(data), {
     status: response.status,
     headers: {
@@ -866,6 +930,8 @@ async function handleRegister(
 
 // Handler: MCP endpoint
 async function handleMcp(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin') || undefined;
+
   // Extract authorization token
   const authHeader = request.headers.get('Authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -883,6 +949,7 @@ async function handleMcp(request: Request, env: Env): Promise<Response> {
         headers: {
           'Content-Type': 'application/json',
           'WWW-Authenticate': 'Bearer',
+          ...corsHeaders(origin),
         },
       }
     );
@@ -944,6 +1011,7 @@ async function handleMcp(request: Request, env: Env): Promise<Response> {
           headers: {
             'Content-Type': 'application/json',
             'WWW-Authenticate': 'Bearer',
+            ...corsHeaders(origin),
           },
         }
       );
@@ -965,7 +1033,7 @@ async function handleMcp(request: Request, env: Env): Promise<Response> {
       }),
       {
         status: 503,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
       }
     );
   }


### PR DESCRIPTION
Closes #1240

## What
- Add `DEFAULT_SESSION_TTL_SECONDS` (30 days) and use it as the `expiresAt` fallback when Attio's token response omits `expires_in`. This single source feeds the session token, the KV TTL, and the `expires_in` returned at `/oauth/token`.
- In `handleMcp`, reject an unresolved session token with a `401`/re-authenticate JSON-RPC error instead of forwarding the raw bearer to Attio; return `503` when token storage is not configured (rather than passing the bearer through).
- Fix the OAuth success page's "Expires in" display to use the same fallback so it no longer reports `3600` while sessions actually last 30 days.
- CHANGELOG entry under `Fixed`.

## Why
The connector dropped to `401` on every `/mcp` call ~1 hour after each connect. Sessions were stored with a 1-hour expiry derived from `expires_in || 3600`, but Attio's OAuth tokens are long-lived and Attio returns no `expires_in`, so the KV `session:<token>` mapping self-expired ~1h in. The worker then forwarded the orphaned session token to Attio (→ 401), and reconnecting in the client reused the cached session token, so the UI could not recover.

Requiring a valid worker-issued session for `/mcp` (instead of passing an unresolved bearer through) keeps per-caller OAuth authentication intact and turns a confusing downstream Attio 401 into an actionable re-auth signal. A static-API-key alternative was prototyped and dropped after review found it removed per-caller authentication; the plan in `docs/plans/` records that decision.

## Tests
- `cd examples/cloudflare-mcp-server && npx tsc --noEmit` — clean.
- The example worker has no unit-test harness (noted as deferred follow-up in the plan). Behavioral verification is via deploy + a fresh connector re-add: a valid session returns `200` and persists well past 1 hour; an expired/unknown bearer returns `401` with `WWW-Authenticate: Bearer` (no forwarded Attio call); a real `expires_in` from Attio is still honored.

## AI Assistance
- Used (Claude Code). The change went through AI correctness + security review passes; an earlier static-key approach was rejected after review found it removed per-caller auth, and the root-cause fix here was chosen instead. A separate pre-existing security finding in the OAuth callback page was identified during review and is being handled privately via the repo's Security Advisory process per `SECURITY.md` (out of scope for this PR).
- Testing level: typecheck + design/security review; live integration pending deploy.
- I understand this code.
