### PR TITLE
Chore: prepare v1.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-25
+
+**TL;DR for Users**: Safe deals-only `merge_records`, Cloudflare remote MCP sessions that no longer drop after an hour, and tenant/OAuth security hardening.
+
 ### Added
 
-- **`merge_records` universal tool** — dry-runs a deals-only leftover-versus-live field plan, then requires explicit confirmation before patching, clearing, and native-merging into a new survivor record (#1264)
+- **`merge_records` universal tool** — dry-runs a deals-only leftover-versus-live field plan, then requires explicit confirmation and the dry-run fingerprint before patching, clearing, and native-merging into a new survivor record (#1264)
 
 ### Fixed
 
 - **Date-parser relative ranges are host-timezone stable** — `parseRelativeDate` now uses UTC calendar helpers (aligned with `timeframe-utils`), so week/month fixtures no longer flip under Asia/Tokyo and similar offsets (#1253)
-- **Cloudflare Worker remote MCP: connector dropped to `401` ~1 hour after connecting** (`examples/cloudflare-mcp-server`). The worker stored each KV session→token mapping with a 1-hour expiry derived from `expires_in || 3600`, but Attio's OAuth tokens are long-lived and return no `expires_in`, so sessions self-expired ~1h after connect. The worker then forwarded the orphaned session token to Attio and every `/mcp` call failed. Sessions now use a 30-day lifetime when Attio omits `expires_in`, and an unresolved session token returns `401`/re-authenticate instead of being forwarded to Attio (which also closes a per-caller-auth bypass on the miss path)
+- **Cloudflare Worker remote MCP: connector dropped to `401` ~1 hour after connecting** (`examples/cloudflare-mcp-server`). Sessions now use a 30-day lifetime when Attio omits `expires_in`, and an unresolved session token returns `401`/re-authenticate instead of being forwarded to Attio (#1241)
+
+### Security
+
+- Isolate Attio client, search, task, and note caches per request/tenant so credentials and results cannot leak across sessions (#403)
+- Block list mutations through generic CRUD, require `note_id` validation on note write/delete, restore batch operation safety limits, and mark `manage-list-entry` as a write tool
+- Stop forwarding unresolved Cloudflare session tokens and isolate Worker tool auth per request; validate OAuth callback state and escape user-controlled callback HTML (#1241, #1243)
+- Sanitize create/API error logging so raw Axios payloads are not serialized into client responses
+- Harden GitHub Actions, Claude, and publish workflows against untrusted PR/issue context and over-scoped credentials
 
 ## [2026-06-16] - Daily Update
 
@@ -971,7 +983,8 @@ Users upgrading from v0.1.x should note:
 - Troubleshooting guides
 - Development and contribution guidelines
 
-[Unreleased]: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/kesslerio/attio-mcp-server/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/kesslerio/attio-mcp-server/compare/v1.4.1...v1.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attio-mcp",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "AI-powered access to Attio CRM. Manage contacts, companies, deals, tasks, and notes. Search records, update pipelines, and automate workflows for sales and GTM teams.",
   "mcpName": "io.github.kesslerio/attio-mcp-server",
   "main": "dist/smithery.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/kesslerio/attio-mcp-server",
     "source": "github"
   },
-  "version": "1.6.1",
+  "version": "1.7.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "attio-mcp",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/test/scripts/release-notes.test.ts
+++ b/test/scripts/release-notes.test.ts
@@ -17,21 +17,17 @@ describe('release notes builder', () => {
   );
 
   it('builds user-facing notes from the current changelog version', () => {
-    const releaseNotes = buildReleaseNotes(
-      changelogContent,
-      packageJson.version
-    );
+    const version = packageJson.version as string;
+    const releaseNotes = buildReleaseNotes(changelogContent, version);
 
-    expect(releaseNotes).toContain('list configuration tools');
+    expect(releaseNotes.split('\n')[0]?.length).toBeGreaterThan(20);
     expect(releaseNotes).toContain("## What's New");
-    expect(releaseNotes).toContain('### Added');
-    expect(releaseNotes).toContain('### Changed');
-    expect(releaseNotes).toContain('create-list');
-    expect(releaseNotes).toContain('npm provenance');
+    expect(releaseNotes).toMatch(/^### (Added|Changed|Fixed|Security)/m);
     expect(releaseNotes).toContain('npm install -g attio-mcp');
     expect(releaseNotes).toContain('npm update -g attio-mcp');
     expect(releaseNotes).toContain(
-      '**Full Changelog**: https://github.com/kesslerio/attio-mcp-server/compare/v1.6.0...v1.6.1'
+      `**Full Changelog**: https://github.com/kesslerio/attio-mcp-server/compare/`
     );
+    expect(releaseNotes).toContain(`...v${version}`);
   });
 });


### PR DESCRIPTION
## What
- Bump `attio-mcp` to **1.7.0** in `package.json` and `server.json`
- Move `[Unreleased]` notes into `[1.7.0]` with a user-facing TL;DR, Added/Fixed/Security sections, and compare links
- Make the release-notes builder test version-agnostic so it tracks the current changelog instead of 1.6.1 copy

## Why
Ship the deals-only `merge_records` tool plus post-1.6.1 session and security fixes as a minor release. Main is protected, so the version bump lands via PR before the `v1.7.0` tag (which triggers GitHub Release + npm trusted publish).

## Tests
- `node scripts/release-notes.cjs v1.7.0 --validate`
- `bun run build`
- `npm pack --dry-run` (package `attio-mcp@1.7.0`)
- `bun run check`
- `bun run test:offline` (3606 passed)
- `bun run test:single test/scripts/release-notes.test.ts`

## AI Assistance
- Used: Cursor agent for changelog curation, version bump, build, and PR
- Testing: offline suite + release-notes validation + npm pack dry-run
- I understand this code.


Made with [Cursor](https://cursor.com)