### PR TITLE
Docs: Fix broken workflow commands and trim stale agent context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ RULE: Changelogs for humans | WHEN: Updating CHANGELOG.md | DO: Clear, user-focu
 ## MCP TOOL TESTING
 
 RULE: Validate MCP tools with real API calls | WHEN: MCP tool changes | DO: Use mcp-test-client for end-to-end validation | ELSE: Production failures
-USAGE: Create a test in `test/mcp/` following the existing `*.mcp.test.ts` files there (e.g. `test/mcp/search-ranking.mcp.test.ts`); run with `bun run test:mcp`.
+USAGE: Create the test under `test/e2e/mcp/<category>/` following the existing `*.mcp.test.ts` files there (e.g. `test/e2e/mcp/core-operations/create-records.mcp.test.ts`) — that is the directory `vitest.config.mcp.ts` discovers; run with `bun run test:mcp`. Tests placed in `test/mcp/` are NOT picked up by `test:mcp`.
 
 ## Safety & Data Hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,15 +11,15 @@
 bun run typecheck
 
 # 3. Run tests
-bun run test -- -t "test name"     # Single suite
-bun run test:file -- "glob"        # Specific files
+bun run test -- -t "test name"          # Single suite
+bun run test:single "path/to.test.ts"   # Specific files (no watch)
 
 # 4. Lint before committing
-bun run lint:file -- "file1.ts"    # Specific files
-bun run lint                        # All files
+bun run lint:src                    # src/ only (lint:test for test/)
+bun run lint:check                  # Full cached lint
 
 # 5. Before creating PR
