### PR TITLE
Fix: Preserve angle brackets in deal stage values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deal stage titles with `>` are preserved** — `InputSanitizer` no longer strips standalone angle brackets, so values like `Not Qualified (MQL > SQL)` reach Attio byte-for-byte, and an explicit update with an invalid stage now returns an error instead of silently falling back to `ATTIO_DEFAULT_DEAL_STAGE` (#1277)
+
 ## [1.7.0] - 2026-08-25
 
 **TL;DR for Users**: Safe deals-only `merge_records`, Cloudflare remote MCP sessions that no longer drop after an hour, and tenant/OAuth security hardening.

--- a/src/config/deal-defaults.ts
+++ b/src/config/deal-defaults.ts
@@ -493,7 +493,8 @@ function getStageSuggestions(
  */
 export async function validateDealStage(
   stage: string | undefined,
-  skipApiCall: boolean = false
+  skipApiCall: boolean = false,
+  isUpdate: boolean = false
 ): Promise<DealStageValidationResult> {
   if (!stage) {
     return {
@@ -572,6 +573,25 @@ export async function validateDealStage(
       ],
     };
 
+    // Issue #1277: An explicit update must never silently substitute
+    // ATTIO_DEFAULT_DEAL_STAGE when stage resolution fails. Defaulting is a
+    // create-time behavior; on update, surface the failure as an explicit error.
+    if (isUpdate) {
+      const { UniversalValidationError, ErrorType } =
+        await import('../handlers/tool-configs/universal/schemas.js');
+      throw new UniversalValidationError(
+        `Deal stage "${stage}" not found. Available stages: ${availableStagesText}`,
+        ErrorType.USER_ERROR,
+        {
+          field: 'stage',
+          suggestion:
+            stageSuggestions.length > 0
+              ? `Did you mean "${stageSuggestions[0]}"? Available stages: ${availableStagesText}`
+              : `Use one of the available stages: ${availableStagesText}`,
+        }
+      );
+    }
+
     // If strict validation is enabled, throw an error instead of silent fallback
     // WARNING: This environment variable changes runtime behavior
     // Production Impact: Previously working deals may start failing
@@ -597,6 +617,11 @@ export async function validateDealStage(
     return result;
   } catch (err: unknown) {
     error('deal-defaults', 'Stage validation failed', err);
+    // Issue #1277: On update, a stage resolution failure must surface as an
+    // explicit error, not be swallowed into a silent fallback.
+    if (isUpdate) {
+      throw err;
+    }
     return {
       validatedStage: stage, // Return original stage if validation fails
       warnings: [
@@ -661,9 +686,11 @@ export async function applyDealDefaultsWithValidation(
     dealData.stage[0]?.status
   ) {
     // Pass skipValidation flag to validateDealStage to control API calls
+    // Pass isUpdate so update-path failures throw instead of silent fallback (#1277)
     const stageValidation = await validateDealStage(
       dealData.stage[0].status,
-      skipValidation // Skip API calls when in error paths
+      skipValidation, // Skip API calls when in error paths
+      options?.isUpdate ?? false
     );
 
     if (stageValidation.validatedStage) {

--- a/src/config/deal-defaults.ts
+++ b/src/config/deal-defaults.ts
@@ -49,6 +49,7 @@
 
 import { warn, error } from '../utils/logger.js';
 import { isValidUUID } from '@/utils/validation/uuid-validation.js';
+import { UniversalValidationError } from '@/handlers/tool-configs/universal/errors/validation-errors.js';
 
 export interface DealDefaults {
   stage?: string;
@@ -618,8 +619,11 @@ export async function validateDealStage(
   } catch (err: unknown) {
     error('deal-defaults', 'Stage validation failed', err);
     // Issue #1277: On update, a stage resolution failure must surface as an
-    // explicit error, not be swallowed into a silent fallback.
-    if (isUpdate) {
+    // explicit error, not be swallowed into a silent fallback. Only re-throw
+    // the deliberate UniversalValidationError (invalid stage); keep the
+    // graceful fallback for genuine API/network failures so a transient Attio
+    // outage does not turn into a thrown error.
+    if (isUpdate && err instanceof UniversalValidationError) {
       throw err;
     }
     return {

--- a/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
+++ b/src/handlers/tool-configs/universal/core/crud-error-handlers.ts
@@ -35,6 +35,7 @@ import {
   type CrudErrorContext,
   type ErrorEnhancer,
 } from './error-enhancers/index.js';
+import { UniversalValidationError } from '@/handlers/tool-configs/universal/errors/validation-errors.js';
 
 /**
  * Create enhanced error result for CRUD operations
@@ -328,6 +329,20 @@ export const handleUpdateError = async (
       )}`;
     }
 
+    const errorResult = createErrorResult(errorMessage, 'validation_error', {
+      context,
+    });
+    throw errorResult;
+  }
+
+  // Issue #1277: Surface deliberate UniversalValidationError (invalid stage /
+  // invalid value) with its own message and suggestion, not as a generic
+  // "Record not found" or "update failed" error.
+  if (error instanceof UniversalValidationError) {
+    let errorMessage = error.message;
+    if (error.suggestion) {
+      errorMessage += `\n\n${error.suggestion}`;
+    }
     const errorResult = createErrorResult(errorMessage, 'validation_error', {
       context,
     });

--- a/src/handlers/tool-configs/universal/core/crud-operations.ts
+++ b/src/handlers/tool-configs/universal/core/crud-operations.ts
@@ -13,6 +13,10 @@ import {
   validateUniversalToolParams,
 } from '@/handlers/tool-configs/universal/schemas.js';
 import {
+  UniversalValidationError,
+  ErrorType,
+} from '@/handlers/tool-configs/universal/errors/validation-errors.js';
+import {
   handleUniversalCreate,
   handleUniversalUpdate,
   handleUniversalDelete,
@@ -191,7 +195,18 @@ export const updateRecordConfig: UniversalToolConfig<
               actualValues: enhancedResult.validation.actualValues,
             },
           };
-        } catch {
+        } catch (error: unknown) {
+          // Issue #1277: An explicit update with an invalid stage must surface
+          // the error to the user, not be downgraded to a silent fallback to
+          // handleUniversalUpdate (which would send the unvalidated stage to
+          // Attio). Re-throw deliberate user errors; only genuine API/network
+          // failures degrade to the standard update path.
+          if (
+            error instanceof UniversalValidationError &&
+            error.errorType === ErrorType.USER_ERROR
+          ) {
+            throw error;
+          }
           const standardResult = await handleUniversalUpdate(sanitizedParams);
           result = { ...standardResult };
         }

--- a/src/handlers/tool-configs/universal/validators/schema-validator.ts
+++ b/src/handlers/tool-configs/universal/validators/schema-validator.ts
@@ -41,8 +41,10 @@ export class InputSanitizer {
     s = s.replace(/on\w+\s*=\s*([^>\s]*)/gi, '$1');
     // Remove HTML tags
     s = s.replace(/<\/?[^>]+>/g, '');
-    // Final safety: remove any remaining angle brackets to prevent partial tags
-    s = s.replace(/[<>]/g, '');
+    // NOTE: Do NOT strip standalone angle brackets here. The HTML tag regex
+    // above already removes complete tags, and the script regex handles
+    // <script> tags. Stripping [<>] unconditionally corrupts legitimate data
+    // such as "MQL > SQL" (Issue #1277). Standalone < / > are inert HTML.
     return s;
   }
 

--- a/src/services/UniversalUpdateService.ts
+++ b/src/services/UniversalUpdateService.ts
@@ -369,6 +369,16 @@ export class UniversalUpdateService {
           suggestions: dealValidation.suggestions,
         });
       } catch (error: unknown) {
+        // Issue #1277: An explicit update with an invalid stage must surface
+        // the error to the user, not be downgraded to a warning. Re-throw
+        // deliberate user errors (invalid stage) so the update fails loudly;
+        // only genuine API/network failures degrade to a warning.
+        if (
+          error instanceof UniversalValidationError &&
+          error.errorType === ErrorType.USER_ERROR
+        ) {
+          throw error;
+        }
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         validationResult.warnings.push(

--- a/test/config/deal-defaults.test.ts
+++ b/test/config/deal-defaults.test.ts
@@ -104,6 +104,20 @@ describe('Deal Defaults - PR #389 Fix', () => {
       expect(result.dealData.name).toEqual([{ value: 'Test Deal' }]);
       expect(result.dealData.stage).toEqual([{ status: 'MQL' }]);
     });
+
+    it('should throw instead of falling back to default stage on update', async () => {
+      // Issue #1277: an explicit update must never silently substitute
+      // ATTIO_DEFAULT_DEAL_STAGE when stage resolution fails.
+      const dealData = {
+        name: 'Test Deal',
+        stage: 'Not Qualified (MQL > SQL)', // Valid stage title with ">" (not in mock)
+        value: 1000,
+      };
+
+      await expect(
+        applyDealDefaultsWithValidation(dealData, false, { isUpdate: true })
+      ).rejects.toThrow(/Deal stage "Not Qualified \(MQL > SQL\)" not found/);
+    });
   });
 
   describe('validateDealStage', () => {

--- a/test/services/UniversalUpdateService-validation.test.ts
+++ b/test/services/UniversalUpdateService-validation.test.ts
@@ -80,6 +80,10 @@ vi.mock('@/objects/records/index.js', () => ({
     values: {},
   })),
 }));
+vi.mock('@/config/deal-defaults.js', () => ({
+  applyDealDefaultsWithValidation: vi.fn(),
+}));
+import { applyDealDefaultsWithValidation } from '@/config/deal-defaults.js';
 import { UniversalUpdateService } from '@services/UniversalUpdateService.js';
 import { UniversalResourceType } from '@handlers/tool-configs/universal/types.js';
 import {
@@ -475,6 +479,49 @@ describe('UniversalUpdateService', () => {
       });
       expect(result).toBeDefined();
       expect(result.id).toMatchObject({ record_id: 'comp_123' });
+    });
+  });
+
+  describe('Deal stage validation (Issue #1277)', () => {
+    it('should re-throw UniversalValidationError on update with invalid stage', async () => {
+      // Issue #1277: an explicit update with an invalid stage must surface the
+      // error to the user, not be downgraded to a warning and sent to Attio.
+      const { UniversalValidationError, ErrorType } =
+        await import('@/handlers/tool-configs/universal/errors/validation-errors.js');
+      const stageError = new UniversalValidationError(
+        'Deal stage "Not Qualified (MQL > SQL)" not found',
+        ErrorType.USER_ERROR,
+        { field: 'stage' }
+      );
+      vi.mocked(applyDealDefaultsWithValidation).mockRejectedValue(stageError);
+
+      await expect(
+        UniversalUpdateService.updateRecordWithValidation({
+          resource_type: UniversalResourceType.DEALS,
+          record_id: 'deal_123',
+          record_data: { stage: 'Not Qualified (MQL > SQL)' },
+        })
+      ).rejects.toThrow(stageError);
+    });
+
+    it('should downgrade genuine API failures to warnings, not throw', async () => {
+      // A transient Attio API failure should NOT turn into a thrown error on
+      // update; it should degrade to a warning (graceful fallback).
+      const apiError = new Error('Failed to fetch deal stages from API');
+      vi.mocked(applyDealDefaultsWithValidation).mockRejectedValue(apiError);
+
+      const { updateObjectRecord } = await import('@/objects/records/index.js');
+      vi.mocked(updateObjectRecord).mockResolvedValue({
+        id: { record_id: 'deal_123' },
+        values: {},
+      } as any);
+
+      const result = await UniversalUpdateService.updateRecordWithValidation({
+        resource_type: UniversalResourceType.DEALS,
+        record_id: 'deal_123',
+        record_data: { stage: 'Not Qualified (MQL > SQL)' },
+      });
+      expect(result).toBeDefined();
     });
   });
 });

--- a/test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts
+++ b/test/unit/handlers/tool-configs/universal/validators/schema-validator.test.ts
@@ -36,6 +36,21 @@ describe('InputSanitizer', () => {
       expect(result).toBe('alert("xss")safe');
       expect(result).not.toContain('<script>');
     });
+
+    it('should preserve legitimate angle brackets in data values', () => {
+      // Issue #1277: ">" in a deal stage title must survive sanitization
+      const input = 'Not Qualified (MQL > SQL)';
+      const result = InputSanitizer.sanitizeString(input);
+      expect(result).toBe('Not Qualified (MQL > SQL)');
+      expect(result).toContain('>');
+    });
+
+    it('should preserve legitimate angle brackets in single-line values', () => {
+      const input = 'Route: Not Qualified (MQL > SQL). Reason: x';
+      const result = InputSanitizer.sanitizeString(input);
+      expect(result).toBe('Route: Not Qualified (MQL > SQL). Reason: x');
+      expect(result).toContain('>');
+    });
   });
 
   describe('sanitizeMultilineString', () => {
@@ -81,6 +96,14 @@ describe('InputSanitizer', () => {
       expect(result).not.toContain('<b>');
       expect(result).toContain('\n'); // Still has newlines
       expect(result).toContain('Safe line');
+    });
+
+    it('should preserve legitimate angle brackets in multiline content', () => {
+      // Issue #1277: note content with ">" must survive sanitization
+      const input = 'Route: Not Qualified (MQL > SQL). Reason: x';
+      const result = InputSanitizer.sanitizeMultilineString(input);
+      expect(result).toBe('Route: Not Qualified (MQL > SQL). Reason: x');
+      expect(result).toContain('>');
     });
 
     it('should handle Windows-style line endings (CRLF)', () => {


### PR DESCRIPTION
## Summary

- Problem: Deal stage titles containing `>` (e.g. `Not Qualified (MQL > SQL)`) were stripped to `Not Qualified (MQL SQL)` before validation, the update silently fell back to `ATTIO_DEFAULT_DEAL_STAGE`, and the tool returned success.
- Why it matters: This silently corrupted CRM data — disqualified deals were moved into the default stage for weeks with no error. Note content with `>` was also mangled.
- What changed: `InputSanitizer.stripXss` no longer strips standalone angle brackets (the HTML tag and script regexes already remove real XSS vectors); `validateDealStage` throws an explicit error on update when stage resolution fails; and the error now surfaces end-to-end through `UniversalUpdateService`, `crud-operations`, and `crud-error-handlers` instead of being downgraded to a warning or silently falling back to `handleUniversalUpdate`.
- What did not change (scope boundary): Create-time default fallback is preserved. XSS defense (script tags, event handlers, HTML tags) is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Tool handlers/formatting
- [x] Attio API integration
- [x] Tests/mocks/fixtures
- [ ] Issue/PR templates or community files
- [ ] CI/workflows
- [ ] Other

## Linked Issue/PR

- Closes #1277
- Related #705

## User-visible / Behavior Changes

- Stage titles with `>`/`<` now reach Attio byte-for-byte (e.g. `Not Qualified (MQL > SQL)` is preserved).
- An explicit `update_record` with an invalid stage now returns an error instead of silently substituting `ATTIO_DEFAULT_DEAL_STAGE`.
- Note content with `>`/`<` is preserved.
- Create-time default fallback behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Tool execution surface changed? (`No`)
- If any `Yes`, explain risk and mitigation: N/A — no new permissions, secrets, or network calls. The sanitizer change removes the `[<>]` strip but keeps script-tag, event-handler, and HTML-tag removal, so XSS defense is intact.

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Shell/runtime: bash, Bun 1.3.14, Node 26
- Relevant tool versions: vitest 4.1.8

### Steps

1. `InputSanitizer.sanitizeString("Not Qualified (MQL > SQL)")` — previously returned `Not Qualified (MQL SQL)`, now returns the original.
2. `applyDealDefaultsWithValidation({stage:"Not Qualified (MQL > SQL)"}, false, {isUpdate:true})` — previously fell back to default, now throws `Deal stage "Not Qualified (MQL > SQL)" not found`.
3. `UniversalUpdateService.updateRecordWithValidation` with an invalid stage — previously downgraded to a warning and sent the unvalidated stage to Attio, now re-throws the `UniversalValidationError`.
4. Full offline suite: 3608 passed, 22 skipped.

### Expected

- Stage values with `>`/`<` are preserved byte-for-byte.
- Invalid stage on update errors explicitly (end-to-end).

Attach at least one:
