### PR TITLE
Feature: Add deals-gated merge_records tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`merge_records` universal tool** — dry-runs a deals-only leftover-versus-live field plan, then requires explicit confirmation before patching, clearing, and native-merging into a new survivor record (#1264)
+
 ### Fixed
 
 - **Date-parser relative ranges are host-timezone stable** — `parseRelativeDate` now uses UTC calendar helpers (aligned with `timeframe-utils`), so week/month fixtures no longer flip under Asia/Tokyo and similar offsets (#1253)

--- a/docs/plans/2026-08-25-1244-feat-safe-deal-merge-plan.md
+++ b/docs/plans/2026-08-25-1244-feat-safe-deal-merge-plan.md
@@ -1,0 +1,383 @@
+---
+title: Safe Deal Merge - Plan
+type: feat
+date: 2026-08-25
+topic: safe-deal-merge
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+origin: https://github.com/kesslerio/attio-mcp-server/issues/1264
+product_contract_preservation: restructured, no scope change: Outstanding Questions moved from Deferred to Planning into KTDs; R-IDs unchanged
+---
+
+# Safe Deal Merge - Plan
+
+## Goal Capsule
+
+- Objective: Sales-ops can collapse a leftover Demo Request deal into the live booked or Won sibling without losing unique form-snapshot fields and without clobbering live sales fields; the survivor is a new Attio record and both original deal IDs are dead.
+- Means: One universal `merge_records` tool, deals-gated, wrapping Attio native merge with PUT leftover clears and no in-tool 202 poll (KTD1, KTD2, KTD4).
+- Product authority: This plan owns deals-first merge. People and companies are later coverage on the same operation, not active scope.
+- Open blockers: None.
+
+---
+
+## Product Contract
+
+Product Contract unchanged: R1–R17, A1–A3, F1–F4, AE1–AE6 keep their IDs and meaning.
+
+### Summary
+
+Add one MCP merge operation, gated to deals at launch, that previews leftover vs live deal, lets the operator patch chosen conflict values onto the primary and skip dangerous fills by clearing them on the leftover, then runs Attio native merge. Execute re-diffs and refuses if the pair drifted, returns the new record id, and warns that both old ids are unreadable.
+
+### Problem Frame
+
+Duplicate Demo Request leftovers sit next to a booked or Won sibling on the same person. The leftover still holds the latest form snapshot (website, zip, interest, UTMs, form id). The later deal holds stage, owner, notes, and real value. Deleting the leftover throws the snapshot away. Copying blindly can overwrite Won stage or stamp `consent_to_contact=false` onto a live opportunity. Attio's UI still cannot merge deals. This MCP server only has update and delete, so every agent session reinvents a lossy cleanup.
+
+### Key Decisions
+
+- Deals-first, same operation later. First ship executes deals only; people and companies are refused until a later opening. (session-settled: user-directed — chosen over full objects this round, and over preview-only: the pain is leftover deals.) Governs R1, R2.
+- Wrap Attio native merge, including the new record id. (session-settled: user-directed — chosen over keep-the-live-id fill-then-delete: the API already accepts deals.) Governs R3, R16, R17.
+- Per-field patch onto primary, then merge. (session-settled: user-directed — chosen over swap-entire-primary or abort, and over dry-run-show-only: keep Won as primary while still taking leftover `demo_request_at` when wanted.) Governs R11, R12.
+- Flag dangerous empty-primary fills (consent=false, stage, owner, value). (session-settled: user-directed — chosen over conflicts-only: empty primary is how those fields get clobbered.) Governs R6, R10.
+- Skip a dangerous fill by clearing it on the leftover, then merge. (session-settled: user-directed — chosen over unset-after-merge and abort-if-skip: the live deal stays empty for that field.) Governs R13.
+- Linked person or company mismatch blocks execute unless override. (session-settled: user-directed — chosen over flag-and-proceed and always-abort-no-override.) Governs R7.
+- Dry-run defaults on; execute needs explicit confirm. (session-settled: user-directed — chosen over dry-run-false-enough and a two-step plan token: an agent must not collapse records in one unreviewed call.) Governs R4, R14.
+- One gated merge operation with execute-time freshness check. (session-settled: user-approved — chosen over a deals-only scoped tool and over a separate preview/apply pair: people/companies can open later without a rename; re-diff catches a stale pair without a second tool.) Governs R1, R15.
+- Dangerous fills are strict keep-or-skip; unresolved both-set conflicts default to primary-wins. (session-settled: user-approved — packaged with the chosen approach.) Governs R10, R11.
+
+<!-- ce-section: work-relationships -->
+
+### How This Work Fits Together
+
+This plan owns deals-first merge for leftover vs live sibling deals. The broader duplicate-cleanup picture below is the current understanding, not a committed roadmap.
+
+- People and companies merge on the same operation
+  - Depends on this deals-gated merge shipping first
+  - Still to decide: per-object dangerous-fill policy and a live smoke merge per object before opening the gate
+- Unique-key upsert (`#1191`)
+  - Can proceed independently of this plan
+  - Shares the "do not invent a second record" problem; it creates-or-updates by key rather than collapsing two existing records
+- Attio UI merge for people and companies
+  - Can proceed independently of this plan
+  - Outside this MCP operation's job
+
+### Actors
+
+- A1. Sales-ops operator cleaning leftover Demo Request deals next to booked or Won siblings (the issue author, via an agent).
+- A2. Agent calling the merge operation.
+- A3. Attio native merge, which mints the surviving record and re-parents notes, tasks, and list memberships.
+
+### Requirements
+
+**Operation surface**
+
+- R1. The MCP exposes one merge operation that takes an object type and, at first ship, executes only for deals.
+- R2. People and companies are refused with a message that this version is deals-only; Attio UI merge remains the path for those objects until this operation is opened for them.
+- R3. The tool description states that merge is not idempotent, returns a new record id, and is a beta Attio capability.
+
+**Dry-run plan**
+
+- R4. Dry-run is the default and does not merge, patch, or clear any record.
+- R5. Dry-run reports both-set conflicts with both values, including timestamps such as `demo_request_at`.
+- R6. Dry-run flags dangerous empty-primary fills for `consent_to_contact=false`, stage, owner, and deal value so the operator can keep or skip each.
+- R7. Dry-run flags a differing associated person or company; execute is blocked unless the operator passes an explicit override.
+- R8. Self-merge is rejected.
+- R9. Notes, tasks, and list memberships are omitted from the field plan; Attio re-parents them onto the new record.
+
+**Execute**
+
+- R10. Execute is refused unless every flagged dangerous fill has an explicit keep or skip.
+- R11. Both-set conflicts with no chosen patch keep the primary value.
+- R12. When the operator chooses the secondary value on a conflict, execute writes that value onto the primary before native merge.
+- R13. When the operator skips a dangerous fill, execute clears that attribute on the leftover, then merges, so the surviving deal stays empty for that field.
+- R14. Execute requires an explicit confirm in addition to turning dry-run off.
+- R15. Before mutating, execute re-diffs the pair and refuses if the set of flagged conflicts, fills, or linked mismatches differs from the plan being confirmed.
+- R16. Execute uses Attio native merge; the response returns the new record id and warns that both original ids are unreadable.
+- R17. If Attio reports the merge is still applying, the operation returns a wait state with the new record id rather than treating the survivor as readable.
+
+### Key Flows
+
+```mermaid
+flowchart TB
+  start[Operator names leftover and live deal] --> dry[Dry-run field plan]
+  dry --> mismatch{Linked person or company differs?}
+  mismatch -->|yes, no override| block[Refuse execute]
+  mismatch -->|no, or override| resolve[Patch chosen conflicts onto primary]
+  resolve --> fills{Dangerous fills?}
+  fills -->|any unchosen| block
+  fills -->|keep or skip each| skip[Clear skipped fields on leftover]
+  skip --> rediff{Pair still matches the plan?}
+  rediff -->|drifted| block
+  rediff -->|same| merge[Attio native merge]
+  merge --> newid[Return new record id; old ids dead]
+```
+
+- F1. Preview leftover vs live sibling
+  - **Trigger:** A2 calls merge with dry-run default for a leftover Demo Request and a booked or Won primary.
+  - **Actors:** A1, A2
+  - **Steps:** Load both deals; emit keep / fill / conflict / skip / linked-mismatch; mutate nothing.
+  - **Outcome:** A1 can see timestamp conflicts and dangerous fills before anything is written.
+  - **Covered by:** R4, R5, R6, R7, R9
+
+- F2. Patch then native merge
+  - **Trigger:** A1 confirms execute with chosen conflict patches and keep/skip on every flagged fill.
+  - **Actors:** A1, A2, A3
+  - **Steps:** Re-diff per R15; write chosen secondary values onto primary; clear skipped leftover fills; native merge; return new id plus dead-id warning.
+  - **Outcome:** Won stays primary for live sales fields; leftover snapshot fills empty primary fields; leftover is gone.
+  - **Covered by:** R10, R11, R12, R13, R14, R15, R16
+
+- F3. Linked mismatch without override
+  - **Trigger:** The two deals point at different companies or people and no override is passed.
+  - **Actors:** A2
+  - **Steps:** Dry-run flags the mismatch; execute is refused.
+  - **Outcome:** Two different businesses are not collapsed.
+  - **Covered by:** R7
+
+- F4. Stale pair between preview and execute
+  - **Trigger:** Either deal changes after dry-run so the flagged set no longer matches.
+  - **Actors:** A2
+  - **Steps:** Execute re-diffs and refuses.
+  - **Outcome:** A resolution set is not applied against a different plan.
+  - **Covered by:** R15
+
+### Acceptance Examples
+
+- AE1. Leftover form snapshot into Won
+  - **Covers R5, R11, R12, R16.**
+  - **Given:** Primary is Won with stage, owner, and value set; leftover is Demo Request with empty-on-primary website, zip, UTMs, and form id; `demo_request_at` differs.
+  - **When:** Dry-run, then execute with primary as Won, leftover timestamp chosen onto primary, no dangerous-fill skips needed if those live fields are already set.
+  - **Then:** Dry-run listed the timestamp conflict and the snapshot fills; the new record keeps Won stage/owner/value, has leftover snapshot fields, has the chosen timestamp, and neither original id is readable.
+
+- AE2. Skip consent=false fill
+  - **Covers R6, R10, R13.**
+  - **Given:** Primary consent is empty; leftover has `consent_to_contact=false`.
+  - **When:** Dry-run flags that fill; execute skips it.
+  - **Then:** Leftover consent is cleared before merge; the surviving deal does not receive `false`.
+
+- AE3. Unreviewed execute refused
+  - **Covers R4, R14.**
+  - **Given:** An agent calls merge with no confirm.
+  - **When:** Dry-run is left at default, or confirm is omitted.
+  - **Then:** No merge, patch, or clear occurs.
+
+- AE4. Company mismatch without override
+  - **Covers R7.**
+  - **Given:** Leftover and live deal point at different companies.
+  - **When:** Execute is attempted without override.
+  - **Then:** Execute is refused; dry-run named the mismatch.
+
+- AE5. Self-merge
+  - **Covers R8.**
+  - **Given:** Primary and leftover are the same record id.
+  - **When:** Merge is called.
+  - **Then:** The call is rejected without mutating Attio.
+
+- AE6. Drift between preview and confirm
+  - **Covers R15.**
+  - **Given:** Dry-run ran; then leftover website was edited so the fill set changed.
+  - **When:** Execute is confirmed against the old plan.
+  - **Then:** Execute refuses; no patch, clear, or merge runs.
+
+### Success Criteria
+
+- A leftover Demo Request can be collapsed into a booked or Won sibling in one reviewed execute without losing unique empty-on-primary snapshot fields and without overwriting primary stage, owner, or value.
+- Agents cannot merge two deals in a single unreviewed call.
+- Operators always receive the new record id and a warning that both old ids are dead.
+- `ce-plan` can implement without inventing which object ships first, how conflicts resolve, or what blocks execute.
+
+### Scope Boundaries
+
+**In scope**
+
+- Deals-only execute of the gated merge operation, including dry-run, per-field patch, leftover clear on skip, freshness re-diff, confirm, and native merge wait/new-id behavior.
+
+**Deferred for later**
+
+- Opening the same operation for people and companies (per-object dangerous-fill policy plus a live smoke merge each).
+- A separate read-only preview alias if host approval prompts on dry-run become painful.
+- Batch merge of more than one pair.
+
+**Outside this product's identity**
+
+- Unique-key upsert (`#1191`) — create-or-update, not collapse of two existing records.
+- Attio UI merge for people and companies.
+- A per-field picker inside Attio's merge itself.
+
+### Dependencies / Assumptions
+
+- Attio `POST /v2/objects/{object}/records/merge` accepts deals in this workspace (fake-id probe returned the same `value_not_found` as people and companies). A live smoke merge of two throwaway deals still belongs in planning before coding against the endpoint.
+- Native merge primary-wins / secondary-fills, new record id, non-idempotency, self-merge rejection, and in-progress unreadability are as documented at [Merge two records](https://docs.attio.com/rest-api/endpoint-reference/records/merge-two-records).
+- Skip-clear uses Attio overwrite PUT with `[]`, not the repo PATCH update path (PATCH prepends multiselect). Record-reference `[]` is proven in-repo; checkbox `consent_to_contact` unset is unverified until live smoke.
+- Stage and owner defaults are not injected on update, so patching the primary before merge will not stamp defaults.
+- Help Center UI merge remains people and companies only ([Merge and delete records](https://attio.com/help/reference/managing-your-data/records/merge-and-delete-records)).
+
+### Outstanding Questions
+
+**Resolve Before Planning**
+
+- None.
+
+**Deferred to Implementation**
+
+- Exact Attio slugs for dangerous-fill fields and `demo_request_at` (discover from deal attributes at runtime; do not hardcode guessed titles).
+- If live smoke cannot unset checkbox `consent_to_contact`, stop and confirm a fallback with the operator before changing R13.
+
+### Sources / Research
+
+- Issue [#1264](https://github.com/kesslerio/attio-mcp-server/issues/1264).
+- Attio merge API: [Merge two records](https://docs.attio.com/rest-api/endpoint-reference/records/merge-two-records).
+- Attio UI limitation: [Merge and delete records](https://attio.com/help/reference/managing-your-data/records/merge-and-delete-records).
+- No merge client or tool in this repo: `src/api/operations/index.ts`, `src/handlers/tool-configs/universal/core/index.ts`.
+- Adjacent dry-run precedent: `create-list` dry-run (default false) in `src/handlers/tool-configs/lists.ts`.
+- Clear-on-update: `src/services/value-transformer/record-reference-transformer.ts`; deal defaults skipped on update in `src/config/deal-defaults.ts`.
+- Related but distinct: `#1191` upsert in `BACKLOG.md`.
+- Attio overwrite PUT vs PATCH: PATCH prepends multiselect; skip-clear must PUT `[]`. Do not use generic `callWithRetry` on merge POST (retry confirmed 429 only).
+- Agent-native: dry-run returns a structured field plan; 202 is a wait state, not an in-tool poll.
+
+---
+
+## Planning Contract
+
+### Summary
+
+Ship one universal MCP tool `merge_records`, gated to deals, that (1) builds a field plan from leftover vs live, (2) dry-runs by default, (3) on `confirm` patches chosen values onto the primary, PUT-clears skipped leftover attributes, then POSTs Attio native merge, and (4) returns the new record id plus a 200 complete or 202 wait payload. People/companies refuse until a later opening of the same tool.
+
+### Key Technical Decisions
+
+- **KTD1 — Tool name `merge_records` (universal, deals-gated).** One tool, `resource_type` required; refuse any type other than `deals` with a later-coverage message. Not `merge_deal`. Governs R1, R2. Alternatives: scoped deals-only tool (rejected: Approach B already chosen); two-tool preview/apply (rejected: freshness re-diff lives on one operation).
+- **KTD2 — 202 is a wait state, not an in-tool poll.** Return `new_record_id` plus merge-in-progress guidance; the agent follows up with `get_record_details`. `get_record_details` treats a 404/`merge_in_progress` on that id as wait-not-missing. Governs R17.
+- **KTD3 — Skip-clear uses overwrite PUT, not PATCH.** Dedicated `overwriteRecordAttributes` helper PUTs `values: { slug: [] }` on the leftover. Existing `updateRecord` PATCH stays for primary patches (`isUpdate: true` so deal defaults do not inject). Governs R13.
+- **KTD4 — Merge-safe retry.** Merge POST retries only confirmed HTTP 429 after Retry-After. Timeout and 5xx are indeterminate: do not resend (non-idempotent). Do not wrap merge in generic `callWithRetry`. Governs R16, AE6.
+- **KTD5 — Dual execute gate + static destructive annotation.** Schema: `dry_run` defaults true; execute requires `confirm: true` (boolean, no top-level oneOf). `destructiveHint: true` even on dry-run because hosts cannot flip annotations by argument. Dual gate remains load-bearing. Governs R8, R9.
+- **KTD6 — Keep / skip / override as flat arrays.** `keep_from_leftover: string[]` (attribute slugs to patch onto primary before merge), `skip_leftover_attributes: string[]` (PUT-clear on leftover), `override_linked_mismatch: boolean` (default false). Validate combinations in the handler. Governs R11–R14.
+- **KTD7 — Live smoke before coding against merge POST.** Two throwaway deals: prove deals merge, PUT-clear of record-references, and whether checkbox `consent_to_contact` can unset. If checkbox cannot clear, stop — do not silently change R13. Governs R13, AE2.
+
+### Code Reuse
+
+- CRUD client and retry types: `src/api/operations/crud.ts`, `src/api/operations/retry.ts`, `src/api/operations/index.ts`.
+- Universal tool registration and formatResult: `src/handlers/tool-configs/universal/core/crud-operations.ts`, `src/handlers/tool-configs/universal/core/index.ts`.
+- Deal update defaults skip: `src/config/deal-defaults.ts`.
+- Empty-array record-reference transform: `src/services/value-transformer/record-reference-transformer.ts`.
+- Universal errors: `ErrorService.createUniversalError` — throw, do not return `{ isError: true }`.
+- Dry-run shape (lists, default false — invert default here): `src/handlers/tool-configs/lists.ts`.
+- MCP e2e layout: `test/e2e/mcp/deal-operations/` (create if missing); `bun run test:mcp`.
+
+### Implementation Units
+
+#### U1: Merge API client and PUT overwrite
+
+- **Goal:** Prove deals merge with two throwaway records, then add `mergeRecords` (POST `/v2/objects/{object}/records/merge`) and `overwriteRecordAttributes` (PUT record values) with merge-safe retry.
+- **Requires:** none
+- **Required by:** U2, U4
+- **Files:** Create `src/api/operations/merge.ts` (or add to `crud.ts` if that stays under ~500 lines). Modify `src/api/operations/index.ts`, `src/api/operations/retry.ts` only if a 429-only helper is cleaner than duplicating Retry-After parsing.
+- **Approach:** Live-smoke first with `ATTIO_API_KEY`. Primary + secondary deal IDs; assert 200/202 and new `record_id`. PUT `[]` on a record-reference and on `consent_to_contact` if present. Then implement POST merge (`primary_record_id`, `secondary_record_id`) mapping 200 vs 202. Retry 429 only. Surface `self_merge` 400 clearly.
+- **Patterns to follow:** `src/api/operations/crud.ts` client + path helpers; do not copy `callWithRetry` onto merge POST.
+- **Test scenarios:**
+  - Happy: merge two mocked deals returns new id and status 200.
+  - 202: returns wait payload with `new_record_id`, does not poll.
+  - 429: retries once after Retry-After; 500 timeout: no retry.
+  - 400 self_merge: throws mapped error.
+  - PUT overwrite sends `[]` for named slugs.
+- **Verification:** `bun run typecheck` and unit tests for merge client. Live smoke notes (pass/fail of checkbox clear) in the unit's commit message or a short comment in the helper — not a committed secret dump.
+- **Execution note:** Live-smoke first. If checkbox cannot unset, stop and do not invent a skip-clear workaround.
+
+#### U2: Field plan, dangerous fills, linked mismatch, re-diff
+
+- **Goal:** Pure service that diffs leftover vs live deal attributes into keep/fill/conflict/dangerous-empty-fill, blocks linked person/company mismatch unless override, and re-diffs at execute if the flagged set drifted.
+- **Requires:** U1 (only for attribute fetch via existing get-record; merge client unused here)
+- **Required by:** U3, U4
+- **Files:** Create `src/services/merge/deal-merge-planner.ts` (and small types file if needed). Split if >500 lines.
+- **Approach:** Load both records. Classify each attribute: both empty, primary-only, leftover-only fill, both-set conflict (including timestamps like `demo_request_at`). Dangerous empty-primary fills: `consent_to_contact=false`, stage, owner, value — flag as keep-or-skip, never auto-fill. Linked person/company: if both set and IDs differ, execute-block unless `override_linked_mismatch`. Re-diff: hash or serialize the flagged attribute set; refuse execute on drift (AE4).
+- **Patterns to follow:** Existing record value extraction in `src/handlers/tool-configs/universal/core/value-extractors.ts`; UUID checks `isValidUUID`.
+- **Test scenarios:**
+  - Happy: leftover-only website/UTM proposed as fills; live stage kept.
+  - Conflict: both have `demo_request_at` → listed, applied only if in `keep_from_leftover`.
+  - Dangerous fill: leftover `consent_to_contact=false`, live unset → skip required to execute.
+  - Linked mismatch: different company IDs → block without override; proceed with override.
+  - Re-diff: mutated leftover between plan and execute → refuse.
+  - Empty/nil records or invalid UUIDs → validation error, no API merge.
+- **Verification:** `bun run test:single` on the planner test file.
+- **Execution note:** test-first for classification and re-diff.
+
+#### U3: `merge_records` tool surface
+
+- **Goal:** Register universal `merge_records` with deals gate, dry-run default true, confirm required to execute, flat keep/skip/override args, `formatResult` string, `destructiveHint: true`.
+- **Requires:** U2
+- **Required by:** U4
+- **Files:** Create `src/handlers/tool-configs/universal/core/merge-operations.ts`. Modify `src/handlers/tool-configs/universal/core/index.ts` and whatever schema/types registry lists tool names (search `delete_record` registration). No top-level oneOf/allOf/anyOf.
+- **Approach:** Handler validates `resource_type === 'deals'` else throw universal error. `record_id` (primary/live) and `secondary_record_id` (leftover). `dry_run` default true. Execute only when `confirm === true` (R8/R9: `dry_run: false` alone is not enough). Dry-run returns formatted field plan (conflicts, dangerous fills, proposed patches, skips). People/companies: refuse with later-coverage copy. Throw `ErrorService.createUniversalError` on failure.
+- **Patterns to follow:** `src/handlers/tool-configs/universal/core/crud-operations.ts` (delete_record annotations, formatToolDescription, formatResult string + try/catch + createErrorResult).
+- **Test scenarios:**
+  - Dry-run default: no confirm → no merge POST.
+  - `dry_run: false` without confirm → refuse.
+  - `resource_type: companies` → refuse, no API call.
+  - formatResult is string in all branches.
+- **Verification:** unit tests for handler gating + `bun run typecheck`.
+- **Execution note:** none
+
+#### U4: Execute orchestration (patch, PUT-clear, merge, 200/202)
+
+- **Goal:** On confirm, re-diff, patch primary with `keep_from_leftover`, PUT-clear `skip_leftover_attributes` on leftover, POST merge, map 200 vs 202; treat merge-in-progress 404 on get as wait-not-missing.
+- **Requires:** U1, U2, U3
+- **Required by:** U5
+- **Files:** Merge service execute path (same module as U2 or `src/services/merge/deal-merge-executor.ts`). Modify `src/handlers/tool-configs/universal/core/record-details-operations.ts` (or get-record error mapping) so `merge_in_progress` 404 is wait-not-missing when the id was a merge product.
+- **Approach:** No spanning transaction. If merge fails after leftover clear, surface that leftover was already cleared (AE6). Do not retry merge on timeout/5xx. Success payload includes `new_record_id` and warning that both original IDs are unreadable.
+- **Patterns to follow:** Universal update path for primary patches (`isUpdate: true`). PUT helper from U1 for leftover clears.
+- **Test scenarios:**
+  - Execute with keep website + skip consent: primary patched, leftover consent PUT-cleared, merge called once.
+  - 202: formatted wait + new id; get_record_details wait-not-missing.
+  - Merge error after clear: error mentions leftover already cleared; no silent retry.
+- **Verification:** unit tests with mocked API; `bun run typecheck`.
+- **Execution note:** none
+
+#### U5: Tests, MCP e2e, CHANGELOG
+
+- **Goal:** Unit coverage for planner/gating/retry; MCP e2e under `test/e2e/mcp/deal-operations/` for dry-run and (API-keyed) execute on throwaway deals; Unreleased CHANGELOG entry `#1264`.
+- **Requires:** U1–U4
+- **Required by:** none
+- **Files:** Create `test/e2e/mcp/deal-operations/merge-records.mcp.test.ts` (or similar). Modify `CHANGELOG.md`. Add unit tests beside U1–U4 modules under `test/`.
+- **Approach:** MCP tests follow existing `*.mcp.test.ts`. Cleanup throwaway deals via API token filter. CHANGELOG Added, user-facing, no trailing period, issue `#1264`.
+- **Patterns to follow:** `test/e2e/mcp/core-operations/create-records.mcp.test.ts`; mock factories in `test/utils/mock-factories/`.
+- **Test scenarios:** MCP dry-run returns field plan without merging; execute with confirm merges throwaways when `ATTIO_API_KEY` is set (skip otherwise).
+- **Verification:** `bun run typecheck && bun run test:single <unit files> && bun run lint:src`. MCP: `bun run test:mcp` when key present.
+- **Execution note:** none
+
+### Requirements Trace
+
+| ID             | Implementation                                 |
+| -------------- | ---------------------------------------------- |
+| R1, R2         | U3 deals gate                                  |
+| R3, R16        | U1 native merge + new id                       |
+| R4–R7, R10–R12 | U2 field plan / dangerous fills / keep         |
+| R8, R9         | U3 dual gate                                   |
+| R13            | U1 PUT + U4 skip-clear                         |
+| R14            | U2 linked mismatch                             |
+| R15            | U2 + U4 re-diff                                |
+| R17            | U1/U4 202 wait; U4 get_record_details mapping  |
+| A1–A3          | U3/U4 payloads                                 |
+| F1–F4          | U3 refuse; U2 skip semantics; no extra objects |
+| AE1–AE6        | U2–U4 error paths; U1 429-only retry           |
+
+### Test Strategy
+
+- **Unit:** planner classification, dual gate, retry policy, formatResult string, people/companies refuse.
+- **MCP e2e:** dry-run and execute against Attio when `ATTIO_API_KEY` is set; skip execute otherwise.
+- **Not in this ship:** full people/companies merge; in-tool 202 polling.
+
+### Verification
+
+```sh
+bun run typecheck
+bun run test:single test/services/merge/deal-merge-planner.test.ts
+bun run lint:src
+```
+
+Plus merge-client and tool-handler unit files created in U1/U3. `bun run test:mcp` when API key is available.
+
+### Definition of Done
+
+- `merge_records` dry-runs a leftover vs live deals field plan by default.
+- Execute requires `confirm`, patches keep slugs onto primary, PUT-clears skips on leftover, POSTs native merge, returns new id.
+- Non-deals resource types refuse. 202 does not poll. CHANGELOG Unreleased mentions `#1264`.
+- Checkbox skip-clear either proven by live smoke or explicitly blocked pending operator fallback.

--- a/src/api/operations/index.ts
+++ b/src/api/operations/index.ts
@@ -35,6 +35,8 @@ export {
   listRecords,
 } from './crud.js';
 
+export { mergeRecords, overwriteRecordAttributes } from './merge.js';
+
 // Re-export all notes operations
 export { getObjectNotes, createObjectNote } from './notes.js';
 

--- a/src/api/operations/merge.ts
+++ b/src/api/operations/merge.ts
@@ -1,0 +1,195 @@
+import type { AxiosError, AxiosResponse } from 'axios';
+import { getLazyAttioClient } from '@/api/lazy-client.js';
+
+export interface MergeRecordsResult {
+  status: 200 | 202;
+  new_record_id: string;
+  data: Record<string, unknown>;
+}
+
+export type AttributeOverwriteValues = Record<string, unknown>;
+
+interface RetryableAxiosError extends AxiosError {
+  response?: AxiosResponse<unknown>;
+}
+
+function getRetryAfterMilliseconds(error: RetryableAxiosError): number {
+  const headers = error.response?.headers;
+  const rawValue = headers?.['retry-after'] ?? headers?.['Retry-After'];
+
+  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+    return Math.max(0, rawValue * 1000);
+  }
+
+  if (typeof rawValue === 'string') {
+    const seconds = Number(rawValue.trim());
+    if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+    const retryAt = Date.parse(rawValue);
+    if (Number.isFinite(retryAt)) {
+      return Math.max(0, retryAt - Date.now());
+    }
+  }
+
+  return 1000;
+}
+
+function getResponseData(
+  response: AxiosResponse<unknown>
+): Record<string, unknown> {
+  const responseData = response.data;
+  if (!responseData || typeof responseData !== 'object') return {};
+  return responseData as Record<string, unknown>;
+}
+
+function getInnerResponseData(
+  response: AxiosResponse<unknown>
+): Record<string, unknown> {
+  const responseData = getResponseData(response);
+  const innerData = responseData.data;
+  return innerData && typeof innerData === 'object'
+    ? (innerData as Record<string, unknown>)
+    : responseData;
+}
+
+function getNewRecordId(data: Record<string, unknown>): string | undefined {
+  const nested = data.data;
+  const nestedData =
+    nested && typeof nested === 'object'
+      ? (nested as Record<string, unknown>)
+      : undefined;
+  const nestedId = nestedData?.id;
+  const nestedIdObject =
+    nestedId && typeof nestedId === 'object'
+      ? (nestedId as Record<string, unknown>)
+      : undefined;
+  const responseId = data.id;
+  const responseIdObject =
+    responseId && typeof responseId === 'object'
+      ? (responseId as Record<string, unknown>)
+      : undefined;
+
+  const candidates = [
+    nestedIdObject?.record_id,
+    nestedData?.record_id,
+    nestedData?.new_record_id,
+    responseIdObject?.record_id,
+    data.new_record_id,
+    data.record_id,
+  ];
+
+  return candidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === 'string' && candidate.length > 0
+  );
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const responseData = (error as RetryableAxiosError).response?.data;
+  if (!responseData || typeof responseData !== 'object') return undefined;
+  const data = responseData as Record<string, unknown>;
+  const nestedError = data.error;
+  const nested =
+    nestedError && typeof nestedError === 'object'
+      ? (nestedError as Record<string, unknown>)
+      : undefined;
+  const code = data.code ?? data.type ?? nested?.code ?? nested?.type;
+  return typeof code === 'string' ? code : undefined;
+}
+
+async function sleep(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function postMergeWith429Retry(
+  post: () => Promise<AxiosResponse<unknown>>,
+  maxRetries = 1
+): Promise<AxiosResponse<unknown>> {
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await post();
+    } catch (error: unknown) {
+      const typedError = error as RetryableAxiosError;
+      const isRateLimited = typedError.response?.status === 429;
+      if (!isRateLimited || attempt >= maxRetries) throw error;
+
+      await sleep(getRetryAfterMilliseconds(typedError));
+      attempt += 1;
+    }
+  }
+}
+
+/**
+ * Attio's native merge is non-idempotent. Only a confirmed 429 is retried.
+ * Timeout and 5xx responses are deliberately returned to the caller as
+ * indeterminate outcomes and must not be resent.
+ */
+export async function mergeRecords(
+  objectSlug: string,
+  primaryRecordId: string,
+  secondaryRecordId: string
+): Promise<MergeRecordsResult> {
+  const api = getLazyAttioClient();
+  let response: AxiosResponse<unknown>;
+
+  try {
+    response = await postMergeWith429Retry(() =>
+      api.post(`/objects/${objectSlug}/records/merge`, {
+        data: {
+          primary_record_id: primaryRecordId,
+          secondary_record_id: secondaryRecordId,
+        },
+      })
+    );
+  } catch (error: unknown) {
+    const code = getErrorCode(error);
+    if (code === 'self_merge') {
+      throw new Error('Attio rejected the merge: self_merge', {
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+    throw error;
+  }
+
+  if (response.status !== 200 && response.status !== 202) {
+    throw new Error(
+      `Unexpected Attio merge response status: ${response.status}`
+    );
+  }
+
+  const data = getResponseData(response);
+  const newRecordId = getNewRecordId(data);
+  if (!newRecordId) {
+    throw new Error(
+      `Attio merge response ${response.status} did not include a new record id`
+    );
+  }
+
+  return {
+    status: response.status,
+    new_record_id: newRecordId,
+    data: getInnerResponseData(response),
+  };
+}
+
+export async function overwriteRecordAttributes(
+  objectSlug: string,
+  recordId: string,
+  values: AttributeOverwriteValues
+): Promise<{ status: number; data: Record<string, unknown> }> {
+  const api = getLazyAttioClient();
+  const response: AxiosResponse<unknown> = await api.put(
+    `/objects/${objectSlug}/records/${recordId}`,
+    {
+      data: { values },
+    }
+  );
+
+  return {
+    status: response.status,
+    data: getInnerResponseData(response),
+  };
+}

--- a/src/constants/tool-names.ts
+++ b/src/constants/tool-names.ts
@@ -52,6 +52,7 @@ export const TOOL_NAMES = {
   CREATE_RECORD: 'create_record',
   UPDATE_RECORD: 'update_record',
   DELETE_RECORD: 'delete_record',
+  MERGE_RECORDS: 'merge_records',
   CREATE_COMPANY: 'create_company',
   UPDATE_COMPANY: 'update_company',
   CREATE_DEAL: 'create_deal',

--- a/src/handlers/tool-configs/universal/core/index.ts
+++ b/src/handlers/tool-configs/universal/core/index.ts
@@ -46,6 +46,10 @@ import {
   getRecordInteractionsConfig,
   getRecordInteractionsDefinition,
 } from './interaction-operations.js';
+import {
+  mergeRecordsConfig,
+  mergeRecordsDefinition,
+} from './merge-operations.js';
 
 export const coreOperationsToolConfigs = {
   create_note: createNoteConfig,
@@ -64,6 +68,7 @@ export const coreOperationsToolConfigs = {
   get_record_attribute_options: getAttributeOptionsConfig,
   get_record_info: getDetailedInfoConfig,
   get_record_interactions: getRecordInteractionsConfig,
+  merge_records: mergeRecordsConfig,
 };
 
 export const coreOperationsToolDefinitions = {
@@ -83,6 +88,7 @@ export const coreOperationsToolDefinitions = {
   create_note: createNoteDefinition,
   list_notes: listNotesDefinition,
   get_record_interactions: getRecordInteractionsDefinition,
+  merge_records: mergeRecordsDefinition,
 };
 
 export {
@@ -106,4 +112,6 @@ export {
   createNoteConfig,
   listNotesConfig,
   getRecordInteractionsConfig,
+  mergeRecordsConfig,
+  mergeRecordsDefinition,
 };

--- a/src/handlers/tool-configs/universal/core/merge-operations.ts
+++ b/src/handlers/tool-configs/universal/core/merge-operations.ts
@@ -28,29 +28,6 @@ export type MergeRecordsResult =
   | DealMergeDryRunResult
   | DealMergeExecutionResult;
 
-const dryRunPlans = new Map<string, DealMergePlan>();
-const MAX_CACHED_PLANS = 100;
-
-function planCacheKey(params: MergeRecordsParams): string {
-  return `${params.record_id}:${params.secondary_record_id}`;
-}
-
-function rememberPlan(params: MergeRecordsParams, plan: DealMergePlan): void {
-  if (dryRunPlans.size >= MAX_CACHED_PLANS) {
-    const oldestKey = dryRunPlans.keys().next().value;
-    if (oldestKey) dryRunPlans.delete(oldestKey);
-  }
-  dryRunPlans.set(planCacheKey(params), plan);
-}
-
-function getCachedPlan(params: MergeRecordsParams): DealMergePlan | undefined {
-  return dryRunPlans.get(planCacheKey(params));
-}
-
-function discardCachedPlan(params: MergeRecordsParams): void {
-  dryRunPlans.delete(planCacheKey(params));
-}
-
 function isMergeRecordsResult(value: unknown): value is MergeRecordsResult {
   if (!value || typeof value !== 'object') return false;
   const mode = (value as { mode?: unknown }).mode;
@@ -85,6 +62,7 @@ function formatMergeRecordsResult(result: unknown): string {
           ? 'none'
           : formatFieldSlugs(plan.linked_mismatches)
       }`,
+      `Plan fingerprint: ${plan.fingerprint}`,
     ].join('\n');
   }
 
@@ -129,6 +107,13 @@ function normalizeParams(
     }
   }
 
+  if (
+    params.plan_fingerprint !== undefined &&
+    typeof params.plan_fingerprint !== 'string'
+  ) {
+    throw new Error('plan_fingerprint must be a string');
+  }
+
   return {
     resource_type: params.resource_type,
     record_id: params.record_id,
@@ -138,6 +123,7 @@ function normalizeParams(
     keep_from_leftover: params.keep_from_leftover ?? [],
     skip_leftover_attributes: params.skip_leftover_attributes ?? [],
     override_linked_mismatch: params.override_linked_mismatch ?? false,
+    plan_fingerprint: params.plan_fingerprint ?? '',
   };
 }
 
@@ -192,28 +178,28 @@ export const mergeRecordsConfig: UniversalToolConfig<
           params.record_id,
           params.secondary_record_id
         );
-        rememberPlan(params, plan);
         return {
           mode: 'dry_run',
           plan,
           message:
-            'Dry-run only: no deal was patched, cleared, or merged. Review dangerous fills and linked mismatches before confirming.',
+            'Dry-run only: no deal was patched, cleared, or merged. Review dangerous fills and linked mismatches, then execute with this plan fingerprint.',
         };
       }
 
-      const expectedPlan = getCachedPlan(params);
-      const result = await executeDealMerge(
-        {
-          primary_record_id: params.record_id,
-          leftover_record_id: params.secondary_record_id,
-          keep_from_leftover: params.keep_from_leftover,
-          skip_leftover_attributes: params.skip_leftover_attributes,
-          override_linked_mismatch: params.override_linked_mismatch,
-        },
-        expectedPlan
-      );
-      discardCachedPlan(params);
-      return result;
+      if (!params.plan_fingerprint) {
+        throw new Error(
+          'Execute requires plan_fingerprint from the dry-run field plan so the pair can be re-diffed'
+        );
+      }
+
+      return executeDealMerge({
+        primary_record_id: params.record_id,
+        leftover_record_id: params.secondary_record_id,
+        keep_from_leftover: params.keep_from_leftover,
+        skip_leftover_attributes: params.skip_leftover_attributes,
+        override_linked_mismatch: params.override_linked_mismatch,
+        plan_fingerprint: params.plan_fingerprint,
+      });
     } catch (error: unknown) {
       throw ErrorService.createUniversalError(
         TOOL_NAMES.MERGE_RECORDS,
@@ -246,7 +232,7 @@ export const mergeRecordsDefinition = {
     boundaries:
       'merge people or companies, merge more than one pair, or retry an indeterminate native merge',
     constraints:
-      'Dry-run defaults to true. Execute requires dry_run=false and confirm=true, returns a new record id, and is not idempotent',
+      'Dry-run defaults to true. Execute requires dry_run=false, confirm=true, and plan_fingerprint from that dry-run',
     requiresApproval: true,
     recoveryHint:
       'For HTTP 202, wait and call get_record_details with new_record_id later; both original ids are unreadable after native merge',

--- a/src/handlers/tool-configs/universal/core/merge-operations.ts
+++ b/src/handlers/tool-configs/universal/core/merge-operations.ts
@@ -1,0 +1,203 @@
+import type {
+  MergeRecordsParams,
+  UniversalToolConfig,
+} from '@/handlers/tool-configs/universal/types.js';
+import {
+  mergeRecordsSchema,
+  validateUniversalToolParams,
+} from '@/handlers/tool-configs/universal/schemas.js';
+import { ErrorService } from '@/services/ErrorService.js';
+import { createErrorResult } from '@/utils/error-handler.js';
+import { formatToolDescription } from '@/handlers/tools/standards/index.js';
+import { isValidUUID } from '@/utils/validation/uuid-validation.js';
+import {
+  executeDealMerge,
+  loadDealMergePlan,
+  type DealMergeExecutionResult,
+} from '@/services/merge/deal-merge-executor.js';
+import type { DealMergePlan } from '@/services/merge/deal-merge-planner.js';
+
+export interface DealMergeDryRunResult {
+  mode: 'dry_run';
+  plan: DealMergePlan;
+  message: string;
+}
+
+export type MergeRecordsResult =
+  | DealMergeDryRunResult
+  | DealMergeExecutionResult;
+
+const dryRunPlans = new Map<string, DealMergePlan>();
+const MAX_CACHED_PLANS = 100;
+
+function planCacheKey(params: MergeRecordsParams): string {
+  return `${params.record_id}:${params.secondary_record_id}`;
+}
+
+function rememberPlan(params: MergeRecordsParams, plan: DealMergePlan): void {
+  if (dryRunPlans.size >= MAX_CACHED_PLANS) {
+    const oldestKey = dryRunPlans.keys().next().value;
+    if (oldestKey) dryRunPlans.delete(oldestKey);
+  }
+  dryRunPlans.set(planCacheKey(params), plan);
+}
+
+function getCachedPlan(params: MergeRecordsParams): DealMergePlan | undefined {
+  return dryRunPlans.get(planCacheKey(params));
+}
+
+function discardCachedPlan(params: MergeRecordsParams): void {
+  dryRunPlans.delete(planCacheKey(params));
+}
+
+function normalizeParams(
+  params: MergeRecordsParams
+): Required<MergeRecordsParams> {
+  for (const [name, value] of [
+    ['dry_run', params.dry_run],
+    ['confirm', params.confirm],
+    ['override_linked_mismatch', params.override_linked_mismatch],
+  ] as const) {
+    if (value !== undefined && typeof value !== 'boolean') {
+      throw new Error(`${name} must be a boolean`);
+    }
+  }
+
+  for (const [name, value] of [
+    ['keep_from_leftover', params.keep_from_leftover],
+    ['skip_leftover_attributes', params.skip_leftover_attributes],
+  ] as const) {
+    if (
+      value !== undefined &&
+      (!Array.isArray(value) ||
+        value.some((entry) => typeof entry !== 'string'))
+    ) {
+      throw new Error(`${name} must be an array of attribute slugs`);
+    }
+  }
+
+  return {
+    resource_type: params.resource_type,
+    record_id: params.record_id,
+    secondary_record_id: params.secondary_record_id,
+    dry_run: params.dry_run ?? true,
+    confirm: params.confirm ?? false,
+    keep_from_leftover: params.keep_from_leftover ?? [],
+    skip_leftover_attributes: params.skip_leftover_attributes ?? [],
+    override_linked_mismatch: params.override_linked_mismatch ?? false,
+  };
+}
+
+function assertDealsOnly(params: MergeRecordsParams): void {
+  if (params.resource_type !== 'deals') {
+    throw new Error(
+      'merge_records is currently available for deals only. People and companies remain on the Attio UI merge path until later coverage opens.'
+    );
+  }
+}
+
+function assertValidMergeIds(params: MergeRecordsParams): void {
+  if (
+    !isValidUUID(params.record_id) ||
+    !isValidUUID(params.secondary_record_id)
+  ) {
+    throw new Error(
+      'merge_records requires valid UUID record_id and secondary_record_id values'
+    );
+  }
+  if (params.record_id === params.secondary_record_id) {
+    throw new Error('A deal cannot be merged with itself');
+  }
+}
+
+export const mergeRecordsConfig: UniversalToolConfig<
+  MergeRecordsParams,
+  MergeRecordsResult
+> = {
+  name: 'merge_records',
+  handler: async (
+    rawParams: MergeRecordsParams
+  ): Promise<MergeRecordsResult> => {
+    try {
+      const params = normalizeParams(
+        validateUniversalToolParams(
+          'merge_records',
+          rawParams
+        ) as MergeRecordsParams
+      );
+      assertDealsOnly(params);
+      assertValidMergeIds(params);
+
+      if (!params.dry_run && params.confirm !== true) {
+        throw new Error(
+          'Execute requires confirm: true in addition to dry_run: false'
+        );
+      }
+
+      if (params.dry_run) {
+        const plan = await loadDealMergePlan(
+          params.record_id,
+          params.secondary_record_id
+        );
+        rememberPlan(params, plan);
+        return {
+          mode: 'dry_run',
+          plan,
+          message:
+            'Dry-run only: no deal was patched, cleared, or merged. Review dangerous fills and linked mismatches before confirming.',
+        };
+      }
+
+      const expectedPlan = getCachedPlan(params);
+      const result = await executeDealMerge(
+        {
+          primary_record_id: params.record_id,
+          leftover_record_id: params.secondary_record_id,
+          keep_from_leftover: params.keep_from_leftover,
+          skip_leftover_attributes: params.skip_leftover_attributes,
+          override_linked_mismatch: params.override_linked_mismatch,
+        },
+        expectedPlan
+      );
+      discardCachedPlan(params);
+      return result;
+    } catch (error: unknown) {
+      throw ErrorService.createUniversalError('merge_records', 'deals', error);
+    }
+  },
+  formatResult: (result: MergeRecordsResult): string => {
+    try {
+      if (!result) return 'No merge result';
+      return JSON.stringify(result, null, 2);
+    } catch (error: unknown) {
+      const fallback = createErrorResult(
+        error instanceof Error ? error : new Error(String(error)),
+        'merge_records#format',
+        'FORMAT'
+      ) as { content?: Array<{ text?: string }> };
+      return fallback.content?.[0]?.text || 'Error formatting merge result';
+    }
+  },
+  structuredOutput: (result: MergeRecordsResult): Record<string, unknown> =>
+    result as unknown as Record<string, unknown>,
+};
+
+export const mergeRecordsDefinition = {
+  name: 'merge_records',
+  description: formatToolDescription({
+    capability:
+      'Preview and, after explicit confirmation, safely merge two Attio deal records using the native beta merge operation',
+    boundaries:
+      'merge people or companies, merge more than one pair, or retry an indeterminate native merge',
+    constraints:
+      'Dry-run defaults to true. Execute requires dry_run=false and confirm=true, returns a new record id, and is not idempotent',
+    requiresApproval: true,
+    recoveryHint:
+      'For HTTP 202, wait and call get_record_details with new_record_id later; both original ids are unreadable after native merge',
+  }),
+  inputSchema: mergeRecordsSchema,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+  },
+};

--- a/src/handlers/tool-configs/universal/core/merge-operations.ts
+++ b/src/handlers/tool-configs/universal/core/merge-operations.ts
@@ -34,13 +34,9 @@ function isMergeRecordsResult(value: unknown): value is MergeRecordsResult {
   return mode === 'dry_run' || mode === 'complete' || mode === 'wait';
 }
 
-function formatFieldSlugs(
-  fields: Array<{ slug?: string; attribute?: string }>
-): string {
+function formatFieldSlugs(fields: Array<{ attribute?: string }>): string {
   if (fields.length === 0) return 'none';
-  return fields
-    .map((field) => field.slug || field.attribute || 'unknown')
-    .join(', ');
+  return fields.map((field) => field.attribute || 'unknown').join(', ');
 }
 
 function formatMergeRecordsResult(result: unknown): string {

--- a/src/handlers/tool-configs/universal/core/merge-operations.ts
+++ b/src/handlers/tool-configs/universal/core/merge-operations.ts
@@ -1,3 +1,4 @@
+import { TOOL_NAMES } from '@/constants/tool-names.js';
 import type {
   MergeRecordsParams,
   UniversalToolConfig,
@@ -48,6 +49,58 @@ function getCachedPlan(params: MergeRecordsParams): DealMergePlan | undefined {
 
 function discardCachedPlan(params: MergeRecordsParams): void {
   dryRunPlans.delete(planCacheKey(params));
+}
+
+function isMergeRecordsResult(value: unknown): value is MergeRecordsResult {
+  if (!value || typeof value !== 'object') return false;
+  const mode = (value as { mode?: unknown }).mode;
+  return mode === 'dry_run' || mode === 'complete' || mode === 'wait';
+}
+
+function formatFieldSlugs(
+  fields: Array<{ slug?: string; attribute?: string }>
+): string {
+  if (fields.length === 0) return 'none';
+  return fields
+    .map((field) => field.slug || field.attribute || 'unknown')
+    .join(', ');
+}
+
+function formatMergeRecordsResult(result: unknown): string {
+  if (!isMergeRecordsResult(result)) {
+    return 'No merge result';
+  }
+
+  if (result.mode === 'dry_run') {
+    const plan = result.plan;
+    return [
+      result.message,
+      `Primary: ${plan.primary_record_id}`,
+      `Leftover: ${plan.leftover_record_id}`,
+      `Fills: ${formatFieldSlugs(plan.fills)}`,
+      `Conflicts: ${formatFieldSlugs(plan.conflicts)}`,
+      `Dangerous empty-primary fills: ${formatFieldSlugs(plan.dangerous_fills)}`,
+      `Linked mismatches: ${
+        plan.linked_mismatches.length === 0
+          ? 'none'
+          : formatFieldSlugs(plan.linked_mismatches)
+      }`,
+    ].join('\n');
+  }
+
+  const headline =
+    result.mode === 'wait'
+      ? 'Deal merge is in progress. Do not poll here; retry get_record_details later.'
+      : 'Deal merge complete.';
+
+  return [
+    headline,
+    `New record ID: ${result.new_record_id}`,
+    result.message,
+    result.warning,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n');
 }
 
 function normalizeParams(
@@ -114,14 +167,14 @@ export const mergeRecordsConfig: UniversalToolConfig<
   MergeRecordsParams,
   MergeRecordsResult
 > = {
-  name: 'merge_records',
+  name: TOOL_NAMES.MERGE_RECORDS,
   handler: async (
     rawParams: MergeRecordsParams
   ): Promise<MergeRecordsResult> => {
     try {
       const params = normalizeParams(
         validateUniversalToolParams(
-          'merge_records',
+          TOOL_NAMES.MERGE_RECORDS,
           rawParams
         ) as MergeRecordsParams
       );
@@ -162,17 +215,20 @@ export const mergeRecordsConfig: UniversalToolConfig<
       discardCachedPlan(params);
       return result;
     } catch (error: unknown) {
-      throw ErrorService.createUniversalError('merge_records', 'deals', error);
+      throw ErrorService.createUniversalError(
+        TOOL_NAMES.MERGE_RECORDS,
+        'deals',
+        error
+      );
     }
   },
   formatResult: (result: MergeRecordsResult): string => {
     try {
-      if (!result) return 'No merge result';
-      return JSON.stringify(result, null, 2);
+      return formatMergeRecordsResult(result);
     } catch (error: unknown) {
       const fallback = createErrorResult(
         error instanceof Error ? error : new Error(String(error)),
-        'merge_records#format',
+        `${TOOL_NAMES.MERGE_RECORDS}#format`,
         'FORMAT'
       ) as { content?: Array<{ text?: string }> };
       return fallback.content?.[0]?.text || 'Error formatting merge result';
@@ -183,7 +239,7 @@ export const mergeRecordsConfig: UniversalToolConfig<
 };
 
 export const mergeRecordsDefinition = {
-  name: 'merge_records',
+  name: TOOL_NAMES.MERGE_RECORDS,
   description: formatToolDescription({
     capability:
       'Preview and, after explicit confirmation, safely merge two Attio deal records using the native beta merge operation',

--- a/src/handlers/tool-configs/universal/core/record-details-operations.ts
+++ b/src/handlers/tool-configs/universal/core/record-details-operations.ts
@@ -18,6 +18,34 @@ import { handleSearchError } from '@/handlers/tool-configs/universal/core/error-
 import { UniversalUtilityService } from '@/services/UniversalUtilityService.js';
 import { formatToolDescription } from '@/handlers/tools/standards/index.js';
 
+export interface MergeInProgressRecord {
+  id: { record_id: string };
+  values: Record<string, unknown>;
+  merge_in_progress: true;
+  message: string;
+}
+
+export function isMergeInProgressError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const response = (error as { response?: { status?: number; data?: unknown } })
+    .response;
+  if (response?.status !== 404) return false;
+
+  const responseData = response.data;
+  if (!responseData || typeof responseData !== 'object') return false;
+  const data = responseData as Record<string, unknown>;
+  const nestedError = data.error;
+  const code = [
+    data.code,
+    data.type,
+    data.status,
+    typeof nestedError === 'object' && nestedError
+      ? (nestedError as Record<string, unknown>).code
+      : undefined,
+  ].find((value): value is string => typeof value === 'string');
+  return code === 'merge_in_progress' || code === 'merge-in-progress';
+}
+
 /**
  * Issue #1068: Lists returned in list-native format (UniversalRecord)
  */
@@ -36,6 +64,15 @@ export const getRecordDetailsConfig: UniversalToolConfig<
       );
       return await handleUniversalGetDetails(sanitizedParams);
     } catch (error: unknown) {
+      if (isMergeInProgressError(error)) {
+        return {
+          id: { record_id: params.record_id },
+          values: {},
+          merge_in_progress: true,
+          message:
+            'Attio is still applying this merge. The record is not missing; retry later.',
+        } as unknown as UniversalRecordResult;
+      }
       return await handleSearchError(
         error,
         params.resource_type,
@@ -47,6 +84,14 @@ export const getRecordDetailsConfig: UniversalToolConfig<
     const resourceType = extractResourceTypeFromFormatArgs(args);
     if (!record) {
       return 'Record not found';
+    }
+
+    if (
+      typeof record === 'object' &&
+      (record as Record<string, unknown>).merge_in_progress === true
+    ) {
+      const recordId = String(record.id?.record_id || 'unknown');
+      return `⏳ Merge is still in progress for deal ${recordId}; it is not missing. Retry get_record_details later.`;
     }
 
     const resourceTypeName = getSingularResourceLabel(resourceType);

--- a/src/handlers/tool-configs/universal/core/record-details-operations.ts
+++ b/src/handlers/tool-configs/universal/core/record-details-operations.ts
@@ -17,33 +17,13 @@ import { handleUniversalGetDetails } from '@/handlers/tool-configs/universal/sha
 import { handleSearchError } from '@/handlers/tool-configs/universal/core/error-utils.js';
 import { UniversalUtilityService } from '@/services/UniversalUtilityService.js';
 import { formatToolDescription } from '@/handlers/tools/standards/index.js';
+import { isMergeInProgressError } from '@/services/merge/merge-in-progress.js';
 
 export interface MergeInProgressRecord {
   id: { record_id: string };
   values: Record<string, unknown>;
   merge_in_progress: true;
   message: string;
-}
-
-export function isMergeInProgressError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const response = (error as { response?: { status?: number; data?: unknown } })
-    .response;
-  if (response?.status !== 404) return false;
-
-  const responseData = response.data;
-  if (!responseData || typeof responseData !== 'object') return false;
-  const data = responseData as Record<string, unknown>;
-  const nestedError = data.error;
-  const code = [
-    data.code,
-    data.type,
-    data.status,
-    typeof nestedError === 'object' && nestedError
-      ? (nestedError as Record<string, unknown>).code
-      : undefined,
-  ].find((value): value is string => typeof value === 'string');
-  return code === 'merge_in_progress' || code === 'merge-in-progress';
 }
 
 /**

--- a/src/handlers/tool-configs/universal/index.ts
+++ b/src/handlers/tool-configs/universal/index.ts
@@ -144,7 +144,7 @@ export const universalToolDefinitions = {
 };
 
 /**
- * Core universal operations (13 tools)
+ * Core universal operations (14 tools)
  * These consolidate the majority of CRUD and basic search operations
  */
 export const coreUniversalTools = [
@@ -161,6 +161,7 @@ export const coreUniversalTools = [
   'discover_record_attributes',
   'get_record_info',
   'get_record_interactions',
+  'merge_records',
 ];
 
 /**

--- a/src/handlers/tool-configs/universal/schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas.ts
@@ -25,6 +25,7 @@ export {
   updateRecordSchema,
   deleteRecordSchema,
 } from './schemas/core-schemas.js';
+export { mergeRecordsSchema } from './schemas/merge-schemas.js';
 
 // Validation-related schemas (attributes)
 export {

--- a/src/handlers/tool-configs/universal/schemas/merge-schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas/merge-schemas.ts
@@ -1,0 +1,54 @@
+export const mergeRecordsSchema = {
+  type: 'object' as const,
+  properties: {
+    resource_type: {
+      type: 'string' as const,
+      description:
+        'Object type to merge. This beta operation executes for deals only; people and companies are reserved for later coverage.',
+    },
+    record_id: {
+      type: 'string' as const,
+      description: 'Primary/live deal record UUID that should win conflicts',
+    },
+    secondary_record_id: {
+      type: 'string' as const,
+      description: 'Leftover deal record UUID to merge into the primary',
+    },
+    dry_run: {
+      type: 'boolean' as const,
+      default: true,
+      description:
+        'Preview the field plan without patching, clearing, or merging',
+    },
+    confirm: {
+      type: 'boolean' as const,
+      default: false,
+      description: 'Required true in addition to dry_run=false to execute',
+    },
+    keep_from_leftover: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      default: [],
+      description:
+        'Attribute slugs whose leftover values should patch the primary',
+    },
+    skip_leftover_attributes: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      default: [],
+      description: 'Dangerous fill slugs to clear on the leftover before merge',
+    },
+    override_linked_mismatch: {
+      type: 'boolean' as const,
+      default: false,
+      description:
+        'Explicitly allow differing associated person/company records',
+    },
+  },
+  required: [
+    'resource_type' as const,
+    'record_id' as const,
+    'secondary_record_id' as const,
+  ],
+  additionalProperties: false,
+};

--- a/src/handlers/tool-configs/universal/schemas/merge-schemas.ts
+++ b/src/handlers/tool-configs/universal/schemas/merge-schemas.ts
@@ -44,6 +44,11 @@ export const mergeRecordsSchema = {
       description:
         'Explicitly allow differing associated person/company records',
     },
+    plan_fingerprint: {
+      type: 'string' as const,
+      description:
+        'Fingerprint from the dry-run field plan. Required to execute so the pair can be re-diffed',
+    },
   },
   required: [
     'resource_type' as const,

--- a/src/handlers/tool-configs/universal/types.ts
+++ b/src/handlers/tool-configs/universal/types.ts
@@ -259,6 +259,17 @@ export interface UniversalDeleteParams {
   record_id: string;
 }
 
+export interface MergeRecordsParams {
+  resource_type: string;
+  record_id: string;
+  secondary_record_id: string;
+  dry_run?: boolean;
+  confirm?: boolean;
+  keep_from_leftover?: string[];
+  skip_leftover_attributes?: string[];
+  override_linked_mismatch?: boolean;
+}
+
 /**
  * Universal attributes parameters
  */

--- a/src/handlers/tool-configs/universal/types.ts
+++ b/src/handlers/tool-configs/universal/types.ts
@@ -268,6 +268,7 @@ export interface MergeRecordsParams {
   keep_from_leftover?: string[];
   skip_leftover_attributes?: string[];
   override_linked_mismatch?: boolean;
+  plan_fingerprint?: string;
 }
 
 /**

--- a/src/handlers/tool-configs/universal/validators/schema-validator.ts
+++ b/src/handlers/tool-configs/universal/validators/schema-validator.ts
@@ -320,6 +320,42 @@ const toolValidators: Record<string, ToolValidator> = {
     }
     return p;
   },
+  merge_records: (p) => {
+    if (!p.resource_type) {
+      throw new UniversalValidationError(
+        'Missing required parameter: resource_type',
+        ErrorType.USER_ERROR,
+        { field: 'resource_type', example: `resource_type: 'deals'` }
+      );
+    }
+    if (!p.record_id) {
+      throw new UniversalValidationError(
+        'Missing required parameter: record_id',
+        ErrorType.USER_ERROR,
+        { field: 'record_id', example: `record_id: 'deal_uuid'` }
+      );
+    }
+    if (!p.secondary_record_id) {
+      throw new UniversalValidationError(
+        'Missing required parameter: secondary_record_id',
+        ErrorType.USER_ERROR,
+        {
+          field: 'secondary_record_id',
+          example: `secondary_record_id: 'deal_uuid'`,
+        }
+      );
+    }
+    for (const field of ['keep_from_leftover', 'skip_leftover_attributes']) {
+      if (p[field] !== undefined && !Array.isArray(p[field])) {
+        throw new UniversalValidationError(
+          `${field} must be an array of attribute slugs`,
+          ErrorType.USER_ERROR,
+          { field }
+        );
+      }
+    }
+    return p;
+  },
   create_note: (p) => {
     if (!p.resource_type) {
       throw new UniversalValidationError(
@@ -512,6 +548,7 @@ const TOOLS_WITH_DYNAMIC_RESOURCE_TYPES = new Set([
   'create_record',
   'update_record',
   'delete_record',
+  'merge_records',
 ]);
 
 function validateStandardResourceType(resourceType: string): string {

--- a/src/handlers/tool-configs/universal/validators/schema-validator.ts
+++ b/src/handlers/tool-configs/universal/validators/schema-validator.ts
@@ -354,6 +354,16 @@ const toolValidators: Record<string, ToolValidator> = {
         );
       }
     }
+    if (
+      p.plan_fingerprint !== undefined &&
+      typeof p.plan_fingerprint !== 'string'
+    ) {
+      throw new UniversalValidationError(
+        'plan_fingerprint must be a string from the dry-run field plan',
+        ErrorType.USER_ERROR,
+        { field: 'plan_fingerprint' }
+      );
+    }
     return p;
   },
   create_note: (p) => {

--- a/src/services/UniversalRetrievalService.ts
+++ b/src/services/UniversalRetrievalService.ts
@@ -47,27 +47,7 @@ import { getObjectRecord } from '@/objects/records/index.js';
 import { getTask } from '@/objects/tasks.js';
 import { getNote, normalizeNoteResponse } from '@/objects/notes.js';
 import { isConfiguredCustomObjectResourceType } from '@/utils/resource-type-detection.js';
-
-function isMergeInProgressError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const response = (error as { response?: { status?: number; data?: unknown } })
-    .response;
-  if (response?.status !== 404) return false;
-
-  const responseData = response.data;
-  if (!responseData || typeof responseData !== 'object') return false;
-  const data = responseData as Record<string, unknown>;
-  const nestedError = data.error;
-  const code = [
-    data.code,
-    data.type,
-    data.status,
-    typeof nestedError === 'object' && nestedError
-      ? (nestedError as Record<string, unknown>).code
-      : undefined,
-  ].find((value): value is string => typeof value === 'string');
-  return code === 'merge_in_progress' || code === 'merge-in-progress';
-}
+import { isMergeInProgressError } from '@/services/merge/merge-in-progress.js';
 
 /**
  * UniversalRetrievalService provides centralized record retrieval functionality

--- a/src/services/UniversalRetrievalService.ts
+++ b/src/services/UniversalRetrievalService.ts
@@ -48,6 +48,27 @@ import { getTask } from '@/objects/tasks.js';
 import { getNote, normalizeNoteResponse } from '@/objects/notes.js';
 import { isConfiguredCustomObjectResourceType } from '@/utils/resource-type-detection.js';
 
+function isMergeInProgressError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const response = (error as { response?: { status?: number; data?: unknown } })
+    .response;
+  if (response?.status !== 404) return false;
+
+  const responseData = response.data;
+  if (!responseData || typeof responseData !== 'object') return false;
+  const data = responseData as Record<string, unknown>;
+  const nestedError = data.error;
+  const code = [
+    data.code,
+    data.type,
+    data.status,
+    typeof nestedError === 'object' && nestedError
+      ? (nestedError as Record<string, unknown>).code
+      : undefined,
+  ].find((value): value is string => typeof value === 'string');
+  return code === 'merge_in_progress' || code === 'merge-in-progress';
+}
+
 /**
  * UniversalRetrievalService provides centralized record retrieval functionality
  *
@@ -197,6 +218,22 @@ export class UniversalRetrievalService {
       return result;
     } catch (apiError: unknown) {
       enhancedPerformanceTracker.markApiEnd(perfId, apiStart);
+
+      if (isMergeInProgressError(apiError)) {
+        enhancedPerformanceTracker.endOperation(
+          perfId,
+          true,
+          'Merge still in progress',
+          202
+        );
+        return {
+          id: { record_id },
+          values: {},
+          merge_in_progress: true,
+          message:
+            'Attio is still applying this merge. The record is not missing; retry later.',
+        } as unknown as AttioRecord;
+      }
 
       // Handle EnhancedApiError instances directly - preserve them through the chain
       if (isEnhancedApiError(apiError)) {

--- a/src/services/merge/deal-merge-executor.ts
+++ b/src/services/merge/deal-merge-executor.ts
@@ -1,0 +1,146 @@
+import type { AttioRecord } from '@/types/attio.js';
+import {
+  getRecord,
+  mergeRecords,
+  overwriteRecordAttributes,
+} from '@/api/operations/index.js';
+import { UniversalUpdateService } from '@/services/UniversalUpdateService.js';
+import {
+  assertDealMergePlanFresh,
+  buildDealMergePlan,
+  getDealMergeClears,
+  getDealMergePatch,
+  validateDealMergeChoices,
+  type DealMergeChoiceOptions,
+  type DealMergePlan,
+} from '@/services/merge/deal-merge-planner.js';
+
+export interface DealMergeExecutionParams extends DealMergeChoiceOptions {
+  primary_record_id: string;
+  leftover_record_id: string;
+  keep_from_leftover: string[];
+  skip_leftover_attributes: string[];
+}
+
+export interface DealMergeExecutionResult {
+  mode: 'complete' | 'wait';
+  status: 200 | 202;
+  new_record_id: string;
+  original_record_ids: string[];
+  warning: string;
+  plan: DealMergePlan;
+  message?: string;
+}
+
+export async function loadDealMergePlan(
+  primaryRecordId: string,
+  leftoverRecordId: string
+): Promise<DealMergePlan> {
+  const [primary, leftover] = await Promise.all([
+    getRecord<AttioRecord>('deals', primaryRecordId),
+    getRecord<AttioRecord>('deals', leftoverRecordId),
+  ]);
+  return buildDealMergePlan(primary, leftover);
+}
+
+/**
+ * Re-diff and execute a deal merge. There is intentionally no spanning
+ * transaction: once a PUT-clear succeeds, a later native merge failure is
+ * surfaced as an indeterminate, already-cleared state.
+ */
+export async function executeDealMerge(
+  params: DealMergeExecutionParams,
+  expectedPlan?: DealMergePlan
+): Promise<DealMergeExecutionResult> {
+  const currentPlan = await loadDealMergePlan(
+    params.primary_record_id,
+    params.leftover_record_id
+  );
+
+  if (expectedPlan) {
+    assertDealMergePlanFresh(expectedPlan, currentPlan);
+  }
+
+  validateDealMergeChoices(
+    currentPlan,
+    params.keep_from_leftover,
+    params.skip_leftover_attributes,
+    params
+  );
+
+  const patch = getDealMergePatch(currentPlan, params.keep_from_leftover);
+  if (Object.keys(patch).length > 0) {
+    await UniversalUpdateService.updateRecordWithValidation({
+      resource_type: 'deals',
+      record_id: params.primary_record_id,
+      record_data: { values: patch },
+      return_details: true,
+    });
+  }
+
+  let leftoverCleared = false;
+  const clears = getDealMergeClears(
+    currentPlan,
+    params.skip_leftover_attributes
+  );
+  try {
+    if (Object.keys(clears).length > 0) {
+      const clearResult = await overwriteRecordAttributes(
+        'deals',
+        params.leftover_record_id,
+        clears
+      );
+      if (clearResult.status < 200 || clearResult.status >= 300) {
+        throw new Error(
+          `Attio leftover clear returned HTTP ${clearResult.status}`
+        );
+      }
+      leftoverCleared = true;
+    }
+
+    const mergeResult = await mergeRecords(
+      'deals',
+      params.primary_record_id,
+      params.leftover_record_id
+    );
+    const warning =
+      'Both original deal ids are unreadable after native merge; use new_record_id for the survivor.';
+
+    if (mergeResult.status === 202) {
+      return {
+        mode: 'wait',
+        status: 202,
+        new_record_id: mergeResult.new_record_id,
+        original_record_ids: [
+          params.primary_record_id,
+          params.leftover_record_id,
+        ],
+        warning,
+        plan: currentPlan,
+        message:
+          'Attio is still applying the merge. Do not poll here; retry get_record_details with new_record_id later.',
+      };
+    }
+
+    return {
+      mode: 'complete',
+      status: 200,
+      new_record_id: mergeResult.new_record_id,
+      original_record_ids: [
+        params.primary_record_id,
+        params.leftover_record_id,
+      ],
+      warning,
+      plan: currentPlan,
+    };
+  } catch (error: unknown) {
+    if (leftoverCleared) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${message}. Leftover attributes were already cleared; do not retry the native merge automatically.`,
+        { cause: error instanceof Error ? error : undefined }
+      );
+    }
+    throw error;
+  }
+}

--- a/src/services/merge/deal-merge-executor.ts
+++ b/src/services/merge/deal-merge-executor.ts
@@ -80,10 +80,7 @@ export async function executeDealMerge(
   }
 
   let leftoverCleared = false;
-  const clears = getDealMergeClears(
-    currentPlan,
-    params.skip_leftover_attributes
-  );
+  const clears = getDealMergeClears(params.skip_leftover_attributes);
   try {
     if (Object.keys(clears).length > 0) {
       const clearResult = await overwriteRecordAttributes(

--- a/src/services/merge/deal-merge-executor.ts
+++ b/src/services/merge/deal-merge-executor.ts
@@ -20,6 +20,7 @@ export interface DealMergeExecutionParams extends DealMergeChoiceOptions {
   leftover_record_id: string;
   keep_from_leftover: string[];
   skip_leftover_attributes: string[];
+  plan_fingerprint: string;
 }
 
 export interface DealMergeExecutionResult {
@@ -49,17 +50,17 @@ export async function loadDealMergePlan(
  * surfaced as an indeterminate, already-cleared state.
  */
 export async function executeDealMerge(
-  params: DealMergeExecutionParams,
-  expectedPlan?: DealMergePlan
+  params: DealMergeExecutionParams
 ): Promise<DealMergeExecutionResult> {
   const currentPlan = await loadDealMergePlan(
     params.primary_record_id,
     params.leftover_record_id
   );
 
-  if (expectedPlan) {
-    assertDealMergePlanFresh(expectedPlan, currentPlan);
-  }
+  assertDealMergePlanFresh(
+    { fingerprint: params.plan_fingerprint },
+    currentPlan
+  );
 
   validateDealMergeChoices(
     currentPlan,

--- a/src/services/merge/deal-merge-planner.ts
+++ b/src/services/merge/deal-merge-planner.ts
@@ -264,12 +264,11 @@ export const planDealMerge = buildDealMergePlan;
 
 /** Refuse to execute a resolution set against a changed flagged plan. */
 export function assertDealMergePlanFresh(
-  expectedPlan: DealMergePlan,
+  expectedPlan: Pick<DealMergePlan, 'fingerprint'>,
   currentPlan: DealMergePlan
 ): void {
   if (
-    expectedPlan.primary_record_id !== currentPlan.primary_record_id ||
-    expectedPlan.leftover_record_id !== currentPlan.leftover_record_id ||
+    !expectedPlan.fingerprint ||
     expectedPlan.fingerprint !== currentPlan.fingerprint
   ) {
     throw new Error(

--- a/src/services/merge/deal-merge-planner.ts
+++ b/src/services/merge/deal-merge-planner.ts
@@ -9,7 +9,6 @@ export type DealMergeFieldKind = 'fill' | 'conflict' | 'dangerous_empty_fill';
 
 export interface DealMergeField {
   attribute: string;
-  slug: string;
   kind: DealMergeFieldKind;
   primary_value: unknown;
   leftover_value: unknown;
@@ -18,15 +17,12 @@ export interface DealMergeField {
 
 export interface DealLinkedMismatch {
   attribute: string;
-  slug: string;
   primary_value: unknown;
   leftover_value: unknown;
 }
 
 export interface DealMergePlan {
   primary_record_id: string;
-  live_record_id: string;
-  secondary_record_id: string;
   leftover_record_id: string;
   fills: DealMergeField[];
   conflicts: DealMergeField[];
@@ -130,7 +126,6 @@ function makeField(
 ): DealMergeField {
   return {
     attribute,
-    slug: attribute,
     kind,
     primary_value: primaryValue,
     leftover_value: leftoverValue,
@@ -192,7 +187,6 @@ export function buildDealMergePlan(
       if (linkedValuesDiffer(primaryValue, leftoverValue)) {
         linkedMismatches.push({
           attribute,
-          slug: attribute,
           primary_value: primaryValue,
           leftover_value: leftoverValue,
         });
@@ -241,8 +235,6 @@ export function buildDealMergePlan(
 
   const planWithoutFingerprint: Omit<DealMergePlan, 'fingerprint'> = {
     primary_record_id: primaryRecordId,
-    live_record_id: primaryRecordId,
-    secondary_record_id: leftoverRecordId,
     leftover_record_id: leftoverRecordId,
     fills,
     conflicts,
@@ -259,8 +251,6 @@ export function buildDealMergePlan(
     ),
   };
 }
-
-export const planDealMerge = buildDealMergePlan;
 
 /** Refuse to execute a resolution set against a changed flagged plan. */
 export function assertDealMergePlanFresh(
@@ -362,7 +352,6 @@ export function getDealMergePatch(
 }
 
 export function getDealMergeClears(
-  plan: DealMergePlan,
   skipLeftoverAttributes: string[]
 ): Record<string, []> {
   return Object.fromEntries(

--- a/src/services/merge/deal-merge-planner.ts
+++ b/src/services/merge/deal-merge-planner.ts
@@ -1,0 +1,372 @@
+import type { AttioRecord } from '@/types/attio.js';
+import { isValidUUID } from '@/utils/validation/uuid-validation.js';
+
+const OMITTED_ATTRIBUTES = new Set(['notes', 'tasks', 'list_memberships']);
+const ALWAYS_DANGEROUS_ATTRIBUTES = new Set(['stage', 'owner', 'value']);
+const LINKED_ATTRIBUTES = new Set(['associated_people', 'associated_company']);
+
+export type DealMergeFieldKind = 'fill' | 'conflict' | 'dangerous_empty_fill';
+
+export interface DealMergeField {
+  attribute: string;
+  slug: string;
+  kind: DealMergeFieldKind;
+  primary_value: unknown;
+  leftover_value: unknown;
+  reason?: string;
+}
+
+export interface DealLinkedMismatch {
+  attribute: string;
+  slug: string;
+  primary_value: unknown;
+  leftover_value: unknown;
+}
+
+export interface DealMergePlan {
+  primary_record_id: string;
+  live_record_id: string;
+  secondary_record_id: string;
+  leftover_record_id: string;
+  fills: DealMergeField[];
+  conflicts: DealMergeField[];
+  dangerous_fills: DealMergeField[];
+  linked_mismatches: DealLinkedMismatch[];
+  requires_linked_mismatch_override: boolean;
+  flagged_attribute_slugs: string[];
+  fingerprint: string;
+}
+
+export interface DealMergeChoiceOptions {
+  override_linked_mismatch?: boolean;
+}
+
+function asRecordValues(
+  record: AttioRecord,
+  label: string
+): Record<string, unknown> {
+  if (!record || typeof record !== 'object') {
+    throw new Error(`${label} deal record is required`);
+  }
+
+  const recordId = record.id?.record_id;
+  if (typeof recordId !== 'string' || !isValidUUID(recordId)) {
+    throw new Error(`${label} deal record requires a valid UUID record_id`);
+  }
+
+  if (!record.values || typeof record.values !== 'object') {
+    throw new Error(`${label} deal record values are required`);
+  }
+
+  return record.values as Record<string, unknown>;
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string') return value.trim().length === 0;
+  if (Array.isArray(value))
+    return value.length === 0 || value.every(isEmptyValue);
+  if (typeof value !== 'object') return false;
+
+  const objectValue = value as Record<string, unknown>;
+  const entries = Object.entries(objectValue);
+  if (entries.length === 0) return true;
+  return entries.every(([, entryValue]) => isEmptyValue(entryValue));
+}
+
+function isFalseValue(value: unknown): boolean {
+  if (value === false) return true;
+  if (Array.isArray(value)) return value.some(isFalseValue);
+  if (value && typeof value === 'object') {
+    return isFalseValue((value as Record<string, unknown>).value);
+  }
+  return false;
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entryValue]) => [key, stableValue(entryValue)])
+    );
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(stableValue(value)) ?? 'undefined';
+}
+
+function referenceIds(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .flatMap((item) => {
+      if (!item || typeof item !== 'object') return [];
+      const reference = item as Record<string, unknown>;
+      const id = reference.target_record_id ?? reference.record_id;
+      return typeof id === 'string' ? [id] : [];
+    })
+    .sort();
+}
+
+function linkedValuesDiffer(primary: unknown, leftover: unknown): boolean {
+  const primaryIds = referenceIds(primary);
+  const leftoverIds = referenceIds(leftover);
+  return (
+    primaryIds.length > 0 &&
+    leftoverIds.length > 0 &&
+    stableStringify(primaryIds) !== stableStringify(leftoverIds)
+  );
+}
+
+function makeField(
+  attribute: string,
+  kind: DealMergeFieldKind,
+  primaryValue: unknown,
+  leftoverValue: unknown,
+  reason?: string
+): DealMergeField {
+  return {
+    attribute,
+    slug: attribute,
+    kind,
+    primary_value: primaryValue,
+    leftover_value: leftoverValue,
+    ...(reason ? { reason } : {}),
+  };
+}
+
+function isDangerousFill(attribute: string, leftoverValue: unknown): boolean {
+  if (ALWAYS_DANGEROUS_ATTRIBUTES.has(attribute)) return true;
+  return attribute === 'consent_to_contact' && isFalseValue(leftoverValue);
+}
+
+function buildFingerprintPayload(plan: Omit<DealMergePlan, 'fingerprint'>) {
+  return {
+    primary_record_id: plan.primary_record_id,
+    leftover_record_id: plan.leftover_record_id,
+    fills: plan.fills,
+    conflicts: plan.conflicts,
+    dangerous_fills: plan.dangerous_fills,
+    linked_mismatches: plan.linked_mismatches,
+    flagged_attribute_slugs: plan.flagged_attribute_slugs,
+  };
+}
+
+/** Build a side-effect-free plan from the current primary and leftover deals. */
+export function buildDealMergePlan(
+  primary: AttioRecord,
+  leftover: AttioRecord
+): DealMergePlan {
+  const primaryValues = asRecordValues(primary, 'Primary');
+  const leftoverValues = asRecordValues(leftover, 'Leftover');
+  const primaryRecordId = primary.id.record_id;
+  const leftoverRecordId = leftover.id.record_id;
+
+  if (primaryRecordId === leftoverRecordId) {
+    throw new Error('A deal cannot be merged with itself');
+  }
+
+  const fills: DealMergeField[] = [];
+  const conflicts: DealMergeField[] = [];
+  const dangerousFills: DealMergeField[] = [];
+  const linkedMismatches: DealLinkedMismatch[] = [];
+  const attributes = new Set([
+    ...Object.keys(primaryValues),
+    ...Object.keys(leftoverValues),
+  ]);
+
+  for (const attribute of [...attributes].sort()) {
+    if (OMITTED_ATTRIBUTES.has(attribute)) continue;
+
+    const primaryValue = primaryValues[attribute];
+    const leftoverValue = leftoverValues[attribute];
+    const primaryEmpty = isEmptyValue(primaryValue);
+    const leftoverEmpty = isEmptyValue(leftoverValue);
+
+    if (primaryEmpty && leftoverEmpty) continue;
+
+    if (LINKED_ATTRIBUTES.has(attribute)) {
+      if (linkedValuesDiffer(primaryValue, leftoverValue)) {
+        linkedMismatches.push({
+          attribute,
+          slug: attribute,
+          primary_value: primaryValue,
+          leftover_value: leftoverValue,
+        });
+      }
+      if (primaryEmpty && !leftoverEmpty) {
+        fills.push(makeField(attribute, 'fill', primaryValue, leftoverValue));
+      }
+      continue;
+    }
+
+    if (primaryEmpty && !leftoverEmpty) {
+      const dangerous = isDangerousFill(attribute, leftoverValue);
+      const field = makeField(
+        attribute,
+        dangerous ? 'dangerous_empty_fill' : 'fill',
+        primaryValue,
+        leftoverValue,
+        dangerous
+          ? 'This empty-primary fill requires an explicit keep or skip'
+          : undefined
+      );
+      if (dangerous) dangerousFills.push(field);
+      else fills.push(field);
+      continue;
+    }
+
+    if (
+      !primaryEmpty &&
+      !leftoverEmpty &&
+      stableStringify(primaryValue) !== stableStringify(leftoverValue)
+    ) {
+      conflicts.push(
+        makeField(attribute, 'conflict', primaryValue, leftoverValue)
+      );
+    }
+  }
+
+  const flaggedAttributeSlugs = [
+    ...new Set([
+      ...fills.map((field) => field.attribute),
+      ...conflicts.map((field) => field.attribute),
+      ...dangerousFills.map((field) => field.attribute),
+      ...linkedMismatches.map((field) => field.attribute),
+    ]),
+  ].sort();
+
+  const planWithoutFingerprint: Omit<DealMergePlan, 'fingerprint'> = {
+    primary_record_id: primaryRecordId,
+    live_record_id: primaryRecordId,
+    secondary_record_id: leftoverRecordId,
+    leftover_record_id: leftoverRecordId,
+    fills,
+    conflicts,
+    dangerous_fills: dangerousFills,
+    linked_mismatches: linkedMismatches,
+    requires_linked_mismatch_override: linkedMismatches.length > 0,
+    flagged_attribute_slugs: flaggedAttributeSlugs,
+  };
+
+  return {
+    ...planWithoutFingerprint,
+    fingerprint: stableStringify(
+      buildFingerprintPayload(planWithoutFingerprint)
+    ),
+  };
+}
+
+export const planDealMerge = buildDealMergePlan;
+
+/** Refuse to execute a resolution set against a changed flagged plan. */
+export function assertDealMergePlanFresh(
+  expectedPlan: DealMergePlan,
+  currentPlan: DealMergePlan
+): void {
+  if (
+    expectedPlan.primary_record_id !== currentPlan.primary_record_id ||
+    expectedPlan.leftover_record_id !== currentPlan.leftover_record_id ||
+    expectedPlan.fingerprint !== currentPlan.fingerprint
+  ) {
+    throw new Error(
+      'The deal merge plan changed after dry-run; re-run dry-run before confirming'
+    );
+  }
+}
+
+function findFlaggedField(
+  plan: DealMergePlan,
+  attribute: string
+): DealMergeField | undefined {
+  return [...plan.fills, ...plan.conflicts, ...plan.dangerous_fills].find(
+    (field) => field.attribute === attribute
+  );
+}
+
+/** Validate keep/skip selections before any mutation begins. */
+export function validateDealMergeChoices(
+  plan: DealMergePlan,
+  keepFromLeftover: string[],
+  skipLeftoverAttributes: string[],
+  options: DealMergeChoiceOptions = {}
+): void {
+  const keep = new Set(keepFromLeftover);
+  const skip = new Set(skipLeftoverAttributes);
+
+  if (
+    keep.size !== keepFromLeftover.length ||
+    skip.size !== skipLeftoverAttributes.length
+  ) {
+    throw new Error(
+      'keep_from_leftover and skip_leftover_attributes cannot contain duplicates'
+    );
+  }
+
+  for (const attribute of keep) {
+    if (!findFlaggedField(plan, attribute)) {
+      throw new Error(
+        `keep_from_leftover contains an unflagged attribute: ${attribute}`
+      );
+    }
+  }
+  for (const attribute of skip) {
+    const field = plan.dangerous_fills.find(
+      (candidate) => candidate.attribute === attribute
+    );
+    if (!field) {
+      throw new Error(
+        `skip_leftover_attributes may only clear dangerous fills: ${attribute}`
+      );
+    }
+  }
+  for (const attribute of keep) {
+    if (skip.has(attribute)) {
+      throw new Error(
+        `An attribute cannot be both kept and skipped: ${attribute}`
+      );
+    }
+  }
+
+  if (
+    plan.requires_linked_mismatch_override &&
+    !options.override_linked_mismatch
+  ) {
+    throw new Error(
+      'Linked person or company mismatch requires override_linked_mismatch: true'
+    );
+  }
+
+  const resolvedDangerous = plan.dangerous_fills.every(
+    (field) => keep.has(field.attribute) || skip.has(field.attribute)
+  );
+  if (!resolvedDangerous) {
+    throw new Error(
+      'Every dangerous empty-primary fill requires an explicit keep or skip'
+    );
+  }
+}
+
+export function getDealMergePatch(
+  plan: DealMergePlan,
+  keepFromLeftover: string[]
+): Record<string, unknown> {
+  return Object.fromEntries(
+    keepFromLeftover
+      .map((attribute) => findFlaggedField(plan, attribute))
+      .filter((field): field is DealMergeField => Boolean(field))
+      .map((field) => [field.attribute, field.leftover_value])
+  );
+}
+
+export function getDealMergeClears(
+  plan: DealMergePlan,
+  skipLeftoverAttributes: string[]
+): Record<string, []> {
+  return Object.fromEntries(
+    skipLeftoverAttributes.map((attribute) => [attribute, []])
+  ) as Record<string, []>;
+}

--- a/src/services/merge/merge-in-progress.ts
+++ b/src/services/merge/merge-in-progress.ts
@@ -1,0 +1,20 @@
+export function isMergeInProgressError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const response = (error as { response?: { status?: number; data?: unknown } })
+    .response;
+  if (response?.status !== 404) return false;
+
+  const responseData = response.data;
+  if (!responseData || typeof responseData !== 'object') return false;
+  const data = responseData as Record<string, unknown>;
+  const nestedError = data.error;
+  const code = [
+    data.code,
+    data.type,
+    data.status,
+    typeof nestedError === 'object' && nestedError
+      ? (nestedError as Record<string, unknown>).code
+      : undefined,
+  ].find((value): value is string => typeof value === 'string');
+  return code === 'merge_in_progress' || code === 'merge-in-progress';
+}

--- a/test/api/operations/merge.test.ts
+++ b/test/api/operations/merge.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { post, put } = vi.hoisted(() => ({
+  post: vi.fn(),
+  put: vi.fn(),
+}));
+
+vi.mock('@/api/lazy-client.js', () => ({
+  getLazyAttioClient: () => ({ post, put }),
+}));
+
+import {
+  mergeRecords,
+  overwriteRecordAttributes,
+} from '@/api/operations/merge.js';
+
+describe('merge API operations', () => {
+  it('merges records and returns the new record id for a 200 response', async () => {
+    post.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        data: { id: { record_id: 'new-record-id' } },
+      },
+    });
+
+    await expect(
+      mergeRecords('deals', 'primary-id', 'secondary-id')
+    ).resolves.toEqual({
+      status: 200,
+      new_record_id: 'new-record-id',
+      data: { id: { record_id: 'new-record-id' } },
+    });
+    expect(post).toHaveBeenCalledWith('/objects/deals/records/merge', {
+      data: {
+        primary_record_id: 'primary-id',
+        secondary_record_id: 'secondary-id',
+      },
+    });
+  });
+
+  it('returns a wait result for 202 without polling', async () => {
+    post.mockResolvedValueOnce({
+      status: 202,
+      data: { data: { new_record_id: 'pending-record-id' } },
+    });
+
+    await expect(
+      mergeRecords('deals', 'primary-id', 'secondary-id')
+    ).resolves.toMatchObject({
+      status: 202,
+      new_record_id: 'pending-record-id',
+    });
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a merge once for HTTP 429 and honors Retry-After', async () => {
+    post
+      .mockRejectedValueOnce({
+        response: { status: 429, headers: { 'retry-after': '0' } },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { data: { id: { record_id: 'new-record-id' } } },
+      });
+
+    await expect(
+      mergeRecords('deals', 'primary-id', 'secondary-id')
+    ).resolves.toMatchObject({ status: 200, new_record_id: 'new-record-id' });
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a 500 response', async () => {
+    post.mockRejectedValueOnce({ response: { status: 500 } });
+
+    await expect(
+      mergeRecords('deals', 'primary-id', 'secondary-id')
+    ).rejects.toMatchObject({ response: { status: 500 } });
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces Attio self_merge errors clearly', async () => {
+    post.mockRejectedValueOnce({
+      response: { status: 400, data: { code: 'self_merge' } },
+    });
+
+    await expect(mergeRecords('deals', 'same-id', 'same-id')).rejects.toThrow(
+      'self_merge'
+    );
+  });
+
+  it('overwrites named attributes and sends empty arrays for clears', async () => {
+    put.mockResolvedValueOnce({
+      status: 200,
+      data: { data: { id: { record_id: 'secondary-id' } } },
+    });
+
+    await expect(
+      overwriteRecordAttributes('deals', 'secondary-id', {
+        associated_people: [],
+        consent_to_contact: [],
+      })
+    ).resolves.toMatchObject({
+      status: 200,
+      data: { id: { record_id: 'secondary-id' } },
+    });
+    expect(put).toHaveBeenCalledWith('/objects/deals/records/secondary-id', {
+      data: {
+        values: {
+          associated_people: [],
+          consent_to_contact: [],
+        },
+      },
+    });
+  });
+});

--- a/test/e2e/mcp/deal-operations/merge-records.mcp.test.ts
+++ b/test/e2e/mcp/deal-operations/merge-records.mcp.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const HAS_API_KEY = Boolean(process.env.ATTIO_API_KEY);
+const STAGE_STATUS_ENDPOINT =
+  'https://api.attio.com/v2/objects/deals/attributes/stage/statuses';
+
+type McpResult = {
+  isError?: boolean;
+  content?: Array<{ text?: string }>;
+};
+
+type ToolArguments = Record<string, unknown>;
+
+class LiveMcpTestClient {
+  private readonly client: Client;
+
+  constructor(apiKey: string) {
+    this.client = new Client(
+      { name: 'safe-deal-merge-e2e', version: '1.0.0' },
+      { capabilities: {} }
+    );
+
+    this.transport = new StdioClientTransport({
+      command: 'node',
+      args: ['./dist/cli.js'],
+      env: { ATTIO_API_KEY: apiKey },
+    });
+  }
+
+  private readonly transport: StdioClientTransport;
+
+  async init(): Promise<void> {
+    await this.client.connect(this.transport);
+  }
+
+  async callTool(
+    toolName: string,
+    args: ToolArguments
+  ): Promise<CallToolResult> {
+    return this.client.callTool({ name: toolName, arguments: args });
+  }
+
+  async cleanup(): Promise<void> {
+    await this.client.close();
+  }
+}
+
+async function resolveStageUuid(): Promise<string> {
+  const response = await fetch(STAGE_STATUS_ENDPOINT, {
+    headers: { Authorization: `Bearer ${process.env.ATTIO_API_KEY}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch an active deal stage (${response.status})`
+    );
+  }
+
+  const json = (await response.json()) as {
+    data?: Array<{ id?: { status_id?: string }; is_archived?: boolean }>;
+  };
+  const active = json.data?.find(
+    (status) => status.id?.status_id && !status.is_archived
+  );
+  if (!active?.id?.status_id) {
+    throw new Error('No active deal stage status was found');
+  }
+  return active.id.status_id;
+}
+
+function resultText(result: unknown): string {
+  const typed = result as McpResult;
+  return (typed.content || []).map((content) => content.text || '').join('\n');
+}
+
+function extractUuid(result: unknown): string | null {
+  const contents = (result as { content?: Array<{ text?: string }> }).content;
+  for (const content of contents || []) {
+    if (!content.text) continue;
+    try {
+      const parsed = JSON.parse(content.text) as {
+        id?: { record_id?: unknown };
+      };
+      const parsedRecordId = parsed.id?.record_id;
+      if (
+        typeof parsedRecordId === 'string' &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+          parsedRecordId
+        )
+      ) {
+        return parsedRecordId;
+      }
+    } catch {
+      // Try the next content block or the human-readable formatter below.
+    }
+  }
+
+  const structuredContent = (
+    result as {
+      structuredContent?: { id?: { record_id?: unknown } };
+    }
+  ).structuredContent;
+  const structuredRecordId = structuredContent?.id?.record_id;
+  if (
+    typeof structuredRecordId === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      structuredRecordId
+    )
+  ) {
+    return structuredRecordId;
+  }
+
+  const recordIdMatch = resultText(result).match(
+    /(?:record_id|new_record_id|ID)"?\s*[:=]\s*"?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i
+  );
+  return recordIdMatch?.[1] || null;
+}
+
+describe('merge_records MCP e2e', () => {
+  let client: LiveMcpTestClient | null = null;
+  let stageUuid: string | null = null;
+  const createdDealIds: string[] = [];
+
+  beforeAll(async () => {
+    if (!HAS_API_KEY) return;
+    stageUuid = await resolveStageUuid();
+    client = new LiveMcpTestClient(process.env.ATTIO_API_KEY as string);
+    await client.init();
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    for (const recordId of createdDealIds) {
+      try {
+        await client.callTool('delete_record', {
+          resource_type: 'deals',
+          record_id: recordId,
+        });
+      } catch {
+        // Native merge makes the original ids unreadable; cleanup is best effort.
+      }
+    }
+    await client.cleanup();
+  });
+
+  async function createDeal(label: string): Promise<string> {
+    if (!client || !stageUuid) throw new Error('MCP e2e client is not ready');
+    const result = await client.callTool('create_record', {
+      resource_type: 'deals',
+      record_data: {
+        values: {
+          name: `SAFE_MERGE_E2E_${label}_${Date.now()}`,
+          stage: stageUuid,
+          value: 1000,
+          ...(process.env.ATTIO_DEFAULT_DEAL_OWNER
+            ? { owner: process.env.ATTIO_DEFAULT_DEAL_OWNER }
+            : {}),
+        },
+      },
+    });
+    expect((result as McpResult).isError).toBeFalsy();
+    const recordId = extractUuid(result);
+    if (!recordId) throw new Error('create_record did not return a deal id');
+    createdDealIds.push(recordId);
+    return recordId;
+  }
+
+  const keyedTest = HAS_API_KEY ? it : it.skip;
+
+  keyedTest(
+    'defaults to a non-mutating dry-run field plan',
+    { timeout: 120000 },
+    async () => {
+      if (!client) throw new Error('MCP e2e client is not ready');
+      const primaryId = await createDeal('DRY_PRIMARY');
+      const leftoverId = await createDeal('DRY_LEFTOVER');
+      expect(leftoverId).not.toBe(primaryId);
+
+      const result = await client.callTool('merge_records', {
+        resource_type: 'deals',
+        record_id: primaryId,
+        secondary_record_id: leftoverId,
+      });
+
+      expect((result as McpResult).isError).toBeFalsy();
+      expect(resultText(result).toLowerCase()).toContain('dry_run');
+
+      const primaryRead = await client.callTool('get_record_details', {
+        resource_type: 'deals',
+        record_id: primaryId,
+      });
+      const leftoverRead = await client.callTool('get_record_details', {
+        resource_type: 'deals',
+        record_id: leftoverId,
+      });
+      expect((primaryRead as McpResult).isError).toBeFalsy();
+      expect((leftoverRead as McpResult).isError).toBeFalsy();
+    }
+  );
+
+  keyedTest(
+    'executes only with confirm and returns the native survivor id without polling 202',
+    { timeout: 120000 },
+    async () => {
+      if (!client) throw new Error('MCP e2e client is not ready');
+      const primaryId = await createDeal('EXEC_PRIMARY');
+      const leftoverId = await createDeal('EXEC_LEFTOVER');
+      expect(leftoverId).not.toBe(primaryId);
+
+      const preview = await client.callTool('merge_records', {
+        resource_type: 'deals',
+        record_id: primaryId,
+        secondary_record_id: leftoverId,
+      });
+      expect((preview as McpResult).isError).toBeFalsy();
+
+      const result = await client.callTool('merge_records', {
+        resource_type: 'deals',
+        record_id: primaryId,
+        secondary_record_id: leftoverId,
+        dry_run: false,
+        confirm: true,
+      });
+
+      expect((result as McpResult).isError).toBeFalsy();
+      const text = resultText(result);
+      expect(text).toContain('new_record_id');
+      const newRecordId = extractUuid(result);
+      if (newRecordId) createdDealIds.push(newRecordId);
+    }
+  );
+});

--- a/test/e2e/mcp/deal-operations/merge-records.mcp.test.ts
+++ b/test/e2e/mcp/deal-operations/merge-records.mcp.test.ts
@@ -118,6 +118,18 @@ function extractUuid(result: unknown): string | null {
   return recordIdMatch?.[1] || null;
 }
 
+function extractFingerprint(result: unknown): string | null {
+  const structuredFingerprint = (
+    result as { structuredContent?: { plan?: { fingerprint?: unknown } } }
+  ).structuredContent?.plan?.fingerprint;
+  if (typeof structuredFingerprint === 'string' && structuredFingerprint) {
+    return structuredFingerprint;
+  }
+
+  const match = resultText(result).match(/^Plan fingerprint: (.+)$/m);
+  return match?.[1]?.trim() || null;
+}
+
 describe('merge_records MCP e2e', () => {
   let client: LiveMcpTestClient | null = null;
   let stageUuid: string | null = null;
@@ -185,7 +197,7 @@ describe('merge_records MCP e2e', () => {
       });
 
       expect((result as McpResult).isError).toBeFalsy();
-      expect(resultText(result).toLowerCase()).toContain('dry_run');
+      expect(resultText(result).toLowerCase()).toContain('dry-run');
 
       const primaryRead = await client.callTool('get_record_details', {
         resource_type: 'deals',
@@ -215,6 +227,8 @@ describe('merge_records MCP e2e', () => {
         secondary_record_id: leftoverId,
       });
       expect((preview as McpResult).isError).toBeFalsy();
+      const planFingerprint = extractFingerprint(preview);
+      expect(planFingerprint).toBeTruthy();
 
       const result = await client.callTool('merge_records', {
         resource_type: 'deals',
@@ -222,11 +236,12 @@ describe('merge_records MCP e2e', () => {
         secondary_record_id: leftoverId,
         dry_run: false,
         confirm: true,
+        plan_fingerprint: planFingerprint,
       });
 
       expect((result as McpResult).isError).toBeFalsy();
       const text = resultText(result);
-      expect(text).toContain('new_record_id');
+      expect(text).toMatch(/New record ID:/i);
       const newRecordId = extractUuid(result);
       if (newRecordId) createdDealIds.push(newRecordId);
     }

--- a/test/formatResult-contract-regression.test.ts
+++ b/test/formatResult-contract-regression.test.ts
@@ -34,6 +34,7 @@ const UNIVERSAL_TOOL_CONFIGS = [
   { name: 'create-record', config: coreOpsConfig.createRecordConfig },
   { name: 'update-record', config: coreOpsConfig.updateRecordConfig },
   { name: 'delete-record', config: coreOpsConfig.deleteRecordConfig },
+  { name: 'merge-records', config: coreOpsConfig.mergeRecordsConfig },
   { name: 'get-attributes', config: coreOpsConfig.getAttributesConfig },
   { name: 'get-detailed-info', config: coreOpsConfig.getDetailedInfoConfig },
   { name: 'advanced-search', config: advancedOpsConfig.advancedSearchConfig },

--- a/test/handlers/tool-configs/universal/core/merge-operations.test.ts
+++ b/test/handlers/tool-configs/universal/core/merge-operations.test.ts
@@ -173,6 +173,11 @@ describe('merge_records tool surface', () => {
     expect(mergeRecordsConfig.formatResult(result)).toContain(
       'Do not poll here'
     );
-    expect(mergeRecordsConfig.formatResult(result)).toContain('new_record_id');
+    expect(mergeRecordsConfig.formatResult(result)).toContain(
+      '33333333-3333-4333-8333-333333333333'
+    );
+    expect(mergeRecordsConfig.formatResult(result).trim().startsWith('{')).toBe(
+      false
+    );
   });
 });

--- a/test/handlers/tool-configs/universal/core/merge-operations.test.ts
+++ b/test/handlers/tool-configs/universal/core/merge-operations.test.ts
@@ -21,8 +21,6 @@ const LEFTOVER_ID = '22222222-2222-4222-8222-222222222222';
 
 const plan = {
   primary_record_id: PRIMARY_ID,
-  live_record_id: PRIMARY_ID,
-  secondary_record_id: LEFTOVER_ID,
   leftover_record_id: LEFTOVER_ID,
   fills: [],
   conflicts: [],

--- a/test/handlers/tool-configs/universal/core/merge-operations.test.ts
+++ b/test/handlers/tool-configs/universal/core/merge-operations.test.ts
@@ -110,8 +110,20 @@ describe('merge_records tool surface', () => {
     expect(executeDealMerge).not.toHaveBeenCalled();
   });
 
+  it('requires plan_fingerprint to execute so freshness cannot be skipped', async () => {
+    await expect(
+      mergeRecordsConfig.handler({
+        resource_type: 'deals',
+        record_id: PRIMARY_ID,
+        secondary_record_id: LEFTOVER_ID,
+        dry_run: false,
+        confirm: true,
+      })
+    ).rejects.toThrow('plan_fingerprint');
+    expect(executeDealMerge).not.toHaveBeenCalled();
+  });
+
   it('passes explicit execute choices through the dual gate', async () => {
-    loadDealMergePlan.mockResolvedValueOnce(plan);
     executeDealMerge.mockResolvedValueOnce({
       mode: 'complete',
       status: 200,
@@ -121,11 +133,6 @@ describe('merge_records tool surface', () => {
       plan,
     });
 
-    await mergeRecordsConfig.handler({
-      resource_type: 'deals',
-      record_id: PRIMARY_ID,
-      secondary_record_id: LEFTOVER_ID,
-    });
     const result = await mergeRecordsConfig.handler({
       resource_type: 'deals',
       record_id: PRIMARY_ID,
@@ -135,19 +142,18 @@ describe('merge_records tool surface', () => {
       keep_from_leftover: ['website'],
       skip_leftover_attributes: ['consent_to_contact'],
       override_linked_mismatch: true,
+      plan_fingerprint: plan.fingerprint,
     });
 
     expect(result).toMatchObject({ mode: 'complete', status: 200 });
-    expect(executeDealMerge).toHaveBeenCalledWith(
-      {
-        primary_record_id: PRIMARY_ID,
-        leftover_record_id: LEFTOVER_ID,
-        keep_from_leftover: ['website'],
-        skip_leftover_attributes: ['consent_to_contact'],
-        override_linked_mismatch: true,
-      },
-      plan
-    );
+    expect(executeDealMerge).toHaveBeenCalledWith({
+      primary_record_id: PRIMARY_ID,
+      leftover_record_id: LEFTOVER_ID,
+      keep_from_leftover: ['website'],
+      skip_leftover_attributes: ['consent_to_contact'],
+      override_linked_mismatch: true,
+      plan_fingerprint: plan.fingerprint,
+    });
   });
 
   it('marks the definition as statically destructive and avoids forbidden schema combinators', () => {

--- a/test/handlers/tool-configs/universal/core/merge-operations.test.ts
+++ b/test/handlers/tool-configs/universal/core/merge-operations.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DealMergePlan } from '@/services/merge/deal-merge-planner.js';
+
+const { executeDealMerge, loadDealMergePlan } = vi.hoisted(() => ({
+  executeDealMerge: vi.fn(),
+  loadDealMergePlan: vi.fn(),
+}));
+
+vi.mock('@/services/merge/deal-merge-executor.js', () => ({
+  executeDealMerge,
+  loadDealMergePlan,
+}));
+
+import {
+  mergeRecordsConfig,
+  mergeRecordsDefinition,
+} from '@/handlers/tool-configs/universal/core/merge-operations.js';
+
+const PRIMARY_ID = '11111111-1111-4111-8111-111111111111';
+const LEFTOVER_ID = '22222222-2222-4222-8222-222222222222';
+
+const plan = {
+  primary_record_id: PRIMARY_ID,
+  live_record_id: PRIMARY_ID,
+  secondary_record_id: LEFTOVER_ID,
+  leftover_record_id: LEFTOVER_ID,
+  fills: [],
+  conflicts: [],
+  dangerous_fills: [],
+  linked_mismatches: [],
+  requires_linked_mismatch_override: false,
+  flagged_attribute_slugs: [],
+  fingerprint: 'fingerprint',
+} as DealMergePlan;
+
+describe('merge_records tool surface', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('defaults to dry-run and does not invoke execute', async () => {
+    loadDealMergePlan.mockResolvedValueOnce(plan);
+
+    const result = await mergeRecordsConfig.handler({
+      resource_type: 'deals',
+      record_id: PRIMARY_ID,
+      secondary_record_id: LEFTOVER_ID,
+    });
+
+    expect(result).toMatchObject({ mode: 'dry_run', plan });
+    expect(loadDealMergePlan).toHaveBeenCalledWith(PRIMARY_ID, LEFTOVER_ID);
+    expect(executeDealMerge).not.toHaveBeenCalled();
+    expect(mergeRecordsConfig.formatResult(result)).toEqual(expect.any(String));
+  });
+
+  it('requires confirm true when dry_run is false', async () => {
+    await expect(
+      mergeRecordsConfig.handler({
+        resource_type: 'deals',
+        record_id: PRIMARY_ID,
+        secondary_record_id: LEFTOVER_ID,
+        dry_run: false,
+      })
+    ).rejects.toThrow('confirm');
+    expect(loadDealMergePlan).not.toHaveBeenCalled();
+    expect(executeDealMerge).not.toHaveBeenCalled();
+  });
+
+  it('rejects self-merge and malformed ids before loading records', async () => {
+    await expect(
+      mergeRecordsConfig.handler({
+        resource_type: 'deals',
+        record_id: 'not-a-uuid',
+        secondary_record_id: LEFTOVER_ID,
+      })
+    ).rejects.toThrow('valid UUID');
+
+    await expect(
+      mergeRecordsConfig.handler({
+        resource_type: 'deals',
+        record_id: PRIMARY_ID,
+        secondary_record_id: PRIMARY_ID,
+      })
+    ).rejects.toThrow('itself');
+    expect(loadDealMergePlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects type-mismatched flat arguments before loading records', async () => {
+    await expect(
+      mergeRecordsConfig.handler({
+        resource_type: 'deals',
+        record_id: PRIMARY_ID,
+        secondary_record_id: LEFTOVER_ID,
+        dry_run: 'false' as unknown as boolean,
+        confirm: true,
+      })
+    ).rejects.toThrow('dry_run must be a boolean');
+    expect(loadDealMergePlan).not.toHaveBeenCalled();
+  });
+
+  it('refuses people and companies without calling the merge service', async () => {
+    await expect(
+      mergeRecordsConfig.handler({
+        resource_type: 'companies',
+        record_id: PRIMARY_ID,
+        secondary_record_id: LEFTOVER_ID,
+      })
+    ).rejects.toThrow('deals only');
+    expect(loadDealMergePlan).not.toHaveBeenCalled();
+    expect(executeDealMerge).not.toHaveBeenCalled();
+  });
+
+  it('passes explicit execute choices through the dual gate', async () => {
+    loadDealMergePlan.mockResolvedValueOnce(plan);
+    executeDealMerge.mockResolvedValueOnce({
+      mode: 'complete',
+      status: 200,
+      new_record_id: '33333333-3333-4333-8333-333333333333',
+      original_record_ids: [PRIMARY_ID, LEFTOVER_ID],
+      warning: 'old ids are unreadable',
+      plan,
+    });
+
+    await mergeRecordsConfig.handler({
+      resource_type: 'deals',
+      record_id: PRIMARY_ID,
+      secondary_record_id: LEFTOVER_ID,
+    });
+    const result = await mergeRecordsConfig.handler({
+      resource_type: 'deals',
+      record_id: PRIMARY_ID,
+      secondary_record_id: LEFTOVER_ID,
+      dry_run: false,
+      confirm: true,
+      keep_from_leftover: ['website'],
+      skip_leftover_attributes: ['consent_to_contact'],
+      override_linked_mismatch: true,
+    });
+
+    expect(result).toMatchObject({ mode: 'complete', status: 200 });
+    expect(executeDealMerge).toHaveBeenCalledWith(
+      {
+        primary_record_id: PRIMARY_ID,
+        leftover_record_id: LEFTOVER_ID,
+        keep_from_leftover: ['website'],
+        skip_leftover_attributes: ['consent_to_contact'],
+        override_linked_mismatch: true,
+      },
+      plan
+    );
+  });
+
+  it('marks the definition as statically destructive and avoids forbidden schema combinators', () => {
+    expect(mergeRecordsDefinition.annotations).toMatchObject({
+      destructiveHint: true,
+    });
+    expect(mergeRecordsDefinition.inputSchema).not.toHaveProperty('oneOf');
+    expect(mergeRecordsDefinition.inputSchema).not.toHaveProperty('allOf');
+    expect(mergeRecordsDefinition.inputSchema).not.toHaveProperty('anyOf');
+  });
+
+  it('formats a 202 result as a wait response without polling', () => {
+    const result = {
+      mode: 'wait' as const,
+      status: 202 as const,
+      new_record_id: '33333333-3333-4333-8333-333333333333',
+      original_record_ids: [PRIMARY_ID, LEFTOVER_ID],
+      warning: 'old ids are unreadable',
+      message: 'Do not poll here',
+      plan,
+    };
+
+    expect(mergeRecordsConfig.formatResult(result)).toContain(
+      'Do not poll here'
+    );
+    expect(mergeRecordsConfig.formatResult(result)).toContain('new_record_id');
+  });
+});

--- a/test/handlers/tool-configs/universal/core/record-details-merge-wait.test.ts
+++ b/test/handlers/tool-configs/universal/core/record-details-merge-wait.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { handleUniversalGetDetails, handleSearchError } = vi.hoisted(() => ({
+  handleUniversalGetDetails: vi.fn(),
+  handleSearchError: vi.fn(),
+}));
+
+vi.mock('@/handlers/tool-configs/universal/shared-handlers.js', () => ({
+  handleUniversalGetDetails,
+}));
+vi.mock('@/handlers/tool-configs/universal/core/error-utils.js', () => ({
+  handleSearchError,
+}));
+
+import { getRecordDetailsConfig } from '@/handlers/tool-configs/universal/core/record-details-operations.js';
+
+const RECORD_ID = '33333333-3333-4333-8333-333333333333';
+
+describe('get_record_details merge wait state', () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it('treats Attio merge_in_progress 404 as wait-not-missing', async () => {
+    handleUniversalGetDetails.mockRejectedValueOnce({
+      response: { status: 404, data: { code: 'merge_in_progress' } },
+    });
+
+    const result = await getRecordDetailsConfig.handler({
+      resource_type: 'deals',
+      record_id: RECORD_ID,
+    });
+
+    expect(result).toMatchObject({
+      id: { record_id: RECORD_ID },
+      merge_in_progress: true,
+    });
+    expect(getRecordDetailsConfig.formatResult(result)).toContain(
+      'not missing'
+    );
+    expect(handleSearchError).not.toHaveBeenCalled();
+  });
+});

--- a/test/handlers/tool-configs/universal/tool-name-consistency.test.ts
+++ b/test/handlers/tool-configs/universal/tool-name-consistency.test.ts
@@ -93,6 +93,7 @@ describe('Tool Name Consistency Validation', () => {
         'create',
         'update',
         'delete',
+        'merge',
         'batch',
         'discover',
         'list',

--- a/test/services/merge/deal-merge-executor.test.ts
+++ b/test/services/merge/deal-merge-executor.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AttioRecord } from '@/types/attio.js';
+
+const { getRecord, mergeRecords, overwriteRecordAttributes } = vi.hoisted(
+  () => ({
+    getRecord: vi.fn(),
+    mergeRecords: vi.fn(),
+    overwriteRecordAttributes: vi.fn(),
+  })
+);
+const { updateRecordWithValidation } = vi.hoisted(() => ({
+  updateRecordWithValidation: vi.fn(),
+}));
+
+vi.mock('@/api/operations/index.js', () => ({
+  getRecord,
+  mergeRecords,
+  overwriteRecordAttributes,
+}));
+vi.mock('@/services/UniversalUpdateService.js', () => ({
+  UniversalUpdateService: { updateRecordWithValidation },
+}));
+
+import {
+  executeDealMerge,
+  loadDealMergePlan,
+} from '@/services/merge/deal-merge-executor.js';
+
+const PRIMARY_ID = '11111111-1111-4111-8111-111111111111';
+const LEFTOVER_ID = '22222222-2222-4222-8222-222222222222';
+const NEW_ID = '33333333-3333-4333-8333-333333333333';
+
+function deal(recordId: string, values: Record<string, unknown>): AttioRecord {
+  return { id: { record_id: recordId }, values };
+}
+
+function arrangeDeals(
+  primaryValues: Record<string, unknown> = {},
+  includeConsent = true
+) {
+  const secondaryValues: Record<string, unknown> = {
+    website: [{ value: 'https://example.com' }],
+  };
+  if (includeConsent) {
+    secondaryValues.consent_to_contact = [{ value: false }];
+  }
+  getRecord
+    .mockResolvedValueOnce(deal(PRIMARY_ID, { website: [], ...primaryValues }))
+    .mockResolvedValueOnce(deal(LEFTOVER_ID, secondaryValues));
+}
+
+describe('deal merge executor', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('patches keeps, clears skips with PUT, then merges once', async () => {
+    arrangeDeals();
+    updateRecordWithValidation.mockResolvedValueOnce({ record: {} });
+    overwriteRecordAttributes.mockResolvedValueOnce({ status: 200, data: {} });
+    mergeRecords.mockResolvedValueOnce({
+      status: 200,
+      new_record_id: NEW_ID,
+      data: { id: { record_id: NEW_ID } },
+    });
+
+    const result = await executeDealMerge({
+      primary_record_id: PRIMARY_ID,
+      leftover_record_id: LEFTOVER_ID,
+      keep_from_leftover: ['website'],
+      skip_leftover_attributes: ['consent_to_contact'],
+    });
+
+    expect(updateRecordWithValidation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource_type: 'deals',
+        record_id: PRIMARY_ID,
+        record_data: {
+          values: { website: [{ value: 'https://example.com' }] },
+        },
+      })
+    );
+    expect(overwriteRecordAttributes).toHaveBeenCalledWith(
+      'deals',
+      LEFTOVER_ID,
+      { consent_to_contact: [] }
+    );
+    expect(mergeRecords).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      mode: 'complete',
+      status: 200,
+      new_record_id: NEW_ID,
+    });
+  });
+
+  it('returns a 202 wait state and does not poll', async () => {
+    arrangeDeals({}, false);
+    mergeRecords.mockResolvedValueOnce({
+      status: 202,
+      new_record_id: NEW_ID,
+      data: { new_record_id: NEW_ID },
+    });
+
+    const result = await executeDealMerge({
+      primary_record_id: PRIMARY_ID,
+      leftover_record_id: LEFTOVER_ID,
+      keep_from_leftover: [],
+      skip_leftover_attributes: [],
+    });
+
+    expect(result).toMatchObject({
+      mode: 'wait',
+      status: 202,
+      new_record_id: NEW_ID,
+    });
+    expect(getRecord).toHaveBeenCalledTimes(2);
+    expect(mergeRecords).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports that leftover data was already cleared and does not retry merge', async () => {
+    arrangeDeals();
+    overwriteRecordAttributes.mockResolvedValueOnce({ status: 200, data: {} });
+    mergeRecords.mockRejectedValueOnce({ response: { status: 500 } });
+
+    await expect(
+      executeDealMerge({
+        primary_record_id: PRIMARY_ID,
+        leftover_record_id: LEFTOVER_ID,
+        keep_from_leftover: [],
+        skip_leftover_attributes: ['consent_to_contact'],
+      })
+    ).rejects.toThrow('already cleared');
+    expect(mergeRecords).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a stale expected plan before any patch, clear, or merge', async () => {
+    arrangeDeals();
+    const expectedPlan = await loadDealMergePlan(PRIMARY_ID, LEFTOVER_ID);
+    vi.clearAllMocks();
+    arrangeDeals();
+    getRecord.mockReset();
+    getRecord
+      .mockResolvedValueOnce(deal(PRIMARY_ID, { website: [] }))
+      .mockResolvedValueOnce(
+        deal(LEFTOVER_ID, {
+          website: [{ value: 'https://changed.example' }],
+          consent_to_contact: [{ value: false }],
+        })
+      );
+
+    await expect(
+      executeDealMerge(
+        {
+          primary_record_id: PRIMARY_ID,
+          leftover_record_id: LEFTOVER_ID,
+          keep_from_leftover: [],
+          skip_leftover_attributes: ['consent_to_contact'],
+        },
+        expectedPlan
+      )
+    ).rejects.toThrow('changed');
+    expect(updateRecordWithValidation).not.toHaveBeenCalled();
+    expect(overwriteRecordAttributes).not.toHaveBeenCalled();
+    expect(mergeRecords).not.toHaveBeenCalled();
+  });
+});

--- a/test/services/merge/deal-merge-executor.test.ts
+++ b/test/services/merge/deal-merge-executor.test.ts
@@ -21,10 +21,8 @@ vi.mock('@/services/UniversalUpdateService.js', () => ({
   UniversalUpdateService: { updateRecordWithValidation },
 }));
 
-import {
-  executeDealMerge,
-  loadDealMergePlan,
-} from '@/services/merge/deal-merge-executor.js';
+import { buildDealMergePlan } from '@/services/merge/deal-merge-planner.js';
+import { executeDealMerge } from '@/services/merge/deal-merge-executor.js';
 
 const PRIMARY_ID = '11111111-1111-4111-8111-111111111111';
 const LEFTOVER_ID = '22222222-2222-4222-8222-222222222222';
@@ -32,6 +30,22 @@ const NEW_ID = '33333333-3333-4333-8333-333333333333';
 
 function deal(recordId: string, values: Record<string, unknown>): AttioRecord {
   return { id: { record_id: recordId }, values };
+}
+
+function fingerprintFor(
+  primaryValues: Record<string, unknown> = {},
+  includeConsent = true
+): string {
+  const secondaryValues: Record<string, unknown> = {
+    website: [{ value: 'https://example.com' }],
+  };
+  if (includeConsent) {
+    secondaryValues.consent_to_contact = [{ value: false }];
+  }
+  return buildDealMergePlan(
+    deal(PRIMARY_ID, { website: [], ...primaryValues }),
+    deal(LEFTOVER_ID, secondaryValues)
+  ).fingerprint;
 }
 
 function arrangeDeals(
@@ -69,6 +83,7 @@ describe('deal merge executor', () => {
       leftover_record_id: LEFTOVER_ID,
       keep_from_leftover: ['website'],
       skip_leftover_attributes: ['consent_to_contact'],
+      plan_fingerprint: fingerprintFor(),
     });
 
     expect(updateRecordWithValidation).toHaveBeenCalledWith(
@@ -106,6 +121,7 @@ describe('deal merge executor', () => {
       leftover_record_id: LEFTOVER_ID,
       keep_from_leftover: [],
       skip_leftover_attributes: [],
+      plan_fingerprint: fingerprintFor({}, false),
     });
 
     expect(result).toMatchObject({
@@ -128,17 +144,13 @@ describe('deal merge executor', () => {
         leftover_record_id: LEFTOVER_ID,
         keep_from_leftover: [],
         skip_leftover_attributes: ['consent_to_contact'],
+        plan_fingerprint: fingerprintFor(),
       })
     ).rejects.toThrow('already cleared');
     expect(mergeRecords).toHaveBeenCalledTimes(1);
   });
 
   it('refuses a stale expected plan before any patch, clear, or merge', async () => {
-    arrangeDeals();
-    const expectedPlan = await loadDealMergePlan(PRIMARY_ID, LEFTOVER_ID);
-    vi.clearAllMocks();
-    arrangeDeals();
-    getRecord.mockReset();
     getRecord
       .mockResolvedValueOnce(deal(PRIMARY_ID, { website: [] }))
       .mockResolvedValueOnce(
@@ -149,15 +161,13 @@ describe('deal merge executor', () => {
       );
 
     await expect(
-      executeDealMerge(
-        {
-          primary_record_id: PRIMARY_ID,
-          leftover_record_id: LEFTOVER_ID,
-          keep_from_leftover: [],
-          skip_leftover_attributes: ['consent_to_contact'],
-        },
-        expectedPlan
-      )
+      executeDealMerge({
+        primary_record_id: PRIMARY_ID,
+        leftover_record_id: LEFTOVER_ID,
+        keep_from_leftover: [],
+        skip_leftover_attributes: ['consent_to_contact'],
+        plan_fingerprint: fingerprintFor(),
+      })
     ).rejects.toThrow('changed');
     expect(updateRecordWithValidation).not.toHaveBeenCalled();
     expect(overwriteRecordAttributes).not.toHaveBeenCalled();

--- a/test/services/merge/deal-merge-planner.test.ts
+++ b/test/services/merge/deal-merge-planner.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { AttioRecord } from '@/types/attio.js';
+import {
+  assertDealMergePlanFresh,
+  buildDealMergePlan,
+  validateDealMergeChoices,
+} from '@/services/merge/deal-merge-planner.js';
+
+const PRIMARY_ID = '11111111-1111-4111-8111-111111111111';
+const LEFTOVER_ID = '22222222-2222-4222-8222-222222222222';
+
+function deal(recordId: string, values: Record<string, unknown>): AttioRecord {
+  return { id: { record_id: recordId }, values };
+}
+
+describe('deal merge planner', () => {
+  it('rejects invalid and self-merge record identities', () => {
+    expect(() =>
+      buildDealMergePlan(deal('not-a-uuid', {}), deal(LEFTOVER_ID, {}))
+    ).toThrow('valid UUID');
+
+    expect(() =>
+      buildDealMergePlan(deal(PRIMARY_ID, {}), deal(PRIMARY_ID, {}))
+    ).toThrow('cannot be merged with itself');
+  });
+
+  it('accepts two empty deals as an empty, side-effect-free plan', () => {
+    const plan = buildDealMergePlan(
+      deal(PRIMARY_ID, {}),
+      deal(LEFTOVER_ID, {})
+    );
+
+    expect(plan.flagged_attribute_slugs).toEqual([]);
+    expect(plan.fills).toEqual([]);
+    expect(plan.conflicts).toEqual([]);
+  });
+
+  it('proposes leftover-only snapshot fields while keeping live sales fields', () => {
+    const plan = buildDealMergePlan(
+      deal(PRIMARY_ID, {
+        name: [{ value: 'Won deal' }],
+        stage: [{ status: 'won-status' }],
+        website: [],
+      }),
+      deal(LEFTOVER_ID, {
+        name: [{ value: 'Form submission' }],
+        stage: [{ status: 'demo-status' }],
+        website: [{ value: 'https://example.com' }],
+        utm_campaign: [{ value: 'spring' }],
+      })
+    );
+
+    expect(plan.fills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ attribute: 'website', kind: 'fill' }),
+        expect.objectContaining({ attribute: 'utm_campaign', kind: 'fill' }),
+      ])
+    );
+    expect(plan.dangerous_fills).toEqual([]);
+    expect(plan.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ attribute: 'stage', kind: 'conflict' }),
+      ])
+    );
+  });
+
+  it('flags timestamp conflicts and dangerous empty-primary fills', () => {
+    const plan = buildDealMergePlan(
+      deal(PRIMARY_ID, {
+        demo_request_at: [{ value: '2026-08-01T10:00:00Z' }],
+        consent_to_contact: [],
+        owner: [],
+        value: [],
+      }),
+      deal(LEFTOVER_ID, {
+        demo_request_at: [{ value: '2026-08-02T10:00:00Z' }],
+        consent_to_contact: [{ value: false }],
+        owner: [{ referenced_actor_id: 'member-id' }],
+        value: [{ currency_value: '1000', currency_code: 'USD' }],
+      })
+    );
+
+    expect(plan.conflicts).toEqual([
+      expect.objectContaining({ attribute: 'demo_request_at' }),
+    ]);
+    expect(plan.dangerous_fills.map((fill) => fill.attribute)).toEqual(
+      expect.arrayContaining(['consent_to_contact', 'owner', 'value'])
+    );
+    expect(() => validateDealMergeChoices(plan, [], [])).toThrow(
+      'explicit keep or skip'
+    );
+  });
+
+  it('blocks differing linked records unless override is enabled', () => {
+    const plan = buildDealMergePlan(
+      deal(PRIMARY_ID, {
+        associated_company: [
+          { target_object: 'companies', target_record_id: 'company-a' },
+        ],
+      }),
+      deal(LEFTOVER_ID, {
+        associated_company: [
+          { target_object: 'companies', target_record_id: 'company-b' },
+        ],
+      })
+    );
+
+    expect(plan.linked_mismatches).toEqual([
+      expect.objectContaining({ attribute: 'associated_company' }),
+    ]);
+    expect(plan.requires_linked_mismatch_override).toBe(true);
+    expect(() => validateDealMergeChoices(plan, [], [])).toThrow(
+      'override_linked_mismatch'
+    );
+    expect(() =>
+      validateDealMergeChoices(plan, [], [], { override_linked_mismatch: true })
+    ).not.toThrow();
+  });
+
+  it('rejects execute when a flagged field changed after the dry-run', () => {
+    const originalPlan = buildDealMergePlan(
+      deal(PRIMARY_ID, { website: [] }),
+      deal(LEFTOVER_ID, { website: [{ value: 'https://before.example' }] })
+    );
+    const changedPlan = buildDealMergePlan(
+      deal(PRIMARY_ID, { website: [] }),
+      deal(LEFTOVER_ID, { website: [{ value: 'https://after.example' }] })
+    );
+
+    expect(() => assertDealMergePlanFresh(originalPlan, changedPlan)).toThrow(
+      'changed'
+    );
+  });
+});


### PR DESCRIPTION
## What

- Add universal `merge_records`, gated to deals, wrapping Attio native `POST /v2/objects/{object}/records/merge`.
- Dry-run defaults to true and returns a leftover-versus-live field plan (fills, both-set conflicts, dangerous empty-primary fills).
- Execute requires `confirm: true` in addition to `dry_run: false`; patches keep slugs onto the primary, PUT-clears skipped leftover attributes, then merges once.
- 429-only merge retry; 202 is a wait state (no in-tool poll). `get_record_details` treats merge-in-progress 404 as wait-not-missing.
- People and companies are refused until later coverage on the same tool.

## Why

Leftover Demo Request deals sit beside booked/Won siblings. Deleting the leftover drops the form snapshot; copying blindly can clobber stage/owner/value or stamp `consent_to_contact=false`. Attio's UI still cannot merge deals. Native merge already accepts deals in this workspace (live smoke: HTTP 200 + new record id).

Closes #1264.

## Tests

```sh
bun run typecheck
bun run lint:src
bun run test -- test/services/merge test/api/operations test/handlers/tool-configs/universal/core
bun run test:single test/handlers/tool-configs/universal/tool-name-consistency.test.ts
bun run test:mcp -- test/e2e/mcp/deal-operations/merge-records.mcp.test.ts
```

Pre-push `test:offline`: 3575 passed. Live smoke (throwaway deals): PUT-clear of record-references and `consent_to_contact`, native merge 200 with new id, survivor cleanup 200. MCP e2e: 2 passed.

## AI Assistance

- Used: yes. Product contract via `/ce-brainstorm`; plan via `/ce-plan`; implementation delegated to Codex (`gpt-5.6-luna`, `xhigh`) via `/ce-work-beta`.
- Testing: unit + MCP e2e + live smoke against Attio; orchestrator reviewed merge retry, dual execute gate, and PUT-clear failure path.
- I understand this code.

## Post-Deploy Monitoring & Validation

- Watch MCP tool errors for `merge_records` (self_merge, leftover-already-cleared, linked mismatch blocks).
- Confirm dry-run remains the default in client traces (`dry_run` omitted or true) and that execute calls include `confirm: true`.
- Failure signal: 5xx/timeout after leftover PUT-clear without a new record id — do not auto-retry merge (non-idempotent). Roll back by pausing use of the tool and inspecting the leftover deal.
- Validation window: first real leftover/Won pair after deploy, then a 202 wait follow-up via `get_record_details`.

Made with [Cursor](https://cursor.com)