-bun run lint:claude && bun run test
+bun run lint:check && bun run test
 ```
 
 ## STYLE & TOKEN BUDGET
@@ -32,7 +32,7 @@ bun run lint:claude && bun run test
 
 ## TL;DR / Quick Start
 
-- **Pre‑commit must pass**: lint → format → build → `test:offline` → TS check (tests). No `--no-verify` unless justified.
+- **Pre‑commit/pre‑push**: see **Quality Gates** below (lint-staged on commit; typecheck + fast tests on push). No `--no-verify` unless justified.
 - **Run the right tests**: see the Test Matrix below (unit, integration, e2e, smoke, performance, affected, offline, ci-json).
 - **Logging**: structured `logger.*` only in `src/`; include `toolName,userId,requestId`; **no secrets/PII**.
 - **`formatResult`**: returns **string**; no env branching; wrap in `try/catch` + `createErrorResult`.
@@ -133,37 +133,7 @@ Avoid top‑level `oneOf`/`allOf`/`anyOf` in tool `inputSchema` due to client/In
 
 ## E2E Diagnostics (#545 & #568)
 
-**Use after failures for deep‑dive debugging; not during passing cycles.**
-
-- `bun run e2e:diagnose` — Enhanced test runner with standardized env
-- `bun run e2e:diagnose:core` — Core‑workflows focus
-- `bun run e2e:analyze` — Enhanced analysis with anomaly detection
-- `bun run e2e:analyze:trends` — 14‑day trend analysis
-- `bun run e2e:analyze -- --latest --stdout` — Latest only
-- `bun run e2e:analyze -- --basic --stdout` — Simple mode
-- `bun run e2e:health` — Env health (0–100), `--fix` to attempt auto‑fix
-
-**Quick path**
-
-```bash
-./scripts/e2e-diagnostics.sh --suite core-workflows --json --verbose
-bun run e2e:analyze -- --latest --stdout
-```
-
-**Manual fallback** (no bail, capture logs)
-
-```bash
-TASKS_DEBUG=true MCP_LOG_LEVEL=DEBUG LOG_FORMAT=json E2E_MODE=true USE_MOCK_DATA=false \
-  bunx vitest run test/e2e/suites/core-workflows.e2e.test.ts --reporter=verbose --reporter=json --bail=0 \
-  |& tee test-results/e2e-console.core-workflows.realapi.full.log
-```
-
-Grep examples (when needed)
-
-```bash
-rg -n "tasks\.createTask|tasks\.updateTask|Prepared (create|update) payload|response shape|assignees|referenced*actor" \
-  test-results/e2e-*-$(date +%Y%m%d)_*.log
-```
+**Use after failures for deep‑dive debugging; not during passing cycles.** Full command reference (diagnose/analyze/health, quick path, manual fallback): see `docs/testing.md` → **E2E Diagnostics**.
 
 ### Policy: E2E ≠ Mocks
 
@@ -199,8 +169,6 @@ PIPELINE STAGES:
 4. **Build Verification**: Ensure artifacts created correctly
 5. **Security Audit**: Dependency vulnerability scanning
 
-> This section replaces older CI/CD variants; remove any duplicate CI/CD sections below.
-
 ## Git Workflow & Issue/PR Policy
 
 ### GIT WORKFLOW COMMANDS
@@ -228,30 +196,12 @@ RULE: Update CHANGELOG before merge | WHEN: Merging any PR with user-facing chan
 - `Tests`: exact commands run (copy/pasteable).
 - `AI Assistance`: used/not used, testing level, prompt/session log link, and "I understand this code."
 
-### ISSUE WORKFLOW [MANDATORY CHECKLIST]
-
-1. `git branch --show-current` - Verify location
-2. `git checkout main` - Start from main
-3. `git pull origin main` - Get latest
-4. `git checkout -b feature/issue-{num}-{desc}` - Create issue branch
-5. `git status` - Verify clean state
-6. [Do work]
-7. `git commit -m "Type: Description #issue-num"` - Reference issue
-8. `git push -u origin HEAD` - Push branch
-9. `gh pr create -R kesslerio/attio-mcp-server` - Create PR
-10. **After merge**: Delete branch via GitHub UI or `git push origin --delete branch-name`
-
 ### ISSUE CREATION
 
 SEARCH FIRST: `gh issue list --repo kesslerio/attio-mcp-server --search "keyword"`
 CREATE: `gh issue create --title "Type: Description" --body "Details" --label "P2,type:bug,area:core"`
 
-**Required Labels** (Enforced by Issue Hygiene Automation):
-
-- **Priority**: P0(Critical), P1(High), P2(Medium), P3(Low), P4(Minor), P5(Trivial) - exactly one required
-- **Type**: bug, feature, enhancement, documentation, test, refactor, chore, ci, dependencies - exactly one required
-- **Status**: status:untriaged, status:ready, status:in-progress, status:blocked, status:needs-info, status:review - exactly one required
-- **Area**: area:core, area:api, area:build, area:dist, area:documentation, area:testing, area:performance, area:refactor, area:api:people, area:api:lists, area:api:notes, area:api:objects, area:api:records, area:api:tasks, area:extension, area:integration, area:security, area:rate-limiting, area:error-handling, area:logging - at least one required
+**Required Labels** (Enforced by Issue Hygiene Automation): exactly one **Priority** (`P0`–`P5`), exactly one **Type**, exactly one **Status** (`status:*`), at least one **Area** (`area:*`). List the current label set with `gh label list --repo kesslerio/attio-mcp-server` — do not work from memory; the repo carries both bare (`bug`) and namespaced (`type:bug`) type labels; prefer the namespaced `type:*` form (current practice).
 
 **Acceptance Criteria**: Required for P0-P2, optional for P3-P5. Format: `### Acceptance Criteria` with `- [ ]` checklist items.
 
