### PR TITLE
Fix: Escape user-controlled values in OAuth callback HTML output

### DIFF
--- a/examples/cloudflare-mcp-server/worker.ts
+++ b/examples/cloudflare-mcp-server/worker.ts
@@ -89,6 +89,16 @@ function normalizeUrl(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
+// Escape user-controlled values before interpolating them into HTML responses.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // Known MCP client hostnames (exact match required)
 const KNOWN_MCP_CLIENT_HOSTS = [
   'claude.ai', // Claude.ai
@@ -467,8 +477,8 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
         <head><title>OAuth Error</title></head>
         <body style="font-family: system-ui; text-align: center; padding: 50px;">
           <h1>Authentication Failed</h1>
-          <p>Error: ${error}</p>
-          <p>${url.searchParams.get('error_description') || ''}</p>
+          <p>Error: ${escapeHtml(error)}</p>
+          <p>${escapeHtml(url.searchParams.get('error_description') || '')}</p>
         </body>
       </html>
     `,
@@ -672,25 +682,25 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
           <p>Your tokens have been securely stored. For security, only previews are shown below.</p>
 
           <h4>Access Token (Preview)</h4>
-          <div class="token-box">${tokens.access_token.substring(0, 12)}...${tokens.access_token.slice(-8)}</div>
+          <div class="token-box">${escapeHtml(tokens.access_token.substring(0, 12))}...${escapeHtml(tokens.access_token.slice(-8))}</div>
           <p style="font-size: 12px; color: #666;">Token stored securely in KV. Use the server URL above to authenticate.</p>
 
           ${
             tokens.refresh_token
               ? `
           <h4>Refresh Token (Preview)</h4>
-          <div class="token-box">${tokens.refresh_token.substring(0, 12)}...${tokens.refresh_token.slice(-8)}</div>
+          <div class="token-box">${escapeHtml(tokens.refresh_token.substring(0, 12))}...${escapeHtml(tokens.refresh_token.slice(-8))}</div>
           `
               : ''
           }
 
           <h4>Token Info</h4>
-          <pre>Expires in: ${tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS} seconds
+          <pre>Expires in: ${escapeHtml(String(tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS))} seconds
 Token length: ${tokens.access_token.length} chars</pre>
         </div>
 
         <p style="margin-top: 30px; color: #666;">
-          Expires in: ${tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS} seconds
+          Expires in: ${escapeHtml(String(tokens.expires_in || DEFAULT_SESSION_TTL_SECONDS))} seconds
           ${state ? ` | Session: ${state.substring(0, 8)}...` : ''}
         </p>
       </body>


### PR DESCRIPTION
Closes #1242

## What
- Add an `escapeHtml` helper and apply it to user-controlled query parameters (`error`, `error_description`) interpolated into the OAuth callback error page.
- Defense-in-depth: also escape the Attio-derived token previews and `expires_in` rendered on the success page, so every dynamic value written into an HTML response is escaped consistently.

## Why
The callback HTML responses interpolated request-supplied values without HTML-escaping. User-controlled input written into `Content-Type: text/html` output must be escaped so HTML metacharacters render as inert text rather than markup. The escape set (`& < > " '`, with `&` first) is correct for the element-text context these values sit in.

## Tests
- `cd examples/cloudflare-mcp-server && npx tsc --noEmit` — clean.
- The example worker has no unit-test harness (tracked as a separate follow-up). Verified by inspection: the only remaining unescaped interpolations are `tokens.access_token.length` (a JS number) and `state.substring(0, 8)` (gated by `isValidStateParam`'s `^[A-Za-z0-9_-]{32,500}$` regex, which admits no HTML metacharacters).

## AI Assistance
- Used (Claude Code). The fix was checked by an independent security review pass confirming the escaping is correct and complete and that no other unescaped HTML sinks remain. Testing level: typecheck + security review. I understand this code.