@@ -266,21 +216,9 @@ CREATE: `gh issue create --title "Type: Description" --body "Details" --label "P
 
 Use Clear Thought MCP. **Introspect tools** first. Typical pattern: call `clear_thought` with operations like `sequential_thinking`, `mental_model`, `decision_framework`. (Variants exist across forks.)
 
-## Attio API Cheatsheet
+## Attio API — KEY IDS
 
-- Objects: `GET /v2/objects`
-- Attributes: `GET /v2/objects/{object}/attributes`
-- Records: `GET/POST/PATCH /v2/objects/{object}/records[/{id}]`
-- Lists: `GET /v2/lists`
-
-**Verify attributes**
-
-```bash
-curl -H "Authorization: Bearer $ATTIO_API_KEY" https://api.attio.com/v2/objects/companies/attributes \
-| jq -r '.data[] | "\(.api_slug) - \(.title)"'
-```
-
-### KEY IDS
+For endpoint shapes, use the official Attio API docs (Context7 first, per Documentation Search Workflow). Workspace-specific IDs that cannot be looked up:
 
 - Prospecting List: `88709359-01f6-478b-ba66-c07347891b6f`
 - Prospecting Stage: `f78ef71e-9306-4c37-90d6-e83550326228`
@@ -288,9 +226,8 @@ curl -H "Authorization: Bearer $ATTIO_API_KEY" https://api.attio.com/v2/objects/
 
 ## ANY TYPE REDUCTION STRATEGY (PR #483 Progress)
 
-RULE: Progressive `any` reduction | WHEN: Writing TypeScript | DO: Use Record<string, unknown> over any | ELSE: Warning count increases
-CURRENT: 395 warnings (improved from 957) | TARGET: <350 this sprint | GOAL: <200 in 3 months
-RECOMMENDED: Use `Record<string, unknown>` instead of `Record<string, any>` for better type safety
+RULE: Progressive `any` reduction | WHEN: Writing TypeScript | DO: Use `Record<string, unknown>` over `any` | ELSE: Warning count increases
+CURRENT THRESHOLDS: see `.github/lint-baseline.json` (baseline) and the **Quality Gates** CI threshold — do not hardcode counts here
 COMMON PATTERNS:
 
 - API responses: `Record<string, unknown>` or specific interface
@@ -301,8 +238,8 @@ COMMON PATTERNS:
 ## DEBUG UTILITIES
 
 RULE: Use debug scripts for targeted testing | WHEN: Developing/debugging | DO: Check `scripts/debug/README.md` | ELSE: Slower debugging cycles
-KEY SCRIPTS: `debug-field-mapping.js` (field transforms), `debug-formatresult.js` (Issue #483 compliance), `debug-tools.js` (tool registration), `debug-tool-lookup.js` (dispatcher routing)
-USAGE: `node scripts/debug/[script-name].js` (requires `bun run build` first)
+KEY SCRIPTS: `validation/debug-field-mapping.js` (field transforms), `format/test-formatresult-compliance.js` (Issue #483 compliance) — see `scripts/debug/README.md` for the current index
+USAGE: `node scripts/debug/<subdir>/<script-name>.js` (requires `bun run build` first)
 
 ## RELEASE PROCESS
 
@@ -322,25 +259,7 @@ RULE: Changelogs for humans | WHEN: Updating CHANGELOG.md | DO: Clear, user-focu
 ## MCP TOOL TESTING
 
 RULE: Validate MCP tools with real API calls | WHEN: MCP tool changes | DO: Use mcp-test-client for end-to-end validation | ELSE: Production failures
-SETUP: `bun add --dev mcp-test-client` (already installed)
-USAGE: Create test in `test/mcp/` directory:
-
-```typescript
-import { MCPTestClient } from 'mcp-test-client';
-
-const client = new MCPTestClient({
-  serverCommand: 'node',
-  serverArgs: ['./dist/index.js'],
-});
-await client.init();
-
-await client.assertToolCall('search-records', params, (result) => {
-  expect(result.isError).toBeFalsy();
-  // Validate real API responses
-});
-
-await client.cleanup();
-```
+USAGE: Create a test in `test/mcp/` following the existing `*.mcp.test.ts` files there (e.g. `test/mcp/search-ranking.mcp.test.ts`); run with `bun run test:mcp`.
 
 ## Safety & Data Hygiene
 
@@ -356,10 +275,3 @@ await client.cleanup();
 ## GITHUB CLI ADVANCED USAGE
 
 RULE: GitHub URL Access | WHEN: Reading GitHub URLs (issues, PRs, comments) | DO: Use `gh api` or `gh <resource> view` commands instead of WebFetch | ELSE: Access restrictions and incomplete data
-**Workflow Operations**: `gh workflow run workflow.yml` | `gh run list` | `gh run watch <run-id>` | `gh run rerun <run-id>`
-**API Direct Access**: `gh api repos/:owner/:repo/issues -F title="Bug" -F body="Details"` (POST) | `gh api repos/:owner/:repo/pulls/123 --method PATCH -F state=closed`
-**Comment Access**: `gh api repos/:owner/:repo/issues/comments/<comment-id>` | `gh pr view <number> --json comments --jq '.comments[].body'`
-**JSON Output**: `gh pr list --json number,title,state --jq '.[] | select(.state=="OPEN")'` | `gh issue list --json number,title --template '{{range .}}#{{.number}} {{.title}}{{"\n"}}{{end}}'`
-**Secret Management**: `gh secret set SECRET_NAME` | `gh secret list` | `gh variable set VAR_NAME --body "value"`
-**Useful Aliases**: `gh alias set prc 'pr create --title "$1" --body "$2" -R kesslerio/attio-mcp-server'` | `gh alias set iv 'issue view --json body --jq .body'`
-**Batch Operations**: `gh issue list --state open --json number | jq -r '.[].number' | xargs -I {} gh issue close {}`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,14 +29,14 @@ Run the repository validation flow:
 ```bash
 bun run typecheck
 bun run test
-bun run lint
+bun run lint:check
 ```
 
 Run narrower commands for targeted updates when appropriate:
 
 ```bash
-bun run test:file -- "glob"
-bun run lint:file -- "file1.ts"
+bun run test:single "path/to.test.ts"
+bun run lint:src        # or lint:test for test/ files
 ```
 
 ## AI-assisted contributions

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,13 +43,13 @@ cp .env.test.example .env.test
 
 # 3. Edit .env.test with your workspace-specific IDs
 # Or run the setup script to create test data:
-npm run setup:test-data
+bun run setup:test-data
 
 # 4. Run all tests
-npm test
+bun run test
 
 # 5. Run integration tests only
-npm run test:integration
+bun run test:integration
 ```
 
 ## Test Types
@@ -60,13 +60,13 @@ Unit tests run without requiring an API connection and test individual functions
 
 ```bash
 # Run all unit tests
-npm test
+bun run test
 
 # Run unit tests in watch mode
-npm test:watch
+bun run test:watch
 
 # Run offline tests only (no API calls)
-npm test:offline
+bun run test:offline
 ```
 
 ### Integration Tests (IT-XXX)
@@ -79,13 +79,13 @@ Integration tests make real API calls to verify individual API operations, edge 
 
 ```bash
 # Run all integration tests
-npm run test:integration
+bun run test:integration
 
 # Run specific integration test
-npm run test:integration -- test/integration/lists/add-record-to-list.integration.test.ts
+bun run test:integration -- test/integration/lists/add-record-to-list.integration.test.ts
 
 # Run integration tests in watch mode
-npm run test:integration:watch
+bun run test:integration:watch
 ```
 
 **Documentation:**
@@ -103,13 +103,13 @@ End-to-end tests validate complete user workflows through the MCP protocol, test
 
 ```bash
 # Run all E2E tests
-npm run test:e2e
+bun run test:e2e
 
 # Run MCP protocol tests
-npm run test:e2e:mcp
+bun run test:mcp
 
 # Run with diagnostics
-npm run e2e:diagnose
+bun run e2e:diagnose
 ```
 
 **Documentation:**
@@ -125,7 +125,7 @@ npm run e2e:diagnose
 | **Protocol**    | Direct Attio API                      | MCP → Attio API                                 |
 | **Numbering**   | IT-001, IT-105, IT-201...             | TC-001, TC-L01, TC-D01...                       |
 | **Examples**    | Rate limiting, batch CRUD, validation | Search workflow, deal creation, list management |
-| **Run Command** | `npm run test:integration`            | `npm run test:e2e`                              |
+| **Run Command** | `bun run test:integration`            | `bun run test:e2e`                              |
 
 ## Setting Up Integration Tests
 
@@ -166,7 +166,7 @@ Integration tests need specific records in your workspace to test against. You h
 Run the setup script to create test data in your workspace:
 
 ```bash
-npm run setup:test-data
+bun run setup:test-data
 ```
 
 This will:
@@ -188,10 +188,10 @@ To find IDs for existing records:
 
    ```bash
    # Build the project first
-   npm run build
+   bun run build
 
    # Discover available resources
-   npm run discover
+   bun run discover
    ```
 
 ## Running Tests
@@ -200,36 +200,36 @@ To find IDs for existing records:
 
 ```bash
 # Run all tests once
-npm test
+bun run test
 
 # Run tests in watch mode
-npm test:watch
+bun run test:watch
 
 # Run tests with coverage
-npm test:coverage
+bun run test:coverage
 ```
 
 ### Integration Tests Only
 
 ```bash
 # Run all integration tests
-npm run test:integration
+bun run test:integration
 
 # Run a specific integration test file
-npm run test:integration -- test/integration/lists/add-record-to-list.integration.test.ts
+bun run test:integration -- test/integration/lists/add-record-to-list.integration.test.ts
 
 # Run integration tests matching a pattern
-npm run test:integration -- -t "should add record to list"
+bun run test:integration -- -t "should add record to list"
 ```
 
 ### Offline Tests Only
 
 ```bash
 # Run tests that don't require API access
-npm test:offline
+bun run test:offline
 
 # Watch mode for offline tests
-npm test:watch:offline
+bun run test:watch:offline
 ```
 
 ## Test Configuration
@@ -294,14 +294,14 @@ ATTIO_API_KEY=your_actual_api_key
 
 1. Check that `.env.test` exists
 2. Verify it contains the required IDs
-3. Run `npm run setup:test-data` to create test data
+3. Run `bun run setup:test-data` to create test data
 
 #### "Record not found" errors
 
 The test records may have been deleted. Either:
 
 - Update `.env.test` with new IDs
-- Run `npm run setup:test-data` to create new test records
+- Run `bun run setup:test-data` to create new test records
 
 #### Rate limiting errors
 
@@ -315,10 +315,10 @@ The tests include retry logic, but if you see rate limiting:
 
 ```bash
 # Run tests with verbose output
-npm test -- --reporter=verbose
+bun run test -- --reporter=verbose
 
 # Run a single test with debugging
-npm test -- test/integration/lists/add-record-to-list.integration.test.ts --reporter=verbose
+bun run test -- test/integration/lists/add-record-to-list.integration.test.ts --reporter=verbose
 
 # Check test configuration
 cat .env.test
@@ -374,9 +374,9 @@ env:
 
 ### 4. Performance Tips
 
-- Run offline tests during development: `npm test:offline`
-- Use watch mode for faster feedback: `npm test:watch:offline`
-- Run integration tests before commits: `npm run test:integration`
+- Run offline tests during development: `bun run test:offline`
+- Use watch mode for faster feedback: `bun run test:watch:offline`
+- Run integration tests before commits: `bun run test:integration`
 - Consider using separate test workspaces for parallel CI runs
 
 ## Advanced Topics
@@ -433,3 +433,37 @@ When adding new integration tests:
 5. Ensure tests clean up after themselves
 
 For more information, see the main [README](../README.md) and [Contributing Guide](../CONTRIBUTING.md).
+
+## E2E Diagnostics (#545 & #568)
+
+Use after failures for deep-dive debugging; not during passing cycles.
+
+- `bun run e2e:diagnose` — Enhanced test runner with standardized env
+- `bun run e2e:diagnose:core` — Core-workflows focus
+- `bun run e2e:analyze` — Enhanced analysis with anomaly detection
+- `bun run e2e:analyze:trends` — 14-day trend analysis
+- `bun run e2e:analyze -- --latest --stdout` — Latest only
+- `bun run e2e:analyze -- --basic --stdout` — Simple mode
+- `bun run e2e:health` — Env health (0–100), `--fix` to attempt auto-fix
+
+### Quick path
+
+```bash
+./scripts/e2e-diagnostics.sh --suite core-workflows --json --verbose
+bun run e2e:analyze -- --latest --stdout
+```
+
+### Manual fallback (no bail, capture logs)
+
+```bash
+TASKS_DEBUG=true MCP_LOG_LEVEL=DEBUG LOG_FORMAT=json E2E_MODE=true USE_MOCK_DATA=false \
+  bunx vitest run test/e2e/suites/core-workflows.e2e.test.ts --reporter=verbose --reporter=json --bail=0 \
+  |& tee test-results/e2e-console.core-workflows.realapi.full.log
+```
+
+Grep examples (when needed)
+
+```bash
+rg -n "tasks\.createTask|tasks\.updateTask|Prepared (create|update) payload|response shape|assignees|referenced*actor" \
+  test-results/e2e-*-$(date +%Y%m%d)_*.log
+```

--- a/scripts/e2e-diagnostics.sh
+++ b/scripts/e2e-diagnostics.sh
@@ -148,7 +148,7 @@ echo "Log directory: $LOG_DIR"
 echo "Timestamp: $TIMESTAMP"
 
 # Build vitest command
-VITEST_CMD="node --env-file=.env ./node_modules/vitest/vitest.mjs run --config vitest.config.e2e.ts"
+VITEST_CMD="node --env-file=.env ./node_modules/vitest/vitest.mjs run --config configs/vitest/vitest.config.e2e.ts"
 
 # Add reporters
 if [[ "$JSON_OUTPUT" == true ]]; then


### PR DESCRIPTION
## Summary

- Problem: CLAUDE.md and CONTRIBUTING.md instruct running scripts that do not exist (`test:file`, `lint:file`, `lint:claude`) and bare `bun run lint`, which silently resolves to an unrelated non-eslint binary — so the documented pre-PR flow fails or misbehaves. docs/testing.md still used `npm run`/invalid `npm test:*` forms post-bun-migration and cited the non-existent `test:e2e:mcp`.
- Why it matters: CLAUDE.md loads into every agent session; broken first-touch commands and drifted snapshots (label taxonomy, ANY-warning sprint counts, moved debug scripts) actively mislead.
- What changed: commands replaced with verified real scripts (`test:single`, `lint:src`/`lint:test`, `lint:check`); stale TL;DR pre-commit description removed (Quality Gates is the single source, matches .husky); hardcoded label enumeration → `gh label list` pointer + namespaced-`type:*` convention note; warning-count snapshot → `.github/lint-baseline.json` pointer; E2E diagnostics reference moved to docs/testing.md with a pointer; derivable content trimmed (gh-CLI reference, REST cheatsheet — workspace KEY IDS kept, 10-step git recipe, inline MCP test example → pointer to real `test/mcp/*.mcp.test.ts`).
- What did not change (scope boundary): no code, no scripts, no CI config; all safety-critical rules retained (never-bypass hooks, cleanup dry-run-first, hmk rule, E2E ≠ mocks, precedence note).

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] Issue/PR templates or community files
- [x] Other

## Linked Issue/PR

- Closes #1251
- Related #

## User-visible / Behavior Changes

None (documentation only).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No

## Verification

What you personally verified (not just CI), and how:

- Verified scenarios: every replacement command exists in package.json (checked via jq); ran `bun run test:single test/api/attribute-types.test.ts` (14 passed) and `bun run lint:src` (eslint executes, warnings under threshold); confirmed `.husky/pre-commit` = `verify:staged` matches the retained Quality Gates description; confirmed all referenced paths exist (scripts/debug/README.md, .github/lint-baseline.json, scripts/e2e-diagnostics.sh, test/mcp/search-ranking.mcp.test.ts, test/e2e/suites/core-workflows.e2e.test.ts).
- Edge cases checked: label-convention note verified against live `gh label list` + last-40-issues usage (namespaced `type:*` dominates 32:10).
- What you did not verify: full offline suite locally — `test:offline:run` has 19 pre-existing timezone-dependent failures in `test/utils/date-parser.test.ts` unrelated to this docs-only diff (pushed with SKIP_PREPUSH=1 for that reason; CI runs the full suite).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: revert the squash commit.
- Files/config to restore: CLAUDE.md, CONTRIBUTING.md, docs/testing.md
- Known bad symptoms reviewers should watch for: none expected (docs only).

## Risks and Mitigations

- Risk: trimmed reference material someone relied on inline.
  - Mitigation: everything moved (not deleted) lives in docs/testing.md or is one `--help`/`gh label list` away; diff quotes all removals for restore.

## AI Assistance

- AI-assisted: yes
- Tools/agents/models used: Claude Code (Fable 5), context-engineering audit session
- Testing level: lightly tested (commands executed; docs-only)
- Human understanding confirmation: yes